### PR TITLE
fix(lean4): check_axioms_inline.sh directory support, summary fix, set -e safety

### DIFF
--- a/plugins/lean4/agents/lean4-axiom-eliminator.md
+++ b/plugins/lean4/agents/lean4-axiom-eliminator.md
@@ -18,7 +18,7 @@ thinking: on
 
 1. **Audit current state**:
    ```bash
-   bash $LEAN4_SCRIPTS/check_axioms_inline.sh FILE.lean
+   bash $LEAN4_SCRIPTS/check_axioms_inline.sh FILE.lean  # or . for entire project
    bash $LEAN4_SCRIPTS/find_usages.sh axiom_name
    ```
 

--- a/plugins/lean4/lib/scripts/README.md
+++ b/plugins/lean4/lib/scripts/README.md
@@ -50,6 +50,9 @@ Verify theorems use only standard mathlib axioms.
 # Check multiple files (batch mode)
 ./check_axioms_inline.sh "src/**/*.lean"
 
+# Scan a directory (recursively, skips .lake/.git)
+./check_axioms_inline.sh src/
+
 # Report-only (exit 0 even with custom axioms)
 ./check_axioms_inline.sh MyFile.lean --report-only
 ```

--- a/plugins/lean4/lib/scripts/TESTING.md
+++ b/plugins/lean4/lib/scripts/TESTING.md
@@ -7,7 +7,7 @@ Test results and validation status for Lean 4 scripts.
 | Script | Status | Notes |
 |--------|--------|-------|
 | `sorry_analyzer.py` | ✅ Production Ready | Multi-format output, interactive mode |
-| `check_axioms_inline.sh` | ✅ Production Ready | Batch mode, namespace-aware |
+| `check_axioms_inline.sh` | ✅ Production Ready | Batch mode, namespace-aware, directory support |
 | `search_mathlib.sh` | ✅ Production Ready | Pattern search with ripgrep |
 | `smart_search.sh` | ✅ Production Ready | Multi-source (LeanSearch, Loogle) |
 | `parse_lean_errors.py` | ✅ Production Ready | Structured error output |
@@ -30,6 +30,7 @@ ls -la $LEAN4_SCRIPTS/*.{sh,py}
 # Basic functionality tests (in a Lean project directory)
 $LEAN4_SCRIPTS/sorry_analyzer.py . --format=summary
 $LEAN4_SCRIPTS/check_axioms_inline.sh src/File.lean
+$LEAN4_SCRIPTS/check_axioms_inline.sh src/  # directory mode
 $LEAN4_SCRIPTS/search_mathlib.sh "continuous" name
 ```
 

--- a/plugins/lean4/lib/scripts/check_axioms_inline.sh
+++ b/plugins/lean4/lib/scripts/check_axioms_inline.sh
@@ -3,9 +3,11 @@
 # check_axioms_inline.sh - Check axioms in Lean 4 files using inline #print axioms
 #
 # Usage:
-#   ./check_axioms_inline.sh <file-or-pattern> [--verbose] [--exit-zero-on-findings]
+#   ./check_axioms_inline.sh <file-or-dir-or-pattern> [--verbose] [--exit-zero-on-findings]
 #   ./check_axioms_inline.sh src/**/*.lean
 #   ./check_axioms_inline.sh MyFile.lean --verbose --report-only
+#   ./check_axioms_inline.sh .
+#   ./check_axioms_inline.sh src/
 #
 # This script temporarily appends #print axioms commands to Lean files,
 # runs Lean to check axioms, then removes the additions.
@@ -22,6 +24,8 @@
 #   ./check_axioms_inline.sh MyFile.lean
 #   ./check_axioms_inline.sh src/**/*.lean
 #   ./check_axioms_inline.sh "Exchangeability/**/*.lean" --verbose
+#   ./check_axioms_inline.sh .                          # scan entire project
+#   ./check_axioms_inline.sh src/ --report-only         # scan directory
 #
 # IMPORTANT: This script temporarily modifies files. Make sure:
 #   - Files are in version control (can revert if needed)
@@ -65,7 +69,12 @@ NC='\033[0m'
 # Standard acceptable axioms
 STANDARD_AXIOMS="propext|quot.sound|Classical.choice|Quot.sound"
 
-# Parse arguments
+# Global counter for unique marker filenames (avoids basename collisions)
+MARKER_COUNT=0
+
+# Parse arguments: collect flags first, then positional args
+# This ensures --report-only works regardless of position
+POSITIONAL=()
 for arg in "$@"; do
     case "$arg" in
         --verbose)
@@ -79,32 +88,78 @@ for arg in "$@"; do
             exit 1
             ;;
         *)
-            # Expand globs
-            if [[ "$arg" == *"*"* ]]; then
-                # shellcheck disable=SC2206
-                expanded=($arg)
-                for file in "${expanded[@]}"; do
-                    [[ -f "$file" ]] && FILES+=("$file")
-                done
-            elif [[ -f "$arg" ]]; then
-                FILES+=("$arg")
-            else
-                echo -e "${RED}Error: $arg is not a file${NC}" >&2
-                exit 1
-            fi
+            POSITIONAL+=("$arg")
             ;;
     esac
 done
 
+# Resolve positional args to files
+for arg in "${POSITIONAL[@]}"; do
+    if [[ "$arg" == *"*"* ]]; then
+        # Expand globs
+        # shellcheck disable=SC2206
+        expanded=($arg)
+        for file in "${expanded[@]}"; do
+            [[ -f "$file" ]] && FILES+=("$file")
+        done
+    elif [[ -d "$arg" ]]; then
+        dir_files_found=false
+        while IFS= read -r -d '' file; do
+            FILES+=("$file")
+            dir_files_found=true
+        done < <(find "$arg" -type d \( -name .lake -o -name .git \) -prune -o -type f -name '*.lean' -print0)
+        if [[ "$dir_files_found" == false ]]; then
+            if [[ -n "$EXIT_ZERO_ON_FINDINGS" ]]; then
+                echo -e "${YELLOW}Warning: no .lean files found under: $arg; skipping.${NC}" >&2
+            else
+                echo -e "${RED}Error: no .lean files found under: $arg${NC}" >&2
+                exit 1
+            fi
+        fi
+    elif [[ -f "$arg" ]]; then
+        FILES+=("$arg")
+    else
+        echo -e "${RED}Error: $arg is not a file or directory${NC}" >&2
+        exit 1
+    fi
+done
+
+# Normalize paths and dedup for deterministic ordering (handles overlapping args like ". src/A.lean")
+if [[ ${#FILES[@]} -gt 0 ]]; then
+    DEDUPED=()
+    while IFS= read -r f; do
+        DEDUPED+=("$f")
+    done < <(
+        for f in "${FILES[@]}"; do
+            realpath "$f" 2>/dev/null \
+                || (cd "$(dirname "$f")" && echo "$(pwd -P)/$(basename "$f")") \
+                || echo "$f"
+        done | sort -u
+    )
+    FILES=("${DEDUPED[@]}")
+fi
+
 # Validate input
 if [[ ${#FILES[@]} -eq 0 ]]; then
-    echo -e "${RED}Error: No files specified${NC}" >&2
-    echo "Usage: $0 <file-or-pattern> [--verbose] [--exit-zero-on-findings]" >&2
-    echo "Examples:" >&2
-    echo "  $0 MyFile.lean" >&2
-    echo "  $0 src/**/*.lean" >&2
-    echo "  $0 \"Exchangeability/**/*.lean\" --verbose" >&2
-    exit 1
+    if [[ ${#POSITIONAL[@]} -eq 0 ]]; then
+        # No arguments at all — always an error
+        echo -e "${RED}Error: No files specified${NC}" >&2
+        echo "Usage: $0 <file-or-dir-or-pattern> [--verbose] [--exit-zero-on-findings]" >&2
+        echo "Examples:" >&2
+        echo "  $0 MyFile.lean" >&2
+        echo "  $0 src/**/*.lean" >&2
+        echo "  $0 ." >&2
+        echo "  $0 src/ --report-only" >&2
+        echo "  $0 \"Exchangeability/**/*.lean\" --verbose" >&2
+        exit 1
+    elif [[ -n "$EXIT_ZERO_ON_FINDINGS" ]]; then
+        # Args given but resolved to zero files in report-only mode — soft exit
+        echo -e "${YELLOW}Warning: no Lean files found; nothing to check.${NC}" >&2
+        exit 0
+    else
+        echo -e "${RED}Error: No Lean files found in specified paths${NC}" >&2
+        exit 1
+    fi
 fi
 
 # Filter to .lean files only
@@ -173,7 +228,8 @@ check_file() {
 
     # Create backup and track it with marker file for SIGINT safety
     local BACKUP_FILE="${FILE}.axiom_check_backup"
-    local MARKER_FILE="$MARKER_DIR/$(basename "$FILE").marker"
+    ((++MARKER_COUNT))
+    local MARKER_FILE="$MARKER_DIR/${MARKER_COUNT}.marker"
     cp "$FILE" "$BACKUP_FILE"
     echo "$FILE" > "$MARKER_FILE"
 
@@ -215,7 +271,7 @@ check_file() {
                     if [[ ! "$axiom" =~ $STANDARD_AXIOMS ]]; then
                         echo -e "  ${RED}⚠ $CURRENT_DECL uses non-standard axiom: $axiom${NC}"
                         HAS_CUSTOM=true
-                        ((CUSTOM_AXIOM_COUNT++))
+                        ((++CUSTOM_AXIOM_COUNT))
                     elif [[ "$VERBOSE" == "--verbose" ]]; then
                         echo -e "    ${GREEN}✓${NC} $axiom (standard)"
                     fi
@@ -226,11 +282,11 @@ check_file() {
         if [[ "$HAS_CUSTOM" == false ]]; then
             echo -e "  ${GREEN}✓ All declarations use only standard axioms${NC}"
         else
-            ((FILES_WITH_CUSTOM++))
+            ((++FILES_WITH_CUSTOM))
         fi
 
         ((TOTAL_DECLARATIONS+=${#DECLARATIONS[@]}))
-        ((TOTAL_FILES++))
+        ((++TOTAL_FILES))
 
         cleanup_file
         echo
@@ -285,7 +341,7 @@ check_file() {
                         if [[ ! "$axiom" =~ $STANDARD_AXIOMS ]]; then
                             echo -e "  ${RED}⚠ $CURRENT_DECL uses non-standard axiom: $axiom${NC}"
                             HAS_CUSTOM=true
-                            ((CUSTOM_AXIOM_COUNT++))
+                            ((++CUSTOM_AXIOM_COUNT))
                         elif [[ "$VERBOSE" == "--verbose" ]]; then
                             echo -e "    ${GREEN}✓${NC} $axiom (standard)"
                         fi
@@ -297,10 +353,10 @@ check_file() {
                 if [[ "$HAS_CUSTOM" == false ]]; then
                     echo -e "  ${GREEN}✓ Accessible declarations use only standard axioms${NC}"
                 else
-                    ((FILES_WITH_CUSTOM++))
+                    ((++FILES_WITH_CUSTOM))
                 fi
                 ((TOTAL_DECLARATIONS+=${#DECLARATIONS[@]}))
-                ((TOTAL_FILES++))
+                ((++TOTAL_FILES))
             fi
 
             cleanup_file
@@ -331,7 +387,9 @@ echo -e "${BLUE}Summary:${NC}"
 echo -e "  Files checked: $TOTAL_FILES"
 echo -e "  Declarations checked: $TOTAL_DECLARATIONS"
 
-if [[ $FILES_WITH_CUSTOM -eq 0 ]]; then
+if [[ $TOTAL_FILES -eq 0 && ${#FAILED_FILES[@]} -gt 0 ]]; then
+    echo -e "  ${YELLOW}⚠ No files were successfully checked${NC}"
+elif [[ $FILES_WITH_CUSTOM -eq 0 ]]; then
     echo -e "  ${GREEN}✓ All files use only standard axioms${NC}"
 else
     echo -e "  ${RED}⚠ Files with non-standard axioms: $FILES_WITH_CUSTOM${NC}"
@@ -354,7 +412,7 @@ echo "  • Classical.choice (axiom of choice)"
 if [[ $FILES_WITH_CUSTOM -gt 0 ]]; then
     echo
     echo -e "${YELLOW}Tip: Non-standard axioms should have elimination plans${NC}"
-    [[ -z "$EXIT_ZERO_ON_FINDINGS" ]] && exit 1
+    if [[ -z "$EXIT_ZERO_ON_FINDINGS" ]]; then exit 1; fi
 fi
 
 if [[ ${#FAILED_FILES[@]} -gt 0 ]]; then

--- a/plugins/lean4/skills/lean4/references/axiom-elimination.md
+++ b/plugins/lean4/skills/lean4/references/axiom-elimination.md
@@ -18,6 +18,7 @@ Quick reference for systematically eliminating custom axioms from Lean 4 proofs.
 **Check axiom usage:**
 ```bash
 bash $LEAN4_SCRIPTS/check_axioms_inline.sh FILE.lean
+bash $LEAN4_SCRIPTS/check_axioms_inline.sh .          # scan entire project
 ```
 
 **For individual theorems:**
@@ -32,6 +33,7 @@ EOF
 **Always prefer the script over manual checks:**
 ```bash
 $LEAN4_SCRIPTS/check_axioms_inline.sh path/to/file.lean
+$LEAN4_SCRIPTS/check_axioms_inline.sh src/   # scan directory recursively
 ```
 
 The script handles namespace inference and filters standard axioms automatically.


### PR DESCRIPTION
## Summary

Fixes the two remaining bugs from #35 (the grep bug was already fixed by PR #32):

- **Directory inputs rejected** — `./check_axioms_inline.sh .` now recursively finds `.lean` files (prunes `.lake`/`.git`). Two-pass arg parsing ensures `--report-only` works regardless of position. Paths are normalized via `realpath` with a portable `cd`/`pwd -P` fallback, then deduped to handle overlapping args (e.g., `. src/A.lean`).
- **Misleading success summary** — when all files fail to compile, the summary no longer claims "All files use only standard axioms"; it now shows "No files were successfully checked".

Additional hardening:

- **`set -e` safety** — `((var++))` → `((++var))` (post-increment from 0 exits under `set -e`), and `[[ ]] && exit 1` → `if/then/fi`.
- **Marker filename collisions** — same-basename files in different directories no longer collide (counter-based instead of `basename`-based).

Note: Bug 2 from #35 (`grep` failing when MARKER starts with `--`) was already fixed by PR #32.

## Test plan

All commands run from the repo root using `SCRIPT=plugins/lean4/lib/scripts/check_axioms_inline.sh`:

- [x] `bash -n "$SCRIPT"` — syntax check passes
- [x] `bash "$SCRIPT" /nonexistent` → "not a file or directory", exit 1
- [x] `bash "$SCRIPT" /tmp/empty_dir` → "no .lean files found", exit 1
- [x] `bash "$SCRIPT" /tmp/empty_dir --report-only` → warning, exit 0
- [x] `bash "$SCRIPT" --report-only /tmp/empty_dir` — flag before positional arg, same result as above (exit 0)
- [x] `bash "$SCRIPT" /tmp/test_dir /tmp/test_dir/sub/A.lean` — file inside dir not double-counted (verified file count in output matches unique files)
- [x] Created temp dirs with identically-named `.lean` files containing declarations (`a/Test.lean`, `b/Test.lean`) — both processed and cleaned up without marker collision
- [x] `LEAN4_PLUGIN_ROOT=plugins/lean4 bash plugins/lean4/tools/lint_docs.sh` — all checks passed