### PR TITLE
fix(lean4): update How to Contribute link to Lean 4 version

### DIFF
--- a/plugins/lean4/skills/lean4/references/mathlib-style.md
+++ b/plugins/lean4/skills/lean4/references/mathlib-style.md
@@ -350,7 +350,7 @@ theorem main_theorem : ... := by
 
 - **Official Style Guide:** https://leanprover-community.github.io/contribute/style.html
 - **Naming Conventions:** https://leanprover-community.github.io/contribute/naming.html
-- **How to Contribute:** https://leanprover-community.github.io/lean3/contribute/index.html
+- **How to Contribute:** https://leanprover-community.github.io/contribute/index.html
 - **Mathlib Zulip:** https://leanprover.zulipchat.com/ (#mathlib4 channel)
 
 ## Related References


### PR DESCRIPTION
The "How to Contribute" link in mathlib-style.md pointed to the Lean 3 version at `/lean3/contribute/index.html`. Updated it to point to the current Lean 4 page at `/contribute/index.html`.