### PR TITLE
Add cache-first cold-start / fresh-worktree guidance

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -53,7 +53,7 @@ No special setup required.
 #### LSP Server Not Working
 
 1. Verify installation: https://github.com/oOo0oOo/lean-lsp-mcp
-2. Run `lake build` in your project first (avoids timeouts)
+2. Run `lake build` in your project first (avoids timeouts). If fresh clone/worktree or after `lake clean`, prime cache first: `lake cache get` or `lake exe cache get`.
 3. Restart Claude Code
 4. Test: try `lean_goal` on a `.lean` file
 

--- a/plugins/lean4/commands/doctor.md
+++ b/plugins/lean4/commands/doctor.md
@@ -198,6 +198,8 @@ No changes made. Run `/lean4:doctor cleanup --apply` to remove.
 | lake not found | Install via elan |
 | Scripts not executable | `chmod +x $LEAN4_SCRIPTS/*.sh` |
 | Build fails | `lake update && lake clean && lake build` |
+| Fresh worktree rebuild is slow / LSP times out on first use | Prime cache (`lake cache get` or `lake exe cache get`), then `lake build`; do not symlink `.lake/build` from another worktree |
+| Stale build after `lake clean` | Hydrate cache (`lake cache get` or `lake exe cache get`), then `lake build` |
 | Legacy plugin detected | Uninstall old plugin, remove directory |
 | Stale env vars | Restart session after removing old plugin |
 | Commands not found after migration | Check `/lean4:*` not `/lean4-theorem-proving:*` |

--- a/plugins/lean4/skills/lean4/SKILL.md
+++ b/plugins/lean4/skills/lean4/SKILL.md
@@ -176,6 +176,14 @@ ${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/sorry_analyzer.py" . --report-only
 # Counts only (optional): --format=summary
 ```
 
+**Cold start / fresh worktree:**
+- Fresh worktree or after `lake clean`? Prime the cache in that worktree before the first real build.
+- Use the project's cache command: `lake cache get` on newer Lake, or `lake exe cache get` where the project still uses the mathlib cache executable.
+- If Lean LSP is cold or timing out on first use, run one `lake build` to bootstrap the workspace.
+- After bootstrap, return to the normal verification ladder:
+  `lean_diagnostic_messages(file)` → `lake env lean <path/to/File.lean>` (from project root) → `lake build` only at checkpoint/final gate.
+- Do **not** symlink another worktree's `.lake/build`; use Lake cache/artifact mechanisms instead.
+
 ## References
 
 **Cycle Engine:** [cycle-engine](references/cycle-engine.md) — shared prove/autoprove logic (stuck, deep mode, falsification, safety)

--- a/plugins/lean4/skills/lean4/references/cycle-engine.md
+++ b/plugins/lean4/skills/lean4/references/cycle-engine.md
@@ -47,6 +47,8 @@ Do not suppress script stderr via `/dev/null`; surfaced errors are part of the f
 
 ## Build Target Policy
 
+For fresh clones/worktrees or after `lake clean`, hydrate cache first and do an initial `lake build` only if needed to bootstrap LSP; the ladder below is the normal steady-state workflow after startup.
+
 Three-tier verification ladder — use the lightest tool that answers the question:
 
 | Tier | Tool | When | Speed |

--- a/plugins/lean4/skills/lean4/references/lean-lsp-server.md
+++ b/plugins/lean4/skills/lean4/references/lean-lsp-server.md
@@ -10,11 +10,25 @@
 
 ## Prerequisites
 
-**Before using LSP tools:**
+**Before using LSP tools in a fresh clone or worktree:**
 
-1. **Run `lake build` first** - The LSP server runs `lake serve` which can timeout during initial project build. Run `lake build` manually in your project directory before starting the MCP server to ensure fast startup and avoid timeouts.
+1. **Prime the cache in this worktree first.**
+   Use the project's cache command:
+   - `lake cache get` on newer Lake versions, or
+   - `lake exe cache get` for projects that still use the mathlib cache executable.
 
-2. **Install ripgrep** - Required for `lean_local_search` (the most-used search tool):
+   This avoids rebuilding dependencies from scratch after a fresh checkout or `lake clean`.
+
+2. **If the LSP server is cold or timing out, run one `lake build`.**
+   The LSP server runs through `lake serve` and can be slow on first startup if the workspace has not been built yet.
+
+3. **After bootstrap, use LSP for normal iteration.**
+   Day-to-day proof development should use LSP tools for discovery, search, and per-edit validation.
+   Reserve `lake env lean <path/to/File.lean>` (run from project root) for file-level gates and `lake build` for checkpoint/final verification.
+
+**Worktrees:** prime cache separately per worktree. Do **not** symlink another worktree's `.lake/build`.
+
+4. **Install ripgrep** - Required for `lean_local_search` (the most-used search tool):
    - macOS: `brew install ripgrep`
    - Linux: `apt install ripgrep` or https://github.com/BurntSushi/ripgrep#installation
    - Windows: https://github.com/BurntSushi/ripgrep#installation

--- a/plugins/lean4/skills/lean4/references/sorry-filling.md
+++ b/plugins/lean4/skills/lean4/references/sorry-filling.md
@@ -180,12 +180,16 @@ LSP tools can sometimes show success when problems remain. After a sequence of c
 
 This catches issues that per-edit LSP may miss.
 
-**💡 Cache after clean**
-If you run `lake clean`, always follow up with:
+**💡 Cache after clean or in a fresh worktree**
+If you run `lake clean`, or start from a fresh clone/worktree, hydrate the cache before the first full build:
 ```bash
+lake cache get
+# or, in projects that use the older mathlib cache executable:
 lake exe cache get
 ```
-Otherwise you'll wait 30+ minutes for mathlib to recompile from scratch.
+Otherwise you may recompile large dependencies from scratch.
+
+Do this in the current worktree. Do not symlink another worktree's `.lake/build`; separate worktrees may be on different commits and should keep separate local build directories.
 
 ✅ **Do:**
 - Search mathlib exhaustively before proving

--- a/plugins/lean4/tools/lint_docs.sh
+++ b/plugins/lean4/tools/lint_docs.sh
@@ -57,7 +57,7 @@ check_commands() {
         local max_lines=120
         case "$cmd" in
             prove|autoprove) max_lines=235 ;;
-            doctor)          max_lines=220 ;;
+            doctor)          max_lines=225 ;;
             formalize)       max_lines=160 ;;
             golf)            max_lines=150 ;;
             review)          max_lines=330 ;;


### PR DESCRIPTION
## Summary

- Add coherent cache-priming guidance across 6 doc files so fresh worktrees (and post-`lake clean` sessions) do not trigger unnecessary dependency rebuilds
- Warn against symlinking `.lake/build` between worktrees; each worktree should hydrate its own cache
- Keep the normal steady-state verification ladder unchanged: `lean_diagnostic_messages` → `lake env lean` → `lake build`

## Motivation

Fresh worktrees and post-`lake clean` sessions need cache priming before the first real build. Previously only `sorry-filling.md` mentioned `lake exe cache get`, and only in the `lake clean` case. Meanwhile, `doctor.md` suggested `lake clean && lake build` without a cache step, and the LSP setup docs said "run `lake build` first" without explaining cache priming. That created an easy way to fall into a long dependency rebuild.

## Changes

| File | Change |
|------|--------|
| `SKILL.md` | Add a "Cold start / fresh worktree" note under Troubleshooting |
| `lean-lsp-server.md` | Rewrite Prerequisites around cache-first startup before bootstrap `lake build` |
| `sorry-filling.md` | Expand the cache note to cover fresh worktrees and both cache commands |
| `cycle-engine.md` | Add a cold-start preamble before the Build Target Policy table |
| `doctor.md` | Add troubleshooting rows for fresh worktrees and stale builds after `lake clean` |
| `INSTALLATION.md` | Expand the LSP troubleshooting entry with cache priming |
| `lint_docs.sh` | Raise `doctor.md` line budget from 220 to 225 |

## Validation

- Ran `LEAN4_PLUGIN_ROOT=plugins/lean4 bash plugins/lean4/tools/lint_docs.sh` successfully
- Verified `lake cache get` / `lake exe cache get` guidance appears in the intended files
- Verified the `.lake/build` symlink warning appears in the intended files
- Verified `doctor.md` has two new troubleshooting rows and keeps the generic `Build fails` row unchanged
- Verified the steady-state verification ladder remains unchanged in `cycle-engine.md` and `SKILL.md`