### PR TITLE
fix closing tag parse error in hermes-agent

### DIFF
--- a/plugins/lean4/skills/lean4/references/review-hook-schema.md
+++ b/plugins/lean4/skills/lean4/references/review-hook-schema.md
@@ -248,5 +248,5 @@ Use `preferences.verbosity` to signal desired response detail level.
 
 ## See Also
 
-- [/lean4:review](../../../commands/review.md) - Review command documentation
+- [`/lean4:review`](../../../commands/review.md) - Review command documentation
 - [mathlib-style.md](mathlib-style.md) - Style guidelines for suggestions


### PR DESCRIPTION
When trying to install this skill in `hermes-agent`, I kept getting the following error: 
```
Error: closing tag '[/lean4:review]' at position 663 doesn't match any open tag
```

This fixes that issue!