### PR TITLE
Add a `stuck?` skill for Lean next-step triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Typical session: `prove` (or `autoprove`) → `review` → `golf` → `checkpoin
 - **`prove`** — Guided, interactive. Asks preferences at startup, prompts before each commit, pauses between cycles. Start here.
 - **`autoprove`** — Autonomous, unattended. Auto-commits, loops until a stop condition fires (max cycles, max time, or stuck).
 - Both share one cycle engine: **Plan → Work → Checkpoint → Review → Replan → Continue/Stop**. Each sorry gets a mathlib search, tactic attempts, and validation. `--commit` controls per-fill commit behavior. When stuck, both force a review + replan.
-**Without a command:** Editing `.lean` files activates the skill for one bounded pass — fix the immediate issue, then suggest `/lean4:prove` or `/lean4:autoprove` for more. For short "what should I try next?" triage on a blocked goal, use the bundled [`stuck?` skill](plugins/lean4/skills/stuck/SKILL.md).
+**Without a command:** Editing `.lean` files activates the skill for one bounded pass — fix the immediate issue, then suggest `/lean4:prove` or `/lean4:autoprove` for more. If the agent needs short "what should I try next?" triage on a blocked goal, use the bundled [`stuck?` skill](plugins/lean4/skills/stuck/SKILL.md).
 
 See [plugin README](plugins/lean4/README.md) for the full command guide.
 
@@ -85,7 +85,7 @@ claude mcp add lean-lsp uvx lean-lsp-mcp
 ## Documentation
 
 - [SKILL.md](plugins/lean4/skills/lean4/SKILL.md) - Core skill reference
-- [stuck?](plugins/lean4/skills/stuck/SKILL.md) - Short unblock loop for Lean goals and tactic dead ends
+- [stuck?](plugins/lean4/skills/stuck/SKILL.md) - Short unblock loop when the agent needs the next Lean move
 - [INSTALLATION.md](INSTALLATION.md) - Setup guide
 - [Commands](plugins/lean4/commands/) - Command documentation
 - [Advanced References](plugins/lean4/skills/lean4/references/) - grind, simprocs, metaprogramming, linters, FFI, verso-docs, profiling

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Typical session: `prove` (or `autoprove`) → `review` → `golf` → `checkpoin
 - **`prove`** — Guided, interactive. Asks preferences at startup, prompts before each commit, pauses between cycles. Start here.
 - **`autoprove`** — Autonomous, unattended. Auto-commits, loops until a stop condition fires (max cycles, max time, or stuck).
 - Both share one cycle engine: **Plan → Work → Checkpoint → Review → Replan → Continue/Stop**. Each sorry gets a mathlib search, tactic attempts, and validation. `--commit` controls per-fill commit behavior. When stuck, both force a review + replan.
-- Editing `.lean` files without a command activates the skill for one bounded pass — fix the immediate issue, then suggest `prove` or `autoprove` for more.
+**Without a command:** Editing `.lean` files activates the skill for one bounded pass — fix the immediate issue, then suggest `/lean4:prove` or `/lean4:autoprove` for more. For short "what should I try next?" triage on a blocked goal, use the bundled [`stuck?` skill](plugins/lean4/skills/stuck/SKILL.md).
 
 See [plugin README](plugins/lean4/README.md) for the full command guide.
 
@@ -85,6 +85,7 @@ claude mcp add lean-lsp uvx lean-lsp-mcp
 ## Documentation
 
 - [SKILL.md](plugins/lean4/skills/lean4/SKILL.md) - Core skill reference
+- [stuck?](plugins/lean4/skills/stuck/SKILL.md) - Short unblock loop for Lean goals and tactic dead ends
 - [INSTALLATION.md](INSTALLATION.md) - Setup guide
 - [Commands](plugins/lean4/commands/) - Command documentation
 - [Advanced References](plugins/lean4/skills/lean4/references/) - grind, simprocs, metaprogramming, linters, FFI, verso-docs, profiling

--- a/plugins/lean4/README.md
+++ b/plugins/lean4/README.md
@@ -43,6 +43,8 @@ When you edit `.lean` files in a normal conversation, the plugin activates autom
 > Use `/lean4:prove` for guided cycle-by-cycle help.
 > Use `/lean4:autoprove` for autonomous cycles with stop safeguards.
 
+If you only need next-step triage for a blocked goal or tactic dead end, use the bundled [`stuck?` skill](skills/stuck/SKILL.md).
+
 ### `/lean4:formalize` — Autoformalization
 
 Turns informal mathematical claims into Lean 4 theorem statements. Drafts skeletons, attempts proofs, verifies axiom hygiene, and produces an assumption ledger for axiomatic drafts (`--rigor=axiomatic`). Accepts `--source` to ingest papers or files.
@@ -219,9 +221,12 @@ If `$LEAN4_SCRIPTS` is unset, run `/lean4:doctor` to reinitialize.
 plugins/lean4/
 ├── .claude-plugin/plugin.json
 ├── commands/           # User-invocable commands
-├── skills/lean4/
-│   ├── SKILL.md        # Core skill reference
-│   └── references/     # Reference docs
+├── skills/
+│   ├── lean4/
+│   │   ├── SKILL.md    # Core theorem-proving skill
+│   │   └── references/ # Reference docs
+│   └── stuck/
+│       └── SKILL.md    # Short unblock / next-step skill
 ├── agents/             # 4 specialized agents
 ├── hooks/              # Bootstrap and guardrails
 ├── scripts/           # Compat alias → lib/scripts
@@ -235,6 +240,7 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guide.
 ## See Also
 
 - [SKILL.md](skills/lean4/SKILL.md) - Core skill reference
+- [stuck?](skills/stuck/SKILL.md) - Short unblock loop for next-step Lean advice
 - [Commands](commands/) - Command documentation
 - [Scripts](lib/scripts/README.md) - Script reference
 - [Custom Syntax](skills/lean4/references/lean4-custom-syntax.md) - Notations, macros, elaborators, DSLs

--- a/plugins/lean4/README.md
+++ b/plugins/lean4/README.md
@@ -43,7 +43,7 @@ When you edit `.lean` files in a normal conversation, the plugin activates autom
 > Use `/lean4:prove` for guided cycle-by-cycle help.
 > Use `/lean4:autoprove` for autonomous cycles with stop safeguards.
 
-If you only need next-step triage for a blocked goal or tactic dead end, use the bundled [`stuck?` skill](skills/stuck/SKILL.md).
+If the agent only needs next-step triage for a blocked goal or tactic dead end, use the bundled [`stuck?` skill](skills/stuck/SKILL.md).
 
 ### `/lean4:formalize` — Autoformalization
 
@@ -240,7 +240,7 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guide.
 ## See Also
 
 - [SKILL.md](skills/lean4/SKILL.md) - Core skill reference
-- [stuck?](skills/stuck/SKILL.md) - Short unblock loop for next-step Lean advice
+- [stuck?](skills/stuck/SKILL.md) - Short unblock loop when the agent needs the next Lean move
 - [Commands](commands/) - Command documentation
 - [Scripts](lib/scripts/README.md) - Script reference
 - [Custom Syntax](skills/lean4/references/lean4-custom-syntax.md) - Notations, macros, elaborators, DSLs

--- a/plugins/lean4/skills/stuck/SKILL.md
+++ b/plugins/lean4/skills/stuck/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: stuck?
+description: "Use when a user is stuck on a Lean goal, tactic proof, or type error and wants the next concrete move. Triage the blocker, inspect goal/diagnostics, try low-cost tactics first (`try?`, `exact?`, `apply?`, `rw?`, `simp?`, `hint` when mathlib is available), then escalate to search, refactoring, or debugging advice."
+---
+
+# Lean Stuck Triage
+
+Use this skill when the user says they are stuck, asks what tactic to try next, or wants Lean debugging advice rather than a long autonomous proof search.
+
+## Default Loop
+
+1. Make the blocker concrete with `lean_goal`, `lean_term_goal`, `lean_hover_info`, or `lean_diagnostic_messages`.
+2. Classify the blocker before trying tactics:
+   - definitional equality / simplification
+   - missing intro / constructor / cases step
+   - missing rewrite
+   - arithmetic / inequalities
+   - missing library lemma
+   - typeclass / coercion / elaboration issue
+   - proof is too large and needs a helper lemma
+3. Spend a short budget on cheap tactics and suggestion tools. If 2-3 direct attempts fail, switch strategy instead of thrashing.
+4. Replace exploratory tactics with explicit proof code once something works. Do not leave `try?`, `exact?`, `apply?`, `rw?`, or `simp?` in the final proof.
+
+## Cheap Tactic Pass
+
+Start with low-cost, local tactics:
+
+`rfl` → `simp` / `simpa` → `rw [...]` → `change` / `show` → `constructor` / `refine` → `intro` / `cases` / `rcases` / `obtain` → `subst` / `have` / `specialize`
+
+Then use Lean's suggestion tactics:
+
+- `try?` when you want a concrete candidate script.
+- `exact?` when one lemma or hypothesis might close the goal.
+- `apply?` when a known theorem shape likely reduces the goal to manageable subgoals.
+- `rw?` when the next move is "some rewrite exists, but I do not know its name."
+- `simp?` to discover which lemmas `simp` wants before committing to `simp only [...]`.
+- `omega` for Presburger-style arithmetic over naturals and integers.
+- `grind` for mixed equality / constructor / local-hypothesis cleanup after the context is in the right shape.
+- `decide` or `native_decide` for finite decidable goals.
+
+## If Mathlib Is Available
+
+If the file imports `Mathlib` or the project clearly depends on mathlib, add mathlib-heavy tactics to the first pass:
+
+- `hint` for a quick "kitchen sink" pass over registered hint tactics.
+- `linarith` / `nlinarith` for linear or mildly nonlinear arithmetic.
+- `norm_num` for explicit numeral goals.
+- `ring` / `ring_nf` for polynomial normalization.
+- `positivity` for positivity side conditions.
+- `aesop` when the goal is mostly structural search over local facts and tagged lemmas.
+- `field_simp` or `field` for rational-function equalities over fields.
+
+Do not assume mathlib-only tactics exist in core Lean projects. Check imports before suggesting them.
+
+## Search Before More Tactics
+
+When the direct tactic pass stalls, search rather than guessing:
+
+- `lean_local_search` for exact names or prefixes.
+- `lean_loogle` for type-shaped search.
+- `lean_leansearch` for natural-language mathlib search.
+- `lean_leanfinder` for semantic search from the goal text.
+- `lean_hammer_premise` when you want candidate lemmas for `simp only [...]`, `grind [...]`, or `aesop`.
+- `lean_multi_attempt` to compare a small set of candidate tactics without editing the file.
+
+If a tool suggests something plausible, test it quickly and then write the explicit proof term or tactic sequence.
+
+## Structural Advice
+
+If the proof still feels stuck, the issue is usually structure, not one more tactic:
+
+- Shrink the goal with `have`, `suffices`, or `refine`.
+- Put the target into the right shape with `change` or `show`.
+- Turn an opaque local fact into named intermediate facts with `have h1 := ...`.
+- Destructure hypotheses early with `rcases`, `cases`, or `obtain`.
+- For rewrite-heavy goals, normalize one side first and only then search for the key lemma.
+- For typeclass failures, inspect binder order and missing outer instances before adding `haveI` / `letI`.
+- For coercion problems, compare hovered types exactly; avoid random casts.
+- For finite concrete goals, prefer computation (`decide`, `native_decide`) over proof search.
+
+## Communication Pattern
+
+When helping the user, always explain:
+
+1. what kind of blocker this is,
+2. what the next 1-3 concrete things to try are,
+3. why those steps come before heavier search or refactoring.
+
+If you cannot justify the next tactic from the goal state, stop and inspect more instead of guessing.
+
+## Escalation
+
+This skill is for short unblock loops. If the task turns into broader proof development, hand off to the main [lean4](../lean4/SKILL.md) skill or the `/lean4:prove` / `/lean4:autoprove` commands.
+
+## References
+
+- [lean4](../lean4/SKILL.md) - Full Lean proving workflow
+- [tactics-reference](../lean4/references/tactics-reference.md) - Compact tactic catalog
+- [lean-lsp-tools-api](../lean4/references/lean-lsp-tools-api.md) - Search and inspection tools
+- [Lean Tactic Reference](https://lean-lang.org/doc/reference/latest/Tactic-Proofs/Tactic-Reference/) - Core suggestion tactics such as `exact?`, `apply?`, `rw?`, and `try?`
+- [Mathlib `hint` tactic docs](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Tactic/Hint.html) - Mathlib's registered-hint tactic

--- a/plugins/lean4/skills/stuck/SKILL.md
+++ b/plugins/lean4/skills/stuck/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: stuck?
-description: "Use when a user is stuck on a Lean goal, tactic proof, or type error and wants the next concrete move. Triage the blocker, inspect goal/diagnostics, try low-cost tactics first (`try?`, `exact?`, `apply?`, `rw?`, `simp?`, `hint` when mathlib is available), then escalate to search, refactoring, or debugging advice."
+description: "Use when the agent is stuck on a Lean goal, tactic proof, or type error and needs the next concrete move. Triage the blocker, inspect goal/diagnostics, try low-cost tactics first (`try?`, `exact?`, `apply?`, `rw?`, `simp?`, `hint` when mathlib is available), then escalate to search, refactoring, or debugging advice."
 ---
 
 # Lean Stuck Triage
 
-Use this skill when the user says they are stuck, asks what tactic to try next, or wants Lean debugging advice rather than a long autonomous proof search.
+Use this skill when you, the agent, are stuck on the next Lean move and need a short unblock loop rather than a long autonomous proof search.
 
 ## Default Loop
 
@@ -80,7 +80,7 @@ If the proof still feels stuck, the issue is usually structure, not one more tac
 
 ## Communication Pattern
 
-When helping the user, always explain:
+When reporting back to the user, always explain:
 
 1. what kind of blocker this is,
 2. what the next 1-3 concrete things to try are,


### PR DESCRIPTION
## Summary
- add a new `stuck?` skill under the Lean plugin for short unblock loops and next-step tactic advice
- cover a default tactic ladder with `try?`, `exact?`, `apply?`, `rw?`, `simp?`, mathlib-only escalation like `hint`, and broader structural/search guidance
- surface the new skill in the top-level and plugin READMEs so it is discoverable from the normal workflow docs

## Testing
- `bash plugins/lean4/tools/lint_docs.sh` *(reports 50 pre-existing doc anchor/metadata issues unrelated to this change; no new `stuck?` link failures were introduced)*
