### PR TITLE
fix(lean4): grep fails when MARKER starts with -- in check_axioms_inline.sh

### DIFF
--- a/plugins/lean4/lib/scripts/check_axioms_inline.sh
+++ b/plugins/lean4/lib/scripts/check_axioms_inline.sh
@@ -241,7 +241,7 @@ check_file() {
 
         # Find line number where our marker starts (original file length + 1)
         local MARKER_LINE
-        MARKER_LINE=$(grep -n "$MARKER" "$FILE" | head -1 | cut -d: -f1)
+        MARKER_LINE=$(grep -nF -- "$MARKER" "$FILE" | head -1 | cut -d: -f1)
 
         # Extract all error line numbers from output (format: file.lean:LINE:COL: error)
         local HAS_REAL_ERROR=false


### PR DESCRIPTION
## Summary

One-line fix: `grep -nF -- "$MARKER"` instead of `grep -n "$MARKER"`.

The `MARKER` value (`-- AUTO_AXIOM_CHECK_MARKER_DO_NOT_COMMIT`) starts with `--`, which grep parses as an unrecognized option. Adding `-F` (fixed string) and `--` (end of options) prevents this.

Fixes #31.

**Note:** This fixes the grep crash but does not address the upstream UX issue (passing a directory to `check_axioms_inline.sh`). Directory support is a separate follow-up.

## Test plan

- [x] `LEAN4_PLUGIN_ROOT=plugins/lean4 bash plugins/lean4/tools/lint_docs.sh` passes
- [ ] Run `check_axioms_inline.sh` on a file with axiom usage — no grep error