### PR TITLE
docs(lean4): add simp and simproc skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,31 @@ See `/lean4:doctor migrate` for detailed migration help.
 ## Documentation
 
 - [SKILL.md](plugins/lean4/skills/lean4/SKILL.md) - Core skill reference
+- [Lean4 Borrowed Params](plugins/lean4/skills/lean4-borrowed-params/SKILL.md) - `@&` borrowed parameter ABI/ownership guidance for extern/export boundaries
+- [Lean4 Compiler Attrs](plugins/lean4/skills/lean4-compiler-attrs/SKILL.md) - `implemented_by`, `csimp`, inlining, extraction controls
+- [Lean4 Compiler Pipeline](plugins/lean4/skills/lean4-compiler-pipeline/SKILL.md) - LCNF/IR traces, compiler options, `cpass` installer workflow
+- [Lean4 FFI Interop](plugins/lean4/skills/lean4-ffi-interop/SKILL.md) - `extern`/`export` + Lake linking + reverse FFI init flow
+- [Lean4 Init Runtime](plugins/lean4/skills/lean4-init-runtime/SKILL.md) - `initialize`/`[init]`/builtin init sequencing and runtime host setup
+- [Lean4 Simp + Simprocs](plugins/lean4/skills/lean4-simp-simprocs/SKILL.md) - `simp` hygiene, `simproc`/`dsimproc` authoring, and normalization-vs-closure triage
+- [Lean4 Specialization](plugins/lean4/skills/lean4-specialization/SKILL.md) - `@[specialize]`/`@[nospecialize]` decision workflow, traces, and recursion-limit tuning
+- [Lean4 Symbol Linkage](plugins/lean4/skills/lean4-symbol-linkage/SKILL.md) - Name mangling, package prefixes, `_init_` symbols, and export override diagnostics
+- [Zulip Extract](plugins/lean4/skills/zulip-extract/SKILL.md) - Convert Zulip HTML exports to readable plain text
 - [INSTALLATION.md](INSTALLATION.md) - Setup guide
 - [Commands](plugins/lean4/commands/) - Command documentation
 - [Advanced References](plugins/lean4/skills/lean4/references/) - grind, simprocs, metaprogramming, linters, FFI, verso-docs, profiling
 
 ## Changelog
 
+**Unreleased**
+- Added `zulip-extract` skill by upstreaming Lean commit `ff2a2cd7a11c0c619bb4c120be83609e1f541c44` into plugin/global skill format
+- Added `lean4-ffi-interop` skill from Lean compiler + Lake FFI examples (`extern`/`export`, linking, reverse-FFI init)
+- Added `lean4-compiler-attrs` skill for safe use of compiler attributes (`implemented_by`, `csimp`, inlining, `never_extract`)
+- Added `lean4-init-runtime` skill for init sequencing across `initialize`/`[init]`/`builtin_initialize` and host runtime setup
+- Added `lean4-compiler-pipeline` skill for LCNF/IR phase tracing, compiler option debugging, and `cpass` installer workflow
+- Added `lean4-specialization` skill for `@[specialize]`/`@[nospecialize]` tuning, trace-driven triage, and `compiler.maxRecSpecialize` control
+- Added `lean4-borrowed-params` skill for `@&` borrowed-parameter ABI/ownership debugging across extern/export boundaries
+- Added `lean4-symbol-linkage` skill for name-mangling/export/init-symbol diagnostics in compiler and FFI linking workflows
+- Added `lean4-simp-simprocs` skill plus expanded `simp` and simproc references, grounded in the Lean community blog series on `simp` and simprocs
 **v4.1.0** (February 2026)
 - New [`/lean4:learn`](plugins/lean4/commands/learn.md) command: interactive teaching, mathlib exploration, autoformalization
 - Two-layer architecture: Lean-backed verification (always runs) + presentation layer (informal/supporting/formal)

--- a/plugins/lean4/README.md
+++ b/plugins/lean4/README.md
@@ -210,6 +210,15 @@ plugins/lean4/
 ├── skills/lean4/
 │   ├── SKILL.md        # Core skill reference
 │   └── references/     # Reference docs
+├── skills/lean4-borrowed-params/ # `@&` borrowed parameter ABI/ownership playbook
+├── skills/lean4-compiler-attrs/ # Compiler attributes playbook (`csimp`, `implemented_by`, inline)
+├── skills/lean4-compiler-pipeline/ # LCNF/IR tracing, options, and cpass installer workflow
+├── skills/lean4-ffi-interop/    # `extern`/`export` and Lake FFI wiring patterns
+├── skills/lean4-init-runtime/   # `initialize`/`[init]`/builtin init runtime ordering patterns
+├── skills/lean4-simp-simprocs/  # `simp` hygiene, simproc authoring, and normalization-vs-closure triage
+├── skills/lean4-specialization/ # `@[specialize]`/`@[nospecialize]` tuning, traces, and recursion limits
+├── skills/lean4-symbol-linkage/ # Name mangling, symbol stems, export overrides, and init symbol diagnostics
+├── skills/zulip-extract/        # Parse Zulip HTML dumps into plain text
 ├── agents/             # 4 specialized agents
 ├── hooks/              # Bootstrap and guardrails
 ├── scripts/           # Compat alias → lib/scripts
@@ -223,6 +232,15 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guide.
 ## See Also
 
 - [SKILL.md](skills/lean4/SKILL.md) - Core skill reference
+- [Lean4 Borrowed Params](skills/lean4-borrowed-params/SKILL.md) - `@&` borrowed parameter ABI/ownership guidance for extern/export boundaries
+- [Lean4 Compiler Attrs](skills/lean4-compiler-attrs/SKILL.md) - `implemented_by`, `csimp`, inlining, extraction controls
+- [Lean4 Compiler Pipeline](skills/lean4-compiler-pipeline/SKILL.md) - LCNF/IR traces, compiler options, `cpass` installer workflow
+- [Lean4 FFI Interop](skills/lean4-ffi-interop/SKILL.md) - `extern`/`export` + Lake linking + reverse FFI init flow
+- [Lean4 Init Runtime](skills/lean4-init-runtime/SKILL.md) - `initialize`/`[init]`/builtin init sequencing and host runtime setup
+- [Lean4 Simp + Simprocs](skills/lean4-simp-simprocs/SKILL.md) - `simp` hygiene, `simproc`/`dsimproc` authoring, and when to hand off to `grind`
+- [Lean4 Specialization](skills/lean4-specialization/SKILL.md) - `@[specialize]`/`@[nospecialize]` tuning with trace-driven diagnostics and recursion-limit control
+- [Lean4 Symbol Linkage](skills/lean4-symbol-linkage/SKILL.md) - Name mangling, package prefixes, `_init_` symbols, and export override diagnostics
+- [Zulip Extract](skills/zulip-extract/SKILL.md) - Convert Zulip HTML exports to readable plain text
 - [Commands](commands/) - Command documentation
 - [Scripts](lib/scripts/README.md) - Script reference
 - [Custom Syntax](skills/lean4/references/lean4-custom-syntax.md) - Notations, macros, elaborators, DSLs

--- a/plugins/lean4/skills/lean4-simp-simprocs/SKILL.md
+++ b/plugins/lean4/skills/lean4-simp-simprocs/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: lean4-simp-simprocs
+description: Use when debugging or authoring `simp`/`dsimp`, curating `@[simp]` lemmas, tracing simplifier behavior, or writing custom `simproc`/`dsimproc` rewrites.
+---
+
+# Lean4 Simp + Simprocs
+
+Use this skill when the simplifier is close to the proof, but normalization or a reusable computed rewrite is missing.
+
+Grounding for this skill:
+- Lean community blog: [Simp made simple](https://leanprover-community.github.io/blog/posts/simp-made-simple/)
+- Lean community blog: [Fantastic Simprocs and How to Write Them](https://leanprover-community.github.io/blog/posts/simprocs-tutorial/)
+- Lean community blog: [Simprocs for the Working Mathematician](https://leanprover-community.github.io/blog/posts/simprocs-for-the-working-mathematician/)
+- Shared plugin references: `../lean4/references/simp-hygiene.md`, `../lean4/references/simproc-patterns.md`, `../lean4/references/grind-tactic.md`
+
+## Decision Rule
+
+- Start with `simp?`, `simp only [...]`, and better `@[simp]` lemmas.
+- Use a plain `@[simp]` lemma when the rewrite is canonical and proof-producing without computation.
+- Use `dsimproc` when the result is definitional and computable from explicit data.
+- Use `simproc` when the rewrite needs proof construction, a custom discharger, or proposition-level reasoning.
+- Use a pre-simproc when the outer form should simplify before visiting children, such as `ite`-style rewrites.
+- Switch to `grind`, `omega`, `linarith`, or `nlinarith` when the problem is closure after normalization rather than rewriting.
+
+## Debug Loop
+
+1. Inspect what `simp` wants to do.
+   ```lean
+   simp?
+   simp only [lemma1, lemma2]
+   set_option trace.Meta.Tactic.simp true in
+   ```
+2. If a candidate lemma is not canonical, do not mark it `[simp]`; keep it local via `simp only [...]`.
+3. If the missing rewrite would require infinitely many numerically specialized lemmas, repeated local calculation, or different pre/post behavior, write a simproc.
+4. If the simproc only fires on explicit numerals or other concrete syntax, return `.continue` on symbolic inputs rather than guessing.
+5. After normalization, if the remaining goal is mixed-constraint closure, hand off to `grind` rather than forcing more simp machinery.
+
+## Simp Hygiene Rules
+
+- The left-hand side should already be in simp normal form.
+- The right-hand side must be strictly simpler and loop-free.
+- Avoid `[simp]` on commutativity and similarly non-canonical rewrites.
+- Prefer narrowing the simp set before adding new global lemmas.
+- Use `@[simp, nolint simpNF]` only when the non-normal-form orientation is intentional and justified.
+
+## Simproc Authoring Rules
+
+- Match narrowly; small patterns are easier to trust and cheaper to run.
+- Prefer explicit-data rewrites. If you cannot extract concrete data from the syntax, usually return `.continue`.
+- Keep the rewrite one-way and terminating.
+- Use `.visit` when the produced expression should be resimplified.
+- Use `.done` only when you are confident the new expression is already in final simp normal form.
+- Register locally before making a simproc part of a shared simp set.
+
+## Implementation Sketch
+
+```lean
+import Lean
+open Lean Meta Qq Simp
+
+-- Sketch only: real code must also build a proof-backed replacement.
+simproc_decl reduceFoo (foo _) := fun e => do
+  let_expr foo arg := e | return .continue
+  let some n := arg.nat? | return .continue
+  let rhs := mkNatLit (n + 1)
+  let result := <construct a proof-backed rewrite to rhs and revisit it>
+  pure result
+```
+
+Treat this as a shape, not a copy-paste recipe. Real simprocs usually need:
+- better pattern matching via `let_expr`
+- extraction helpers like `.nat?` or `Nat.fromExpr?`
+- proof construction with `Qq`/`toExpr`
+- careful choice of `.continue` vs `.visit` vs `.done`
+
+## Escalation Targets
+
+- `simp` problem with noisy lemmas or wrong orientation: read `../lean4/references/simp-hygiene.md`
+- custom deterministic rewrite inside `simp`: read `../lean4/references/simproc-patterns.md`
+- goal should close after normalization: read `../lean4/references/grind-tactic.md`

--- a/plugins/lean4/skills/lean4-simp-simprocs/SKILL.md
+++ b/plugins/lean4/skills/lean4-simp-simprocs/SKILL.md
@@ -11,7 +11,7 @@ Grounding for this skill:
 - Lean community blog: [Simp made simple](https://leanprover-community.github.io/blog/posts/simp-made-simple/)
 - Lean community blog: [Fantastic Simprocs and How to Write Them](https://leanprover-community.github.io/blog/posts/simprocs-tutorial/)
 - Lean community blog: [Simprocs for the Working Mathematician](https://leanprover-community.github.io/blog/posts/simprocs-for-the-working-mathematician/)
-- Shared plugin references: `../lean4/references/simp-hygiene.md`, `../lean4/references/simproc-patterns.md`, `../lean4/references/grind-tactic.md`
+- Shared plugin references: `../lean4/references/simp-normal-forms.md`, `../lean4/references/simp-hygiene.md`, `../lean4/references/simproc-patterns.md`, `../lean4/references/grind-tactic.md`
 
 ## Decision Rule
 
@@ -42,6 +42,8 @@ Grounding for this skill:
 - Avoid `[simp]` on commutativity and similarly non-canonical rewrites.
 - Prefer narrowing the simp set before adding new global lemmas.
 - Use `@[simp, nolint simpNF]` only when the non-normal-form orientation is intentional and justified.
+
+For precise definitions of simp normal form and canonical versus non-canonical rewrites, read `../lean4/references/simp-normal-forms.md`.
 
 ## Simproc Authoring Rules
 
@@ -75,6 +77,7 @@ Treat this as a shape, not a copy-paste recipe. Real simprocs usually need:
 
 ## Escalation Targets
 
+- unclear canonical form or `simpNF` dispute: read `../lean4/references/simp-normal-forms.md`
 - `simp` problem with noisy lemmas or wrong orientation: read `../lean4/references/simp-hygiene.md`
 - custom deterministic rewrite inside `simp`: read `../lean4/references/simproc-patterns.md`
 - goal should close after normalization: read `../lean4/references/grind-tactic.md`

--- a/plugins/lean4/skills/lean4/SKILL.md
+++ b/plugins/lean4/skills/lean4/SKILL.md
@@ -160,7 +160,7 @@ Verification ladder: `lean_diagnostic_messages(file)` per-edit → `lake env lea
 
 **Errors:** [compilation-errors](references/compilation-errors.md) (read first for any build error), [instance-pollution](references/instance-pollution.md) (typeclass conflicts — grep `## Sub-` for patterns), [compiler-guided-repair](references/compiler-guided-repair.md) (escalation-only repair — not first-pass)
 
-**Tactics:** [tactics-reference](references/tactics-reference.md) (tactic lookup — grep `^### TacticName`), [grind-tactic](references/grind-tactic.md) (SMT-style automation — when simp can't close), [simproc-patterns](references/simproc-patterns.md) (custom deterministic rewrites for simp), [tactic-patterns](references/tactic-patterns.md), [calc-patterns](references/calc-patterns.md), [simp-hygiene](references/simp-hygiene.md)
+**Tactics:** [tactics-reference](references/tactics-reference.md) (tactic lookup — grep `^### TacticName`), [grind-tactic](references/grind-tactic.md) (SMT-style automation — when simp can't close), [simp-normal-forms](references/simp-normal-forms.md) (definitions for simp normal form and canonical vs non-canonical rewrites), [simproc-patterns](references/simproc-patterns.md) (custom deterministic rewrites for simp), [tactic-patterns](references/tactic-patterns.md), [calc-patterns](references/calc-patterns.md), [simp-hygiene](references/simp-hygiene.md)
 
 **Proof Development:** [proof-templates](references/proof-templates.md), [proof-refactoring](references/proof-refactoring.md) (28K — grep by topic), [sorry-filling](references/sorry-filling.md)
 

--- a/plugins/lean4/skills/lean4/references/simp-hygiene.md
+++ b/plugins/lean4/skills/lean4/references/simp-hygiene.md
@@ -6,6 +6,8 @@
 
 Best practices for `@[simp]` lemmas to avoid common issues.
 
+For precise definitions of `simp` normal form and canonical versus non-canonical rewrites, read [simp-normal-forms.md](simp-normal-forms.md) first.
+
 ## First Question: Should This Be a Simp Lemma?
 
 Use a global `@[simp]` lemma only if all of the following are true:
@@ -185,6 +187,7 @@ Before adding `@[simp]`, verify:
 
 ## See Also
 
+- [simp-normal-forms.md](simp-normal-forms.md) - Definitions for simp normal form, canonical rewrites, and non-canonical rewrites
 - [simproc-patterns.md](simproc-patterns.md) - Custom deterministic rewrites inside the simp pipeline
 - [tactics-reference.md](tactics-reference.md) - Full tactic docs including simp variants
 - [performance-optimization.md](performance-optimization.md) - `simp only` for speed

--- a/plugins/lean4/skills/lean4/references/simp-hygiene.md
+++ b/plugins/lean4/skills/lean4/references/simp-hygiene.md
@@ -1,39 +1,61 @@
 # Simp Lemma Hygiene
 
+> **Scope:** Consult when deciding whether a rewrite belongs in `@[simp]`, when `simp` is doing the wrong thing, or when a proof feels "one lemma away" from closing.
+
+> **Grounding:** Distilled from the Lean community posts [Simp made simple](https://leanprover-community.github.io/blog/posts/simp-made-simple/) and [Simprocs for the Working Mathematician](https://leanprover-community.github.io/blog/posts/simprocs-for-the-working-mathematician/), plus current plugin conventions.
+
 Best practices for `@[simp]` lemmas to avoid common issues.
+
+## First Question: Should This Be a Simp Lemma?
+
+Use a global `@[simp]` lemma only if all of the following are true:
+- the rewrite is canonical, not merely convenient for one proof
+- the direction is obvious and stable across the codebase
+- the right-hand side is simpler
+- the lemma will help many proofs, not just the current one
+
+If any of these fail, prefer one of:
+- `simp only [lemma]` locally
+- `simp [lemma]` in one proof
+- a dedicated simproc if the rewrite depends on computation over explicit syntax
 
 ## Common Issues
 
 ### 1. LHS Not in Normal Form
 
-The left-hand side should be irreducible by other simp lemmas.
+The left-hand side should already be irreducible by other simp lemmas.
 
 **Bad:**
 ```lean
 @[simp] lemma bad_form : a + (b + c) = (a + b) + c := ...
--- LHS contains (b + c) which might be simplified first
+-- LHS contains a non-canonical subterm that simp may rewrite first.
 ```
 
 **Good:**
 ```lean
 @[simp] lemma good_form : (a + b) + c = a + (b + c) := ...
--- LHS is already in normal form
+-- LHS already matches the chosen normal form.
 ```
+
+This is the central `simpNF` rule: do not ask the simplifier to orient terms toward a form that some other simp lemma will immediately change again.
 
 ### 2. Potential Infinite Loops
 
-The RHS should be simpler than the LHS.
+The right-hand side must be strictly simpler than the left-hand side.
 
 **Dangerous:**
 ```lean
 @[simp] lemma may_loop : f x = g (f x) := ...
--- LHS appears in RHS!
+-- The LHS reappears on the RHS.
 ```
 
-**Test your lemma:**
+**Test the lemma in isolation:**
 ```lean
-example : f x = expected := by simp only [may_loop]  -- Check it terminates
+example : f x = expected := by
+  simp only [may_loop]
 ```
+
+If this is not obviously terminating, it should not be a simp lemma.
 
 ### 3. Conflicting Simp Lemmas
 
@@ -42,132 +64,128 @@ Avoid lemmas that simplify the same pattern differently.
 **Conflict:**
 ```lean
 @[simp] lemma simp1 : f (g x) = A := ...
-@[simp] lemma simp2 : f (g x) = B := ...  -- Same LHS, different RHS
+@[simp] lemma simp2 : f (g x) = B := ...
 ```
 
-**Resolution:** Remove one, or use `simp only [simp1]` explicitly.
+Resolution options:
+- remove one global lemma
+- keep both ordinary lemmas and choose locally with `simp only [...]`
+- rethink the canonical normal form
 
-## Best Practices
-
-### Direction Matters
+## Direction Matters
 
 Simplify toward canonical forms:
-- Expand abbreviations to definitions
-- Normalize arithmetic (`a - b` → `a + (-b)`)
-- Reduce complexity
+- expand abbreviations to their intended base form
+- eliminate neutral elements
+- normalize arithmetic into the project's preferred shape
+- reduce structure, not increase it
 
-### Specificity
+Good `@[simp]` lemmas tend to erase administrative structure:
 
-More specific lemmas are tried first:
+```lean
+@[simp] lemma my_def_simp : myDef x = underlyingDef x := rfl
+@[simp] lemma id_left : id x = x := rfl
+@[simp] lemma add_zero : x + 0 = x := ...
+@[simp] lemma sub_self : x - x = 0 := ...
+```
+
+Bad candidates usually introduce symmetry without a preferred orientation:
+
+```lean
+-- DON'T: no canonical direction.
+@[simp] lemma bad_comm : a + b = b + a := ...
+
+-- DON'T: only acceptable with a very deliberate normal-form policy.
+@[simp] lemma bad_assoc : a + (b + c) = (a + b) + c := ...
+```
+
+## Specificity and Locality
+
+More specific lemmas fire before more general ones:
+
 ```lean
 @[simp] lemma general : f x = A := ...
-@[simp] lemma specific : f 0 = B := ...  -- Tried before general
+@[simp] lemma specific : f 0 = B := ...
 ```
 
-### Use `@[simp]` Sparingly
-
-Not every equality should be a simp lemma. Consider:
-- Will this be useful in many proofs?
-- Does it simplify in the right direction?
-- Could it interfere with other lemmas?
-
-### Testing
-
-Always test new simp lemmas:
-
-Note: this section uses schematic placeholders like `LHS`, `RHS`, and `goal` to illustrate tactic structure.
+That can be useful, but it is also how surprising interactions happen. Before promoting a lemma to `@[simp]`, ask whether local use is enough:
 
 ```lean
--- Test 1: Direct application works
-example : LHS = RHS := by simp [your_lemma]
-
--- Test 2: Doesn't loop
-example : f x = f x := by simp [your_lemma]  -- Should complete instantly
-
--- Test 3: Works in context
-example (h : some_hypothesis) : goal := by simp [your_lemma]
+example : goal := by
+  simp only [specific, general]
 ```
+
+Long-term bias:
+- default to local `simp only [...]`
+- upgrade to global `@[simp]` only after repeated successful use
+
+## Debugging Workflow
+
+### 1. Ask `simp` for Its Intended Rewrite Set
+
+```lean
+example : goal := by
+  simp?
+```
+
+This is the fastest way to learn whether the problem is "missing lemma", "wrong orientation", or "too many lemmas".
+
+### 2. Minimize the Active Set
+
+```lean
+example : goal := by
+  simp only [lemma1, lemma2]
+
+example : goal := by
+  simp [-bad_lemma]
+```
+
+If a tiny `simp only` call works and the default `simp` call does not, the issue is almost always hygiene, not proof search.
+
+### 3. Trace Rewrites
+
+```lean
+set_option trace.Meta.Tactic.simp true in
+example : goal := by
+  simp
+```
+
+Use tracing after `simp?` and `simp only` have narrowed the problem. Raw simp traces can be noisy.
+
+## When to Escalate Beyond `@[simp]`
+
+Do not fight the simplifier with dozens of narrowly targeted lemmas. Escalate when:
+- the rewrite depends on explicit computation over syntax
+- you would need infinitely many numeral-specific lemmas
+- the rewrite should happen only before or after children are simplified
+- local side conditions need a discharger
+
+Those are simproc problems, not more-lemma problems. See [simproc-patterns.md](simproc-patterns.md).
 
 ## Simp Attributes
 
 ### `@[simp]`
-Standard simplification lemma. Use for common simplifications.
+Standard simplification lemma. Use for broad, canonical rewrites.
 
 ### `@[simp, nolint simpNF]`
-Suppress normal form lint. Use when you know the LHS isn't in NF but it's intentional.
+Suppress normal-form lint. Use only when a non-normal-form orientation is both deliberate and documented.
 
 ### `@[simp high]` / `@[simp low]`
 Priority control. Higher priority means tried earlier.
 
-### `@[simp?]`
-Debug: shows which lemmas are being applied.
+## Testing Checklist
 
-## Debugging Simp
-
-### See what simp does
-```lean
-example : goal := by simp?  -- Shows applied lemmas
-```
-
-### Test specific lemmas
-```lean
-example : goal := by simp only [lemma1, lemma2]
-```
-
-### Disable problematic lemmas
-```lean
-example : goal := by simp [-bad_lemma]
-```
-
-### Trace simp
-```lean
-set_option trace.Meta.Tactic.simp true in
-example : goal := by simp
-```
-
-## Common Patterns
-
-### Good Simp Lemmas
-
-```lean
--- Definition expansion
-@[simp] lemma my_def_simp : myDef x = underlying_def x := rfl
-
--- Identity elimination
-@[simp] lemma id_left : id x = x := rfl
-
--- Neutral element
-@[simp] lemma add_zero : x + 0 = x := ...
-
--- Cancellation
-@[simp] lemma sub_self : x - x = 0 := ...
-```
-
-### Lemmas to Avoid as Simp
-
-```lean
--- Commutativity (no preferred form)
--- DON'T: @[simp] lemma bad : a + b = b + a
-
--- Associativity without normalization direction
--- DON'T: @[simp] lemma bad : (a + b) + c = a + (b + c)
-
--- Anything with LHS appearing in RHS
--- DON'T: @[simp] lemma bad : f x = g (f x)
-```
-
-## Checklist Before Adding `@[simp]`
-
+Before adding `@[simp]`, verify:
 - [ ] LHS is in simp normal form
-- [ ] RHS is simpler than LHS
-- [ ] Doesn't conflict with existing simp lemmas
-- [ ] Tested: `simp only [lemma]` terminates
-- [ ] Tested: works in example proofs
-- [ ] Actually useful in multiple places
+- [ ] RHS is strictly simpler
+- [ ] No conflicting lemma already owns this pattern
+- [ ] `simp only [lemma]` terminates immediately
+- [ ] The rewrite helps more than one proof
+- [ ] A local `simp only [...]` call would not be enough
 
 ## See Also
 
+- [simproc-patterns.md](simproc-patterns.md) - Custom deterministic rewrites inside the simp pipeline
 - [tactics-reference.md](tactics-reference.md) - Full tactic docs including simp variants
-- [simproc-patterns.md](simproc-patterns.md) - Custom simprocs for deterministic rewrites
 - [performance-optimization.md](performance-optimization.md) - `simp only` for speed
 - [mathlib-style.md](mathlib-style.md) - Style conventions

--- a/plugins/lean4/skills/lean4/references/simp-normal-forms.md
+++ b/plugins/lean4/skills/lean4/references/simp-normal-forms.md
@@ -1,0 +1,129 @@
+# Simp Normal Forms and Canonical Rewrites
+
+> **Scope:** Consult when deciding whether a rewrite belongs in `@[simp]`, when a simproc should return `.continue` versus rewriting, or when "canonical" versus "non-canonical" is the real source of a simp design dispute.
+
+> **Grounding:** Distilled from the Lean community posts [Simp made simple](https://leanprover-community.github.io/blog/posts/simp-made-simple/), [Fantastic Simprocs and How to Write Them](https://leanprover-community.github.io/blog/posts/simprocs-tutorial/), and [Simprocs for the Working Mathematician](https://leanprover-community.github.io/blog/posts/simprocs-for-the-working-mathematician/).
+
+## Core Definitions
+
+### `simp` Normal Form
+
+An expression is in **simp normal form** when the current simp set and simp configuration would stop rewriting it.
+
+Important consequences:
+- simp normal form is **relative**, not absolute
+- it depends on the active simp lemmas, simprocs, and configuration
+- "normal form" means "the form chosen by this simp setup", not "the only mathematically natural form"
+
+Operational test:
+
+```lean
+example : goal := by
+  simp only [candidate_lemmas]
+```
+
+If your proposed left-hand side would itself be rewritten by that call, it is not in simp normal form.
+
+### Canonical Rewrite
+
+A rewrite is **canonical** when it moves expressions toward the representative that the project wants simp to prefer globally.
+
+Canonical rewrites usually have these properties:
+- one direction is clearly preferred
+- the right-hand side is simpler or more stable
+- repeated simp use should keep terms there
+- the same orientation makes sense across many proofs
+
+Typical canonical examples:
+- `x + 0 -> x`
+- `id x -> x`
+- expanding an abbreviation to its chosen underlying definition
+
+### Non-Canonical Rewrite
+
+A rewrite is **non-canonical** when it may be mathematically true and locally useful, but it does not point to a globally preferred representative.
+
+Common signs of a non-canonical rewrite:
+- both directions look equally natural
+- the rewrite mostly rearranges structure rather than simplifying it
+- the rewrite exposes more syntax on symbolic terms without reaching a stable endpoint
+- different proofs would reasonably want different orientations
+
+Typical non-canonical examples:
+- commutativity like `a + b = b + a`
+- ad hoc reassociation without a clear project-wide policy
+- partial unfolding of a recursive definition on symbolic inputs
+
+## Practical Tests
+
+Ask these questions before adding `@[simp]`:
+
+1. Would the current simp set rewrite my left-hand side before my lemma sees it?
+   If yes, the left-hand side is not in simp normal form.
+
+2. After rewriting once, does the result look like the form I want to see everywhere?
+   If no, the rewrite is probably not canonical.
+
+3. Would the reverse direction look equally reasonable to another author?
+   If yes, keep it out of global `@[simp]`.
+
+4. On symbolic inputs, does the rewrite merely expose more structure without reaching a stable shape?
+   If yes, it is usually non-canonical for simp.
+
+## Symbolic vs Explicit Data
+
+The simproc posts make an important distinction: a rewrite may be canonical on **explicit** inputs and non-canonical on **symbolic** ones.
+
+Pattern:
+- explicit numerals often have a clear computed normal form
+- symbolic expressions often do not
+
+Example shape:
+- good: reduce arithmetic on concrete naturals
+- bad: partially unfold a recursive definition on arbitrary symbolic `n`
+
+This is why simprocs often:
+- extract concrete data first
+- rewrite only when that succeeds
+- return `.continue` on symbolic inputs
+
+The `revRange` discussion in the working-mathematician post is the model warning: unfolding on symbolic inputs can produce a true equation that is still the wrong simp normal form.
+
+## Relationship to `simpNF`
+
+`simpNF` is the lint-level version of the same idea:
+- the left-hand side should already be in simp normal form
+- the right-hand side should be the chosen destination
+
+If a lemma fails that smell test, it may still be a fine local rewrite. It just should not usually be a global simp lemma.
+
+## Relationship to Simprocs
+
+Simprocs should respect the same normal-form discipline as simp lemmas.
+
+Good simproc behavior:
+- rewrite only when you can produce a better normal form
+- use `.visit` when the replacement still needs simp to finish normalizing
+- use `.done` only when the replacement is already in simp normal form
+- use `.continue` when the term is too symbolic to choose a canonical rewrite
+
+Bad simproc behavior:
+- performing arbitrary true rewrites with no normal-form policy
+- partially evaluating symbolic terms into less stable syntax
+- encoding proof search instead of deterministic normalization
+
+## Decision Table
+
+| Situation | Right tool |
+|---|---|
+| Globally preferred stable orientation | `@[simp]` lemma |
+| Useful only in one proof | `simp only [...]` or `simp [lemma]` |
+| Canonical rewrite depends on explicit computation | `dsimproc` or `simproc` |
+| Symbolic term has no obvious normal form | leave it alone (`.continue`) |
+| Goal is normalized but not closed | `grind` or a domain solver |
+
+## See Also
+
+- [simp-hygiene.md](simp-hygiene.md) - Broader rules for `@[simp]` lemma design
+- [simproc-patterns.md](simproc-patterns.md) - Simproc authoring workflow and performance discipline
+- [grind-tactic.md](grind-tactic.md) - Closure after normalization

--- a/plugins/lean4/skills/lean4/references/simproc-patterns.md
+++ b/plugins/lean4/skills/lean4/references/simproc-patterns.md
@@ -7,11 +7,28 @@
 > - **Last validated:** 2026-02-17
 > - **Confidence:** medium (docs reviewed; snippets not batch-compiled)
 
+> **Grounding:** Distilled from the Lean community posts [Fantastic Simprocs and How to Write Them](https://leanprover-community.github.io/blog/posts/simprocs-tutorial/) and [Simprocs for the Working Mathematician](https://leanprover-community.github.io/blog/posts/simprocs-for-the-working-mathematician/).
+
+## Decision Rule
+
+- Start with ordinary `simp` and better `@[simp]` lemmas.
+- Use `dsimproc` when the rewrite is definitional computation on explicit data.
+- Use `simproc` when you must build proof terms or discharge side conditions.
+- Use a pre-simproc when the outer form should simplify before its children.
+- Use `grind` or a domain solver when normalization is done and closure is the remaining task.
+
 ## When to Use
 
 - `simp` is close but needs a deterministic rewrite
 - You repeat the same rewrite in multiple places
-- A rewrite depends on local computation (e.g., normalization)
+- A rewrite depends on local computation over explicit syntax
+- You need behavior that is naturally pre-order or post-order within the simp traversal
+
+Good simproc use cases from the community examples:
+- evaluating arithmetic on explicit numerals
+- proving divisibility or interval-membership facts after extracting concrete naturals
+- simplifying `ite`-shaped terms before descending into both branches
+- replacing an infinite family of numeral-indexed simp lemmas with one computed rewrite
 
 ## Composable Simp Pipeline
 
@@ -19,8 +36,20 @@ Think of simprocs as a block inside `simp`:
 
 1. `simp set` (lemmas, simp attributes)
 2. `simp config` (zeta, eta, simp theorems)
-3. `simproc` (deterministic rewrite)
+3. `simproc` / `dsimproc` (deterministic rewrite)
 4. `simp` final normalization
+
+The important mental model from the blog posts is that simprocs are not "extra tactics after simp". They are part of the simplifier's traversal strategy.
+
+## Before Writing a Simproc
+
+Exhaust the simpler options first:
+
+1. Can a plain `@[simp]` lemma express the rewrite?
+2. Is a local `simp only [...]` call enough?
+3. Is the desired rewrite really a closure step that belongs to `grind`, `omega`, or `linarith`?
+
+Write a simproc only when the missing rewrite depends on inspecting syntax and computing from it.
 
 ## Minimal Simproc Shape
 
@@ -37,27 +66,115 @@ open Lean Meta Simp
 Escalate to a real simproc only when the rewrite needs custom computation:
 
 ```lean
-open Lean Meta Simp
+open Lean Meta Qq Simp
 
+-- Sketch only: real code must also build a proof-backed replacement.
 simproc_decl mySimproc (foo _) := fun e => do
-  -- compute a rewrite or return .none
-  return .none
+  let_expr foo arg := e | return .continue
+  let some n := arg.nat? | return .continue
+  let rhs := mkNatLit (n + 1)
+  let result := <construct a proof-backed rewrite to rhs and revisit it>
+  pure result
 ```
+
+The crucial control-flow rule from the tutorial is: when the term is not concrete enough, do nothing. Return `.continue` instead of guessing on symbolic inputs.
+
+## `dsimproc` vs `simproc`
+
+Use `dsimproc` when:
+- the simplification is definitional
+- you can compute the replacement directly from explicit data
+- no nontrivial proof construction is needed
+
+Use `simproc` when:
+- the replacement needs a proof witness
+- you need the simplifier's discharger for side conditions
+- the rewrite is proposition-level, not merely definitional reduction
+
+If in doubt, start with `simproc`; switch to `dsimproc` only when you can clearly justify the stronger definitional story.
+
+## Pre vs Post Procedures
+
+Most simprocs are naturally post-order: simplify children first, then rewrite the parent.
+
+Use a preprocedure when:
+- the outer constructor determines the useful rewrite
+- descending first would waste work
+- an `ite` or match-like shape should collapse before both branches are simplified
+
+The `reduceIte` discussion in the working-mathematician post is the model example: sometimes the right place in the simp pipeline matters as much as the rewrite itself.
+
+## Core Building Blocks
+
+### Pattern Matching
+
+Use `let_expr` to destructure the syntax you care about:
+
+```lean
+let_expr HAdd.hAdd _ _ lhs rhs := e | return .continue
+```
+
+Prefer explicit, narrow patterns over broad expression surgery.
+
+### Extracting Data
+
+Typical helpers include:
+- `Expr.nat?`
+- `Nat.fromExpr?`
+- `Qq` quotations
+- `Lean.toExpr`
+
+Community guidance: extract only explicit data. If the term is symbolic, leave it alone.
+
+### Returning Results
+
+The practical meaning of the common results is:
+- `.continue` — no rewrite here
+- `.visit` — rewrite succeeded, now resimplify the replacement
+- `.done` — rewrite succeeded and the replacement is already final
+
+When unsure between `.visit` and `.done`, prefer `.visit`. It is slower, but easier to trust.
+
+### Discharging Side Conditions
+
+Some rewrites need auxiliary facts such as inequalities or proof obligations. That is where `simproc` outgrows `dsimproc`: it can collaborate with the simplifier's discharger rather than embedding brittle proof search inside the simproc itself.
 
 ## Rules of Thumb
 
 - Prefer simp lemmas; use simprocs only when needed
 - Keep patterns small and oriented (avoid loops)
 - Make simproc deterministic and fast
+- Return `.continue` for symbolic inputs you cannot compute on
+- Prefer `.visit` over `.done` until you have confidence in the final normal form
 - Register locally if the rewrite is not global
 
-## Checklist
+## Performance Discipline
+
+- Avoid expensive work on non-matching terms
+- Avoid algebraic search inside the simproc body
+- Reuse existing simp and discharger machinery rather than duplicating it
+- Keep numeral-only procedures numeral-only
+- Benchmark against a plain `simp only [...]` baseline when possible
+
+The long-term failure mode is turning simprocs into hidden proof search. Keep them deterministic, boring, and cheap.
+
+## Testing Checklist
 
 - The simproc rewrite is one-way and terminating
-- `simp` set remains minimal (no noisy lemmas)
+- Symbolic inputs return `.continue`
+- Explicit-data inputs rewrite correctly
+- `.visit`/`.done` choice matches the desired normal form
+- The simp set remains minimal (no noisy lemmas)
 - The simproc is only enabled where it helps
+
+## Relationship to `grind`
+
+Use simprocs to normalize expressions into better shapes for `simp`.
+
+Use `grind` after that normalization step when the goal is now about closing mixed equalities, inequalities, or congruence facts. Simprocs and `grind` complement each other; they should not try to do each other's jobs.
 
 ## See Also
 
 - [simp-hygiene.md](simp-hygiene.md) — simp lemma best practices
+- [grind-tactic.md](grind-tactic.md) — closure after normalization
 - [tactics-reference.md](tactics-reference.md) — tactic catalog including simp deep-dive


### PR DESCRIPTION
## Summary
- add a focused `lean4-simp-simprocs` skill inside the unified `lean4` plugin
- expand the shared `simp-hygiene` and `simproc-patterns` references with decision rules and authoring guidance grounded in the Lean community simp/simproc blog posts
- surface the new skill in the root and plugin READMEs so it is discoverable alongside the other focused Lean 4 skills

## Verification
- ran `bash plugins/lean4/tools/lint_docs.sh --verbose`
- lint still reports existing broken anchors and metadata warnings elsewhere in the repo; this change did not introduce a new lint class
