### PR TITLE
fix: honest invocation contract + session tracker for explicit stop budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ others all use the same core skill; only the invocation surface differs.
 | formalize | Interactive formalization — drafting plus guided proving |
 | autoformalize | Autonomous end-to-end formalization from informal sources |
 | prove | Guided cycle-by-cycle theorem proving |
-| autoprove | Autonomous multi-cycle proving with stop rules |
+| autoprove | Autonomous multi-cycle proving with explicit stop budgets |
 | checkpoint | Save point (per-file + project build, axiom check, commit) |
 | review | Read-only quality review |
 | refactor | Leverage mathlib, extract helpers, simplify proof strategies |
@@ -25,13 +25,18 @@ others all use the same core skill; only the invocation surface differs.
 
 Typical session: `draft` (or `formalize` / `autoformalize`) → `prove` (or `autoprove`) → `review` → `refactor` → `golf` → `checkpoint` → `git push`.
 
+CLI-like inputs are model-parsed at command startup, not host-parsed. Commands
+must announce resolved inputs, reject invalid startup configs, and treat
+wall-clock budgets as best-effort rather than host-enforced timeouts. See the
+[Command Invocation Contract](plugins/lean4/skills/lean4/references/command-invocation.md).
+
 ## How It Works
 
 - **`draft`** — Skeleton-only drafting from informal claims. Use when you want Lean declarations without a full prove run.
 - **`formalize`** — Interactive synthesis. Drafts a skeleton, then runs guided prove cycles with user interaction.
 - **`autoformalize`** — Autonomous synthesis. Extracts claims from a source, drafts skeletons, and proves them unattended.
 - **`prove`** — Guided proof engine for existing declarations. Asks preferences at startup, prompts before each commit, pauses between cycles.
-- **`autoprove`** — Autonomous proof engine for existing declarations. Auto-commits, loops until a stop condition fires (max cycles, max time, or stuck).
+- **`autoprove`** — Autonomous proof engine for existing declarations. Auto-commits, loops until a stop budget fires (max cycles, wall-clock budget, or stuck). The wall-clock budget is checked between cycles; it is not a host timeout.
 - The proof engines share one cycle engine: **Plan → Work → Checkpoint → Review → Replan → Continue/Stop**. Each sorry gets a mathlib search, tactic attempts, and validation. `--commit` controls per-fill commit behavior. When stuck, both force a review + replan.
 - `formalize` and `autoformalize` wrap drafting around that same engine. Statement and header changes belong there — `prove` and `autoprove` keep declaration headers immutable.
 - Editing `.lean` files without a command activates the skill for one bounded pass — fix the immediate issue, then suggest the right next command: `draft` / `formalize` for statement work, `prove` / `autoprove` for proof work.

--- a/plugins/lean4/MIGRATION.md
+++ b/plugins/lean4/MIGRATION.md
@@ -101,7 +101,7 @@ Or run `/lean4:doctor cleanup` for guided removal.
 7. git push                # Manual (safety guardrail)
 ```
 
-Or for unattended work: `/lean4:autoprove` (autonomous with stop rules).
+Or for unattended work: `/lean4:autoprove` (autonomous with explicit stop budgets).
 
 ## Key Differences
 
@@ -211,7 +211,7 @@ If you have external tooling or scripts that dispatch agents by the old names, u
 
 **`/lean4:autoprover` split into two commands:**
 - `/lean4:prove` — guided, cycle-by-cycle (asks before each cycle)
-- `/lean4:autoprove` — autonomous, with hard stop rules
+- `/lean4:autoprove` — autonomous, with explicit stop budgets
 
 Both share the same cycle engine and most flags. Key differences:
 - **prove-only:** `--deep=ask` (interactive prompt), `--planning=ask`, `--commit=ask` (per-commit confirmation)

--- a/plugins/lean4/README.md
+++ b/plugins/lean4/README.md
@@ -15,7 +15,7 @@ Unified Lean 4 plugin for theorem proving, interactive learning, and formalizati
 | `/lean4:formalize` | Interactive formalization — drafting plus guided proving |
 | `/lean4:autoformalize` | Autonomous end-to-end formalization from informal sources |
 | `/lean4:prove` | Guided cycle-by-cycle theorem proving with explicit checkpoints |
-| `/lean4:autoprove` | Autonomous multi-cycle theorem proving with hard stop rules |
+| `/lean4:autoprove` | Autonomous multi-cycle theorem proving with explicit stop budgets |
 | `/lean4:checkpoint` | Save progress with a safe commit checkpoint |
 | `/lean4:review` | Read-only code review of Lean proofs |
 | `/lean4:refactor` | Leverage mathlib, extract helpers, simplify proof strategies |
@@ -39,6 +39,11 @@ Unified Lean 4 plugin for theorem proving, interactive learning, and formalizati
 /lean4:doctor              # Diagnostics and migration help
 git push                   # Manual, after review
 ```
+
+CLI-like inputs are model-parsed at command startup, not host-parsed. Commands
+must echo resolved inputs, reject invalid startup configs before doing work, and
+treat wall-clock budgets as best-effort. See the
+[Command Invocation Contract](skills/lean4/references/command-invocation.md).
 
 ## How It Works
 
@@ -85,7 +90,7 @@ No questionnaire — discovers state and starts immediately. Commits without pro
 - All sorries filled
 - 3 consecutive stuck cycles (`--max-stuck-cycles`)
 - 20 total cycles (`--max-cycles`)
-- 120 minutes elapsed (`--max-total-runtime`)
+- 120 minutes wall-clock budget reached (`--max-total-runtime`, checked between cycles)
 
 On stop, emits a structured summary (sorries before/after, cycles, time, handoff recommendations).
 

--- a/plugins/lean4/commands/autoformalize.md
+++ b/plugins/lean4/commands/autoformalize.md
@@ -34,6 +34,11 @@ Startup requirements:
    A failed init (exit 2) is a startup validation error — do not proceed.
 4. The state file is the single source of truth for session counters.
    Read counters from `tick`/`status` output, not from conversational memory.
+5. **Per-claim lifecycle:** `--max-cycles` and `--max-stuck-cycles` are per-claim;
+   `--max-total-runtime` is per-session. Before each claim, call `start-claim`.
+   After each claim completes or stops (before the next), call `reset-claim`.
+   The final claim does not need `reset-claim` — totals are accumulated live.
+   See [Claim Boundary Protocol](../skills/lean4/references/cycle-engine.md#claim-boundary-protocol-autoformalize).
 
 ## Inputs
 
@@ -106,16 +111,16 @@ When autoformalize stops, emit:
 
 **Reason stopped:** [queue-empty | max-stuck | max-cycles | max-runtime | user-stop]
 
-| Metric | Value |
-|--------|-------|
-| Claims attempted | N/M |
-| Sorries before | 0 |
-| Sorries after | S |
-| Cycles run | C |
-| Stuck cycles | K |
-| Deep invocations | D |
-| Time elapsed | T |
-| Drafts | F (R redrafted) |
+| Metric | Value | Source |
+|--------|-------|--------|
+| Claims attempted | N/M | `claims_attempted` from `status` (includes in-progress claim) |
+| Sorries before | 0 | |
+| Sorries after | S | |
+| Cycles run | C | `cycles_total` from `status` (session total across all claims) |
+| Stuck cycles | K | `stuck_cycles_total` from `status` (session total) |
+| Deep invocations | D | `deep_total` from `status` (session total) |
+| Time elapsed | T | `elapsed_display` from `status` |
+| Drafts | F (R redrafted) | |
 
 **Handoff recommendations:**
 - [If incomplete: "Run /lean4:formalize for guided work on remaining claims"]

--- a/plugins/lean4/commands/autoformalize.md
+++ b/plugins/lean4/commands/autoformalize.md
@@ -16,6 +16,24 @@ Autonomous end-to-end formalization: extracts claims from a source, drafts Lean 
 /lean4:autoformalize --source ./notes.md --claim-select=named:"Main Lemma" --out=Lemma.lean
 ```
 
+## Invocation Contract
+
+Slash-command inputs are raw text. Before extracting claims or drafting
+anything, parse the raw invocation text using this command's input table and
+the
+[Command Invocation Contract](../skills/lean4/references/command-invocation.md).
+
+Startup requirements:
+
+1. Emit a **Resolved Inputs** block with explicit values, defaults, coercions,
+   ignored flags, and startup validation errors.
+2. Refuse to start on startup validation errors.
+3. Maintain session state explicitly: `claims_attempted`, `cycles_run`,
+   `stuck_cycles`, and `session_start_epoch`.
+4. Check `--max-total-runtime` with wall-clock time (`date +%s` or equivalent)
+   at claim and cycle boundaries. It is a best-effort budget, not a
+   host-enforced kill switch.
+
 ## Inputs
 
 | Arg | Required | Default | Description |
@@ -27,9 +45,9 @@ Autonomous end-to-end formalization: extracts claims from a source, drafts Lean 
 | --rigor | no | `sketch` | `sketch` \| `checked`. Rigor for drafted skeletons. |
 | --draft-mode | no | `skeleton` | `skeleton` \| `attempt`. Passed to draft phase. |
 | --draft-elab-check | no | `best-effort` | `best-effort` \| `strict`. Passed to draft phase. |
-| --max-cycles | no | 20 | Hard stop: max total cycles per claim |
-| --max-total-runtime | no | 120m | Hard stop: max total runtime |
-| --max-stuck-cycles | no | 3 | Hard stop: max consecutive stuck cycles per claim |
+| --max-cycles | no | 20 | Session stop budget: max total cycles per claim |
+| --max-total-runtime | no | 120m | Best-effort wall-clock session budget |
+| --max-stuck-cycles | no | 3 | Session stop budget: max consecutive stuck cycles per claim |
 | --deep | no | stuck | `never`, `stuck`, or `always` |
 | --deep-sorry-budget | no | 2 | Max sorries per deep invocation |
 | --deep-time-budget | no | 20m | Max time per deep invocation |
@@ -64,12 +82,16 @@ Summary:
 
 ## Stop Conditions
 
+Autoformalize checks these stop budgets at safe claim and cycle boundaries.
+`--max-total-runtime` is best-effort: it is re-checked before starting new
+work, not enforced as a mid-step timeout.
+
 Autoformalize stops when the **first** of these is satisfied:
 
 1. **Queue empty** — all claims attempted (expected completion)
 2. **Max stuck cycles** — `--max-stuck-cycles` consecutive stuck cycles on current claim
 3. **Max cycles** — `--max-cycles` total cycles reached on current claim
-4. **Max runtime** — `--max-total-runtime` elapsed
+4. **Max runtime** — best-effort wall-clock budget reached (`--max-total-runtime`)
 5. **Manual user stop** — user interrupts
 
 ## Structured Summary on Stop

--- a/plugins/lean4/commands/autoformalize.md
+++ b/plugins/lean4/commands/autoformalize.md
@@ -28,11 +28,12 @@ Startup requirements:
 1. Emit a **Resolved Inputs** block with explicit values, defaults, coercions,
    ignored flags, and startup validation errors.
 2. Refuse to start on startup validation errors.
-3. Maintain session state explicitly: `claims_attempted`, `cycles_run`,
-   `stuck_cycles`, and `session_start_epoch`.
-4. Check `--max-total-runtime` with wall-clock time (`date +%s` or equivalent)
-   at claim and cycle boundaries. It is a best-effort budget, not a
-   host-enforced kill switch.
+3. Call `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" init` with resolved numeric
+   values for `--max-cycles`, `--max-stuck-cycles`, `--max-total-runtime`,
+   `--max-deep-per-cycle`, and `--max-consecutive-deep-cycles`.
+   A failed init (exit 2) is a startup validation error — do not proceed.
+4. The state file is the single source of truth for session counters.
+   Read counters from `tick`/`status` output, not from conversational memory.
 
 ## Inputs
 
@@ -50,7 +51,7 @@ Startup requirements:
 | --max-stuck-cycles | no | 3 | Session stop budget: max consecutive stuck cycles per claim |
 | --deep | no | stuck | `never`, `stuck`, or `always` |
 | --deep-sorry-budget | no | 2 | Max sorries per deep invocation |
-| --deep-time-budget | no | 20m | Max time per deep invocation |
+| --deep-time-budget | no | 20m | Advisory: scopes deep-mode subagent work. Not tracked or enforced by session tracker. |
 | --max-deep-per-cycle | no | 1 | Max deep invocations per cycle |
 | --deep-snapshot | no | stash | V1: `stash` only |
 | --deep-rollback | no | on-regression | `on-regression` \| `on-no-improvement` \| `always` \| `never` |
@@ -82,17 +83,19 @@ Summary:
 
 ## Stop Conditions
 
-Autoformalize checks these stop budgets at safe claim and cycle boundaries.
-`--max-total-runtime` is best-effort: it is re-checked before starting new
-work, not enforced as a mid-step timeout.
+Autoformalize checks stop budgets at cycle boundaries via `$LEAN4_SCRIPTS/cycle_tracker.sh tick --stuck=yes|no`.
+Limits are checked at cycle boundaries only — a long-running tool call within a cycle
+will not be interrupted.
 
 Autoformalize stops when the **first** of these is satisfied:
 
 1. **Queue empty** — all claims attempted (expected completion)
-2. **Max stuck cycles** — `--max-stuck-cycles` consecutive stuck cycles on current claim
-3. **Max cycles** — `--max-cycles` total cycles reached on current claim
-4. **Max runtime** — best-effort wall-clock budget reached (`--max-total-runtime`)
+2. **Max stuck cycles** — `--max-stuck-cycles` consecutive stuck cycles on current claim. Session-enforced via `$LEAN4_SCRIPTS/cycle_tracker.sh`.
+3. **Max cycles** — `--max-cycles` total cycles reached on current claim. Session-enforced via `$LEAN4_SCRIPTS/cycle_tracker.sh`.
+4. **Max runtime** — best-effort wall-clock budget reached (`--max-total-runtime`). Checked at cycle boundaries and deep preflight.
 5. **Manual user stop** — user interrupts
+
+See [Session Tracking](../skills/lean4/references/cycle-engine.md#session-tracking) for the cycle boundary protocol and enforcement levels.
 
 ## Structured Summary on Stop
 

--- a/plugins/lean4/commands/autoformalize.md
+++ b/plugins/lean4/commands/autoformalize.md
@@ -30,7 +30,7 @@ Startup requirements:
 2. Refuse to start on startup validation errors.
 3. Call `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" init` with resolved numeric
    values for `--max-cycles`, `--max-stuck-cycles`, `--max-total-runtime`,
-   `--max-deep-per-cycle`, and `--max-consecutive-deep-cycles`.
+   and `--max-deep-per-cycle`.
    A failed init (exit 2) is a startup validation error — do not proceed.
 4. The state file is the single source of truth for session counters.
    Read counters from `tick`/`status` output, not from conversational memory.

--- a/plugins/lean4/commands/autoprove.md
+++ b/plugins/lean4/commands/autoprove.md
@@ -1,12 +1,12 @@
 ---
 name: autoprove
-description: Autonomous multi-cycle theorem proving with hard stop rules
+description: Autonomous multi-cycle theorem proving with explicit stop budgets
 user_invocable: true
 ---
 
 # Lean4 Autoprove
 
-Autonomous multi-cycle theorem proving. Runs cycles automatically with hard stop conditions and structured summaries.
+Autonomous multi-cycle theorem proving. Runs cycles automatically with explicit stop budgets and structured summaries.
 
 ## Usage
 
@@ -16,6 +16,23 @@ Autonomous multi-cycle theorem proving. Runs cycles automatically with hard stop
 /lean4:autoprove --repair-only          # Fix build errors without filling sorries
 /lean4:autoprove --max-cycles=10        # Limit total cycles
 ```
+
+## Invocation Contract
+
+Slash-command inputs are raw text. Before Phase 1, parse the raw invocation
+text using this command's input table and the
+[Command Invocation Contract](../skills/lean4/references/command-invocation.md).
+
+Startup requirements:
+
+1. Emit a **Resolved Inputs** block with explicit values, defaults, coercions,
+   ignored flags, and startup validation errors.
+2. Refuse to start on startup validation errors.
+3. Maintain session state explicitly: `cycles_run`, `stuck_cycles`,
+   `consecutive_deep_cycles`, and `session_start_epoch`.
+4. Check `--max-total-runtime` with wall-clock time (`date +%s` or equivalent)
+   at cycle boundaries and before deep mode. It is a best-effort budget, not a
+   host-enforced kill switch.
 
 ## Inputs
 
@@ -41,9 +58,9 @@ Autonomous multi-cycle theorem proving. Runs cycles automatically with hard stop
 | --batch-size | No | 2 | Sorries to attempt per cycle |
 | --commit | No | auto | `auto` or `never` (`ask` coerced to `auto` — see note below) |
 | --golf | No | never | `prompt`, `auto`, or `never` |
-| --max-cycles | No | 20 | Hard stop: max total cycles |
-| --max-total-runtime | No | 120m | Hard stop: max total runtime |
-| --max-stuck-cycles | No | 3 | Hard stop: max consecutive stuck cycles |
+| --max-cycles | No | 20 | Session stop budget: max total cycles |
+| --max-total-runtime | No | 120m | Best-effort wall-clock session budget |
+| --max-stuck-cycles | No | 3 | Session stop budget: max consecutive stuck cycles |
 | --formalize | No | never | `never` \| `restage` \| `auto`. See Formalize Outer Loop. (deprecated: use `/lean4:autoformalize`) |
 | --source | No | — | File path, URL, or PDF for claim extraction. Required when `--formalize=auto`. (deprecated: use `/lean4:autoformalize`) |
 | --claim-select | No | — | `first` \| `named:"..."` \| `regex:"..."`. Queue-extraction filter applied once at startup. Required when `--formalize=auto`. Ignored without `--source`. (deprecated: use `/lean4:autoformalize`) |
@@ -149,12 +166,16 @@ The inner 6-phase cycle is unchanged. The outer loop reads the stuck-mode `next_
 
 ## Stop Conditions
 
+Autoprove checks these stop budgets at safe cycle boundaries. `--max-total-runtime`
+is best-effort: it is re-checked before starting new work, not enforced as a
+mid-step timeout.
+
 Autoprove stops when the **first** of these is satisfied:
 
 1. **Completion** — all sorries in scope are filled
 2. **Max stuck cycles** — `--max-stuck-cycles` consecutive stuck cycles (default: 3)
 3. **Max cycles** — `--max-cycles` total cycles reached (default: 20)
-4. **Max runtime** — `--max-total-runtime` elapsed (default: 120m)
+4. **Max runtime** — best-effort wall-clock budget reached (`--max-total-runtime`, default: 120m)
 5. **Manual user stop** — user interrupts
 6. **Queue empty** — all claims attempted; expected completion for `--formalize=auto` sessions
 

--- a/plugins/lean4/commands/autoprove.md
+++ b/plugins/lean4/commands/autoprove.md
@@ -28,11 +28,12 @@ Startup requirements:
 1. Emit a **Resolved Inputs** block with explicit values, defaults, coercions,
    ignored flags, and startup validation errors.
 2. Refuse to start on startup validation errors.
-3. Maintain session state explicitly: `cycles_run`, `stuck_cycles`,
-   `consecutive_deep_cycles`, and `session_start_epoch`.
-4. Check `--max-total-runtime` with wall-clock time (`date +%s` or equivalent)
-   at cycle boundaries and before deep mode. It is a best-effort budget, not a
-   host-enforced kill switch.
+3. Call `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" init` with resolved numeric
+   values for `--max-cycles`, `--max-stuck-cycles`, `--max-total-runtime`,
+   `--max-deep-per-cycle`, and `--max-consecutive-deep-cycles`.
+   A failed init (exit 2) is a startup validation error — do not proceed.
+4. The state file is the single source of truth for session counters.
+   Read counters from `tick`/`status` output, not from conversational memory.
 
 ## Inputs
 
@@ -46,7 +47,7 @@ Startup requirements:
 | --checkpoint | No | true | Create checkpoint commits after each cycle |
 | --deep | No | stuck | `never`, `stuck`, or `always` (`ask` coerced to `stuck` — see Deep Mode) |
 | --deep-sorry-budget | No | 2 | Max sorries per deep invocation |
-| --deep-time-budget | No | 20m | Max time per deep invocation |
+| --deep-time-budget | No | 20m | Advisory: scopes deep-mode subagent work. Not tracked or enforced by session tracker. |
 | --max-deep-per-cycle | No | 1 | Max deep invocations per cycle |
 | --max-consecutive-deep-cycles | No | 2 | Hard cap on consecutive cycles using deep mode |
 | --deep-snapshot | No | stash | V1: `stash` only |
@@ -55,7 +56,7 @@ Startup requirements:
 | --deep-max-files | No | 2 | Max files per deep invocation |
 | --deep-max-lines | No | 200 | Max added+deleted lines per deep invocation |
 | --deep-regression-gate | No | strict | `strict` or `off` (see coercion below) |
-| --batch-size | No | 2 | Sorries to attempt per cycle |
+| --batch-size | No | 2 | Sorries to attempt per cycle (advisory) |
 | --commit | No | auto | `auto` or `never` (`ask` coerced to `auto` — see note below) |
 | --golf | No | never | `prompt`, `auto`, or `never` |
 | --max-cycles | No | 20 | Session stop budget: max total cycles |
@@ -166,18 +167,20 @@ The inner 6-phase cycle is unchanged. The outer loop reads the stuck-mode `next_
 
 ## Stop Conditions
 
-Autoprove checks these stop budgets at safe cycle boundaries. `--max-total-runtime`
-is best-effort: it is re-checked before starting new work, not enforced as a
-mid-step timeout.
+Autoprove checks stop budgets at cycle boundaries via `$LEAN4_SCRIPTS/cycle_tracker.sh tick --stuck=yes|no`.
+Limits are checked at cycle boundaries only — a long-running tool call within a cycle
+will not be interrupted.
 
 Autoprove stops when the **first** of these is satisfied:
 
 1. **Completion** — all sorries in scope are filled
-2. **Max stuck cycles** — `--max-stuck-cycles` consecutive stuck cycles (default: 3)
-3. **Max cycles** — `--max-cycles` total cycles reached (default: 20)
-4. **Max runtime** — best-effort wall-clock budget reached (`--max-total-runtime`, default: 120m)
+2. **Max stuck cycles** — `--max-stuck-cycles` consecutive stuck cycles (default: 3). Session-enforced via `$LEAN4_SCRIPTS/cycle_tracker.sh`.
+3. **Max cycles** — `--max-cycles` total cycles reached (default: 20). Session-enforced via `$LEAN4_SCRIPTS/cycle_tracker.sh`.
+4. **Max runtime** — best-effort wall-clock budget reached (`--max-total-runtime`, default: 120m). Checked at cycle boundaries and deep preflight.
 5. **Manual user stop** — user interrupts
 6. **Queue empty** — all claims attempted; expected completion for `--formalize=auto` sessions
+
+See [Session Tracking](../skills/lean4/references/cycle-engine.md#session-tracking) for the cycle boundary protocol and enforcement levels.
 
 ## Structured Summary on Stop
 

--- a/plugins/lean4/commands/draft.md
+++ b/plugins/lean4/commands/draft.md
@@ -18,17 +18,30 @@ Draft Lean 4 declaration skeletons from informal mathematical claims. Produces s
 /lean4:draft --output=file --out=MyTheorem.lean "..."
 ```
 
+## Invocation Contract
+
+Slash-command inputs are raw text. Before claim acquisition, parse the raw
+invocation text using this command's input table and the
+[Command Invocation Contract](../skills/lean4/references/command-invocation.md).
+
+Startup requirements:
+
+1. Emit a **Resolved Inputs** block with explicit values, defaults, coercions,
+   ignored flags, and startup validation errors.
+2. Refuse to start on startup validation errors.
+3. Validate output paths and overwrite policy before writing anything.
+
 ## Inputs
 
 | Arg | Required | Default | Description |
 |-----|----------|---------|-------------|
-| topic | no | — | Informal claim to draft. Optional when `--source` provides it (source-led flow). At least one of `topic` or `--source` must be given; omitting both is a hard error. |
+| topic | no | — | Informal claim to draft. Optional when `--source` provides it (source-led flow). At least one of `topic` or `--source` must be given; omitting both is a startup validation error. |
 | --mode | no | `skeleton` | `skeleton` \| `attempt`. `skeleton` produces sorry-stubbed declarations only. `attempt` adds a proof-attempt loop (`lean_multi_attempt`) before finalizing. |
 | --elab-check | no | `best-effort` | `best-effort` \| `strict`. Elaboration check strictness for drafted skeletons. |
 | --level | no | `intermediate` | `beginner` \| `intermediate` \| `expert` |
 | --output | no | `chat` | `chat` \| `scratch` \| `file` |
-| --out | no | — | Output path. Required when `--output=file`; hard error if missing. |
-| --overwrite | no | `false` | Allow overwriting existing files with `--output=file`. Without flag, existing target → hard error. |
+| --out | no | — | Output path. Required when `--output=file`; startup validation error if missing. |
+| --overwrite | no | `false` | Allow overwriting existing files with `--output=file`. Without flag, existing target → startup validation error. |
 | --source | no | — | File path, URL, or PDF to seed drafting. See [learn-pathways.md](../skills/lean4/references/learn-pathways.md#source-handling). |
 | --intent | no | `math` | `auto` \| `usage` \| `math`. See [learn-pathways.md](../skills/lean4/references/learn-pathways.md#intent-taxonomy). |
 | --presentation | no | `auto` | `informal` \| `supporting` \| `formal` \| `auto`. Controls user-facing display, not Lean backing. See [learn-pathways.md](../skills/lean4/references/learn-pathways.md#two-layer-architecture). |
@@ -36,16 +49,16 @@ Draft Lean 4 declaration skeletons from informal mathematical claims. Produces s
 
 ### Output validation
 
-- `--output=file` without `--out` → hard error
+- `--output=file` without `--out` → startup validation error
 - `--output=scratch` → `.scratch/lean4/draft-<timestamp>.lean` (workspace-local). Auto-create `.scratch/lean4/` if missing; warn if `.scratch/` is not in `.gitignore`.
-- `--output=file` with existing target and no `--overwrite` → hard error
+- `--output=file` with existing target and no `--overwrite` → startup validation error
 
 ### Flag validation
 
-- `--intent`, `--presentation`, or `--elab-check` with invalid value → hard error.
+- `--intent`, `--presentation`, or `--elab-check` with invalid value → startup validation error.
 - `--intent=auto` inference: apply the shared [inference rules](../skills/lean4/references/learn-pathways.md#inference-rules-when---intentauto), then coerce `internals` → `usage` and `authoring` → `usage` (draft does not define behavior for those intents).
 - `--source` + unreadable format → warn + ask for text excerpt.
-- `--claim-select` without `--source` → hard error (nothing to select from).
+- `--claim-select` without `--source` → startup validation error (nothing to select from).
 
 ### Noninteractive Claim Selection
 
@@ -107,7 +120,7 @@ Output format follows `--presentation`: `informal` → prose with math notation 
 - **No silent mutations.** Prefer LSP tools (`lean_goal`) over file writes for compilation checks. If LSP unavailable and temp file needed for internal compilation, write only under `/tmp/lean4-draft/`, auto-cleanup after use, warn user before writing.
 - **No commits.** `/draft` never commits. `--output=file` writes but does not stage or commit.
 - **Path restriction.** User-requested outputs (`--output=file`, `--output=scratch`) restricted to workspace root (scratch uses `.scratch/lean4/`). Reject path traversal (`../`) or absolute paths outside workspace. Internal temp files may use `/tmp/lean4-draft/`.
-- **Overwrite protection.** `--output=file` with existing target requires `--overwrite`; otherwise hard error.
+- **Overwrite protection.** `--output=file` with existing target requires `--overwrite`; otherwise startup validation error.
 - **Caller integration:** When `--caller=autoformalize` or `--caller=formalize`, file assembly and `draft:` commits are handled by the outer loop, not by draft.
 - **All `guardrails.sh` rules apply.**
 - **Line width.** Follow mathlib 100-char line width — do not wrap lines at 80 when they fit within 100.

--- a/plugins/lean4/commands/formalize.md
+++ b/plugins/lean4/commands/formalize.md
@@ -20,17 +20,30 @@ Interactive formalization: draft Lean skeletons from informal claims, then prove
 /lean4:formalize --output=file --out=MyTheorem.lean "..."
 ```
 
+## Invocation Contract
+
+Slash-command inputs are raw text. Before drafting or proving, parse the raw
+invocation text using this command's input table and the
+[Command Invocation Contract](../skills/lean4/references/command-invocation.md).
+
+Startup requirements:
+
+1. Emit a **Resolved Inputs** block with explicit values, defaults, coercions,
+   ignored flags, and startup validation errors.
+2. Refuse to start on startup validation errors.
+3. Validate output paths and overwrite policy before writing anything.
+
 ## Inputs
 
 | Arg | Required | Default | Description |
 |-----|----------|---------|-------------|
-| topic | no | — | Informal claim to formalize. Optional when `--source` provides it (source-led flow). At least one of `topic` or `--source` must be given; omitting both is a hard error. |
+| topic | no | — | Informal claim to formalize. Optional when `--source` provides it (source-led flow). At least one of `topic` or `--source` must be given; omitting both is a startup validation error. |
 | --rigor | no | `checked` | `checked` \| `sketch` \| `axiomatic` |
 | --verify | no | `best-effort` | `best-effort` \| `strict`. Verification strictness for key claims. See [learn-pathways.md](../skills/lean4/references/learn-pathways.md#verification-status). |
 | --level | no | `intermediate` | `beginner` \| `intermediate` \| `expert` |
 | --output | no | `chat` | `chat` \| `scratch` \| `file` |
-| --out | no | — | Output path. Required when `--output=file`; hard error if missing. |
-| --overwrite | no | `false` | Allow overwriting existing files with `--output=file`. Without flag, existing target → hard error. |
+| --out | no | — | Output path. Required when `--output=file`; startup validation error if missing. |
+| --overwrite | no | `false` | Allow overwriting existing files with `--output=file`. Without flag, existing target → startup validation error. |
 | --source | no | — | File path, URL, or PDF to seed formalization. See [learn-pathways.md](../skills/lean4/references/learn-pathways.md#source-handling). |
 | --intent | no | `math` | `auto` \| `usage` \| `math`. See [learn-pathways.md](../skills/lean4/references/learn-pathways.md#intent-taxonomy). |
 | --presentation | no | `auto` | `informal` \| `supporting` \| `formal` \| `auto`. Controls user-facing display, not Lean backing. See [learn-pathways.md](../skills/lean4/references/learn-pathways.md#two-layer-architecture). |
@@ -45,16 +58,16 @@ Interactive formalization: draft Lean skeletons from informal claims, then prove
 
 ### Output validation
 
-- `--output=file` without `--out` → hard error
+- `--output=file` without `--out` → startup validation error
 - `--output=scratch` → `.scratch/lean4/formalize-<timestamp>.lean` (workspace-local). Auto-create `.scratch/lean4/` if missing; warn if `.scratch/` is not in `.gitignore`.
-- `--output=file` with existing target and no `--overwrite` → hard error
+- `--output=file` with existing target and no `--overwrite` → startup validation error
 
 ### Flag validation
 
-- `--intent`, `--presentation`, or `--verify` with invalid value → hard error.
+- `--intent`, `--presentation`, or `--verify` with invalid value → startup validation error.
 - `--intent=auto` inference: apply the shared [inference rules](../skills/lean4/references/learn-pathways.md#inference-rules-when---intentauto), then coerce `internals` → `usage` and `authoring` → `usage` (formalize does not define behavior for those intents).
 - `--source` + unreadable format → warn + ask for text excerpt.
-- `--claim-select` without `--source` → hard error (nothing to select from).
+- `--claim-select` without `--source` → startup validation error (nothing to select from).
 
 ### Noninteractive Claim Selection
 
@@ -149,7 +162,7 @@ Always run `bash "$LEAN4_SCRIPTS/check_axioms_inline.sh" <target> --report-only`
 - **No silent mutations.** Prefer LSP tools (`lean_goal`) over file writes for compilation checks. If LSP unavailable and temp file needed for internal compilation, write only under `/tmp/lean4-formalize/`, auto-cleanup after use, warn user before writing.
 - **No commits in standalone mode.** `/formalize` never commits in standalone mode (`--commit` is accepted for prove-phase compatibility but inert — no staging, no committing). `--output=file` writes but does not stage or commit.
 - **Path restriction.** User-requested outputs (`--output=file`, `--output=scratch`) restricted to workspace root (scratch uses `.scratch/lean4/`). Reject path traversal (`../`) or absolute paths outside workspace. Internal temp files may use `/tmp/lean4-formalize/`.
-- **Overwrite protection.** `--output=file` with existing target requires `--overwrite`; otherwise hard error.
+- **Overwrite protection.** `--output=file` with existing target requires `--overwrite`; otherwise startup validation error.
 - **Never add global axioms silently.** Assumptions go as explicit theorem parameters or in `namespace Assumptions`. Always verified with `bash "$LEAN4_SCRIPTS/check_axioms_inline.sh" <target> --report-only`.
 - **All `guardrails.sh` rules apply.**
 - **Line width.** Follow mathlib 100-char line width — do not wrap lines at 80 when they fit within 100.

--- a/plugins/lean4/commands/formalize.md
+++ b/plugins/lean4/commands/formalize.md
@@ -52,7 +52,7 @@ Startup requirements:
 | --draft-elab-check | no | `best-effort` | `best-effort` \| `strict`. Elaboration check for the draft phase. |
 | --deep | no | never | `never` \| `ask` \| `stuck` \| `always`. Deep mode for prove phase. |
 | --deep-sorry-budget | no | 1 | Max sorries per deep invocation |
-| --deep-time-budget | no | 10m | Max time per deep invocation |
+| --deep-time-budget | no | 10m | Advisory: scopes deep-mode subagent work. Not tracked or enforced. |
 | --commit | no | ask | `ask` \| `auto` \| `never` |
 | --golf | no | prompt | `prompt` \| `auto` \| `never` |
 

--- a/plugins/lean4/commands/learn.md
+++ b/plugins/lean4/commands/learn.md
@@ -23,6 +23,19 @@ Interactive teaching and mathlib exploration. Adapts to beginner, intermediate, 
 /lean4:learn --style=socratic --adaptive=off  # Socratic, no style/level drift
 ```
 
+## Invocation Contract
+
+Slash-command inputs are raw text. Before discovery begins, parse the raw
+invocation text using this command's input table and the
+[Command Invocation Contract](../skills/lean4/references/command-invocation.md).
+
+Startup requirements:
+
+1. Emit a **Resolved Inputs** block with explicit values, defaults, coercions,
+   ignored flags, and startup validation errors.
+2. Refuse to start on startup validation errors.
+3. Validate output paths and overwrite policy before writing anything.
+
 ## Inputs
 
 | Arg | Required | Default | Description |
@@ -33,8 +46,8 @@ Interactive teaching and mathlib exploration. Adapts to beginner, intermediate, 
 | --scope | no | `auto` | `auto` \| `file` \| `changed` \| `project` \| `topic` |
 | --style | no | `tour` | `tour` \| `socratic` \| `exercise` \| `game` |
 | --output | no | `chat` | `chat` \| `scratch` \| `file` |
-| --out | no | — | Output path. Required when `--output=file`; hard error if missing. |
-| --overwrite | no | `false` | Allow overwriting existing files with `--output=file`. Without flag, existing target → hard error. |
+| --out | no | — | Output path. Required when `--output=file`; startup validation error if missing. |
+| --overwrite | no | `false` | Allow overwriting existing files with `--output=file`. Without flag, existing target → startup validation error. |
 | --interactive | no | `false` | True Socratic method (withhold answers, ask questions). Valid only with `--style=socratic`; ignored with warning otherwise. |
 | --intent | no | `auto` | `auto` \| `usage` \| `internals` \| `authoring` \| `math`. See [learn-pathways.md](../skills/lean4/references/learn-pathways.md#intent-taxonomy). |
 | --presentation | no | `auto` | `informal` \| `supporting` \| `formal` \| `auto`. Controls user-facing display, not Lean backing. See [learn-pathways.md](../skills/lean4/references/learn-pathways.md#two-layer-architecture). |
@@ -55,16 +68,16 @@ Interactive teaching and mathlib exploration. Adapts to beginner, intermediate, 
 
 ### Output validation
 
-- `--output=file` without `--out` → hard error
+- `--output=file` without `--out` → startup validation error
 - `--output=scratch` → `.scratch/lean4/learn-<timestamp>.lean` (workspace-local). Auto-create `.scratch/lean4/` if missing; warn if `.scratch/` is not in `.gitignore`.
-- `--output=file` with existing target and no `--overwrite` → hard error
+- `--output=file` with existing target and no `--overwrite` → startup validation error
 
 ### Flag validation
 
-- `--intent`, `--presentation`, or `--verify` with invalid value → hard error.
+- `--intent`, `--presentation`, or `--verify` with invalid value → startup validation error.
 - `--track` without `--style=game` → warn + ignore. `--style=game` without `--track` → prompt track picker.
 - `--source` + `--scope=file|changed|project` → warn "source overrides scope for initial discovery". Unsupported source type → warn + ask for text excerpt.
-- `--adaptive` with invalid value → hard error. `--adaptive=off` freezes the Learning Profile: the debate cannot change `style` or `level`. Within-style remediation (hint escalation, trying a counterexample instead of repeating an explanation) is unaffected — those don't modify the profile.
+- `--adaptive` with invalid value → startup validation error. `--adaptive=off` freezes the Learning Profile: the debate cannot change `style` or `level`. Within-style remediation (hint escalation, trying a counterexample instead of repeating an explanation) is unaffected — those don't modify the profile.
 
 ## Actions
 
@@ -165,7 +178,7 @@ Output format follows `--presentation`: `informal` → prose with math notation 
 - **No silent mutations.** Prefer LSP tools (`lean_goal`) over file writes for compilation checks. If LSP unavailable and temp file needed for internal compilation, write only under `/tmp/lean4-learn/`, auto-cleanup after use, warn user before writing.
 - **No commits.** `/learn` never commits. `--output=file` writes but does not stage or commit.
 - **Path restriction.** User-requested outputs (`--output=file`, `--output=scratch`) restricted to workspace root (scratch uses `.scratch/lean4/`). Reject path traversal (`../`) or absolute paths outside workspace. Internal temp files may use `/tmp/lean4-learn/`.
-- **Overwrite protection.** `--output=file` with existing target requires `--overwrite`; otherwise hard error.
+- **Overwrite protection.** `--output=file` with existing target requires `--overwrite`; otherwise startup validation error.
 - **Scope guardrails.** `--scope=project` in repo mode with >50 `.lean` files → warn with count, ask to narrow. In non-interactive contexts (e.g., LLM-invoked), default to "no" (do not proceed with large scope).
 - **All `guardrails.sh` rules apply.**
 

--- a/plugins/lean4/commands/prove.md
+++ b/plugins/lean4/commands/prove.md
@@ -17,6 +17,20 @@ Guided, cycle-by-cycle theorem proving. Asks before each cycle, supports deep es
 /lean4:prove --deep=stuck            # Enable deep escalation when stuck
 ```
 
+## Invocation Contract
+
+Slash-command inputs are raw text. Before Phase 1, parse the raw invocation
+text using this command's input table and the
+[Command Invocation Contract](../skills/lean4/references/command-invocation.md).
+
+Startup requirements:
+
+1. Emit a **Resolved Inputs** block with explicit values, defaults, coercions,
+   ignored flags, and startup validation errors.
+2. Refuse to start on startup validation errors.
+3. Persist any user-approved adjustments as session state so later cycles follow
+   the updated configuration rather than the initial prose alone.
+
 ## Inputs
 
 | Arg | Required | Default | Description |

--- a/plugins/lean4/commands/prove.md
+++ b/plugins/lean4/commands/prove.md
@@ -43,7 +43,7 @@ Startup requirements:
 | --checkpoint | No | true | Create checkpoint commits after each cycle |
 | --deep | No | never | `never`, `ask`, `stuck`, or `always` |
 | --deep-sorry-budget | No | 1 | Max sorries per deep invocation |
-| --deep-time-budget | No | 10m | Max time per deep invocation |
+| --deep-time-budget | No | 10m | Advisory: scopes deep-mode subagent work. Not tracked or enforced. |
 | --max-deep-per-cycle | No | 1 | Max deep invocations per cycle |
 | --deep-snapshot | No | stash | V1: `stash` only |
 | --deep-rollback | No | on-regression | `on-regression`, `on-no-improvement`, `always`, or `never` |

--- a/plugins/lean4/lib/scripts/cycle_tracker.sh
+++ b/plugins/lean4/lib/scripts/cycle_tracker.sh
@@ -621,7 +621,7 @@ cmd_start_claim() {
   if [[ "$_json_backend" == "jq" ]]; then
     active=$(jq -r '.claim_active' "$file" 2>/dev/null)
   else
-    active=$(python3 -c "import json; print(json.load(open('$file'))['claim_active'])" 2>/dev/null)
+    active=$(python3 -c "import json; print(str(json.load(open('$file'))['claim_active']).lower())" 2>/dev/null)
   fi
   if [[ "$active" == "true" ]]; then
     echo "error=start-claim called while claim_active is already true" >&2
@@ -661,7 +661,7 @@ cmd_reset_claim() {
   if [[ "$_json_backend" == "jq" ]]; then
     active=$(jq -r '.claim_active' "$file" 2>/dev/null)
   else
-    active=$(python3 -c "import json; print(json.load(open('$file'))['claim_active'])" 2>/dev/null)
+    active=$(python3 -c "import json; print(str(json.load(open('$file'))['claim_active']).lower())" 2>/dev/null)
   fi
   if [[ "$active" != "true" ]]; then
     echo "error=reset-claim called while claim_active is false" >&2

--- a/plugins/lean4/lib/scripts/cycle_tracker.sh
+++ b/plugins/lean4/lib/scripts/cycle_tracker.sh
@@ -113,10 +113,12 @@ _persist_env() {
   local env_out
   env_out=$(_resolve_env_file)
   if [[ -z "$env_out" ]]; then return; fi
-  # Guard: if the file exists, it must be readable+writable.
-  if [[ -e "$env_out" && ( ! -r "$env_out" || ! -w "$env_out" ) ]]; then return; fi
-  # Guard: if the file does not exist, the parent directory must be writable.
-  if [[ ! -e "$env_out" ]]; then
+  # Guard: if something exists at the path, it must be a regular file that is
+  # readable+writable. Directories, FIFOs, devices, etc. are rejected.
+  if [[ -e "$env_out" ]]; then
+    if [[ ! -f "$env_out" || ! -r "$env_out" || ! -w "$env_out" ]]; then return; fi
+  else
+    # File does not exist: parent directory must exist and be writable.
     local _pdir
     _pdir=$(dirname "$env_out")
     if [[ ! -d "$_pdir" || ! -w "$_pdir" ]]; then return; fi
@@ -269,16 +271,16 @@ cmd_init() {
   # same file even if LEAN4_ENV_FILE/CLAUDE_ENV_FILE changes between calls.
   local resolved_env_file
   resolved_env_file=$(_resolve_env_file)
-  # Only record if actually writable; otherwise empty = stdout-only fallback.
+  # Only record if actually writable regular file (or creatable); otherwise
+  # empty = stdout-only fallback. Directories, FIFOs, devices are rejected.
   if [[ -n "$resolved_env_file" ]]; then
     if [[ -e "$resolved_env_file" ]]; then
-      # Existing file: must be both readable and writable.
-      if [[ ! -r "$resolved_env_file" || ! -w "$resolved_env_file" ]]; then
+      # Must be a regular file that is readable+writable.
+      if [[ ! -f "$resolved_env_file" || ! -r "$resolved_env_file" || ! -w "$resolved_env_file" ]]; then
         resolved_env_file=""
       fi
     else
-      # File does not exist: parent directory must exist and be writable,
-      # and we must be able to create the file.
+      # File does not exist: parent directory must exist and be writable.
       local parent_dir
       parent_dir=$(dirname "$resolved_env_file")
       if [[ ! -d "$parent_dir" || ! -w "$parent_dir" ]]; then
@@ -665,9 +667,10 @@ cmd_stop() {
   rm -f "$f"
   # Also clean up any orphaned tmp files from atomic writes
   rm -f "${f}".tmp.* 2>/dev/null || true
-  # Unpersist LEAN4_SESSION_ID from the env file
+  # Unpersist only this session's LEAN4_SESSION_ID from the env file, not
+  # another session's. Match the exact value being stopped.
   if [[ -n "$recorded_env" && -f "$recorded_env" && -r "$recorded_env" && -w "$recorded_env" ]]; then
-    grep -v "^export LEAN4_SESSION_ID=" "$recorded_env" > "${recorded_env}.tmp" 2>/dev/null || true
+    grep -v "^export LEAN4_SESSION_ID=\"${sid}\"" "$recorded_env" > "${recorded_env}.tmp" 2>/dev/null || true
     mv "${recorded_env}.tmp" "$recorded_env"
   fi
 }

--- a/plugins/lean4/lib/scripts/cycle_tracker.sh
+++ b/plugins/lean4/lib/scripts/cycle_tracker.sh
@@ -6,6 +6,11 @@ set -euo pipefail
 # (write-to-temp, then mv). Single-writer assumption: only the main command
 # thread writes; subagents never touch the state file.
 #
+# Env-file persistence: resolves LEAN4_ENV_FILE → CLAUDE_ENV_FILE → (none).
+# CLAUDE_ENV_FILE is the Claude Code adapter input; LEAN4_ENV_FILE is the
+# host-neutral override. When neither is available, session ID is printed
+# to stdout for manual env-prefix passing.
+#
 # Subcommands:
 #   init   --max-cycles=N --max-stuck=N [--max-runtime=Xm] [--max-deep-per-cycle=N] [--max-consecutive-deep=N]
 #   tick   --stuck=yes|no
@@ -94,26 +99,37 @@ with open('$file', 'w') as f:
 }
 
 # ---------------------------------------------------------------------------
-# persist_env: same pattern as bootstrap.sh
+# persist_env: host-neutral env-file persistence
+# Resolves: LEAN4_ENV_FILE → CLAUDE_ENV_FILE → (none = stdout fallback)
 # ---------------------------------------------------------------------------
+_resolve_env_file() {
+  echo "${LEAN4_ENV_FILE:-${CLAUDE_ENV_FILE:-}}"
+}
+
 _persist_env() {
   local kv="$1"
   local var_name="${kv%%=*}"
   var_name="${var_name#export }"
-  local env_out="${CLAUDE_ENV_FILE:-}"
-  if [[ -n "$env_out" ]]; then
-    if [[ -f "$env_out" ]]; then
-      grep -v "^export ${var_name}=" "$env_out" > "${env_out}.tmp" 2>/dev/null || true
-      mv "${env_out}.tmp" "$env_out"
-    fi
-    printf '%s\n' "$kv" >> "$env_out" 2>/dev/null || true
+  local env_out
+  env_out=$(_resolve_env_file)
+  if [[ -z "$env_out" ]]; then return; fi
+  # True fallback: if the file exists but is not both readable and writable,
+  # do not touch it — rely on stdout session-id handoff instead.
+  if [[ -e "$env_out" && ( ! -r "$env_out" || ! -w "$env_out" ) ]]; then return; fi
+  if [[ -f "$env_out" ]]; then
+    grep -v "^export ${var_name}=" "$env_out" > "${env_out}.tmp" 2>/dev/null || true
+    mv "${env_out}.tmp" "$env_out"
   fi
+  printf '%s\n' "$kv" >> "$env_out" 2>/dev/null || true
 }
 
 _unpersist_env() {
   local var_name="$1"
-  local env_out="${CLAUDE_ENV_FILE:-}"
-  if [[ -n "$env_out" && -f "$env_out" ]]; then
+  local env_out
+  env_out=$(_resolve_env_file)
+  if [[ -z "$env_out" ]]; then return; fi
+  if [[ -e "$env_out" && ( ! -r "$env_out" || ! -w "$env_out" ) ]]; then return; fi
+  if [[ -f "$env_out" ]]; then
     grep -v "^export ${var_name}=" "$env_out" > "${env_out}.tmp" 2>/dev/null || true
     mv "${env_out}.tmp" "$env_out"
   fi
@@ -134,6 +150,23 @@ _state_file() {
     exit 2
   fi
   echo "$f"
+}
+
+_validate_state() {
+  # Verify state file contains valid JSON. Exit 2 with clear error if not.
+  local file="$1"
+  _detect_backend
+  if [[ "$_json_backend" == "jq" ]]; then
+    if ! jq empty "$file" 2>/dev/null; then
+      echo "error=corrupted state file: $file" >&2
+      exit 2
+    fi
+  else
+    if ! python3 -c "import json; json.load(open('$file'))" 2>/dev/null; then
+      echo "error=corrupted state file: $file" >&2
+      exit 2
+    fi
+  fi
 }
 
 _read_state() {
@@ -273,6 +306,7 @@ cmd_tick() {
 
   local file
   file=$(_state_file)
+  _validate_state "$file"
   _detect_backend
 
   local now
@@ -307,11 +341,14 @@ cmd_tick() {
         ] | join(",")
       ) as $violations |
 
-      # Format elapsed display
-      (($elapsed / 60) | floor) as $elapsed_min |
-      (if .max_runtime_seconds > 0 then
-        ((.max_runtime_seconds / 60) | floor | tostring) + "m"
-       else "unlimited" end) as $max_display |
+      # Format elapsed display — use seconds when max < 60s
+      (if .max_runtime_seconds > 0 and .max_runtime_seconds < 60 then
+        ($elapsed | tostring) + "s/" + (.max_runtime_seconds | tostring) + "s"
+       elif .max_runtime_seconds > 0 then
+        (($elapsed / 60) | floor | tostring) + "m/" + ((.max_runtime_seconds / 60) | floor | tostring) + "m"
+       else
+        (($elapsed / 60) | floor | tostring) + "m/unlimited"
+       end) as $elapsed_display |
 
       # Output key=value, then the object for saving
       {
@@ -321,7 +358,7 @@ cmd_tick() {
           "cycles=" + (.cycles | tostring) + "/" + (.max_cycles | tostring) + "\n" +
           "consecutive_stuck=" + (.consecutive_stuck | tostring) + "/" + (.max_stuck | tostring) + "\n" +
           "elapsed_seconds=" + ($elapsed | tostring) + "\n" +
-          "elapsed_display=" + ($elapsed_min | tostring) + "m/" + $max_display + "\n" +
+          "elapsed_display=" + $elapsed_display + "\n" +
           "deep_this_cycle=" + (.deep_this_cycle | tostring) + "/" + (.max_deep_per_cycle | tostring) + "\n" +
           "consecutive_deep_cycles=" + (.consecutive_deep_cycles | tostring) + "/" + (.max_consecutive_deep | tostring)
         ),
@@ -382,12 +419,14 @@ if d['consecutive_stuck'] >= d['max_stuck']:
 if d['max_runtime_seconds'] > 0 and elapsed >= d['max_runtime_seconds']:
     violations.append('max-runtime')
 
-# Format display
-elapsed_min = elapsed // 60
-if d['max_runtime_seconds'] > 0:
-    max_display = str(d['max_runtime_seconds'] // 60) + 'm'
+# Format display — use seconds when max < 60s
+mrs = d['max_runtime_seconds']
+if mrs > 0 and mrs < 60:
+    elapsed_display = f'{elapsed}s/{mrs}s'
+elif mrs > 0:
+    elapsed_display = f'{elapsed // 60}m/{mrs // 60}m'
 else:
-    max_display = 'unlimited'
+    elapsed_display = f'{elapsed // 60}m/unlimited'
 
 result = 'LIMIT_REACHED' if violations else 'ok'
 lines = ['result=' + result]
@@ -397,7 +436,7 @@ lines.extend([
     f\"cycles={d['cycles']}/{d['max_cycles']}\",
     f\"consecutive_stuck={d['consecutive_stuck']}/{d['max_stuck']}\",
     f'elapsed_seconds={elapsed}',
-    f'elapsed_display={elapsed_min}m/{max_display}',
+    f'elapsed_display={elapsed_display}',
     f\"deep_this_cycle={d['deep_this_cycle']}/{d['max_deep_per_cycle']}\",
     f\"consecutive_deep_cycles={d['consecutive_deep_cycles']}/{d['max_consecutive_deep']}\",
 ])
@@ -421,6 +460,7 @@ sys.exit(1 if violations else 0)
 cmd_can_deep() {
   local file
   file=$(_state_file)
+  _validate_state "$file"
   _detect_backend
 
   local now
@@ -491,6 +531,7 @@ sys.exit(1 if reason else 0)
 cmd_deep() {
   local file
   file=$(_state_file)
+  _validate_state "$file"
   _detect_backend
 
   if [[ "$_json_backend" == "jq" ]]; then
@@ -518,6 +559,7 @@ os.rename(tmp, '$file')
 cmd_status() {
   local file
   file=$(_state_file)
+  _validate_state "$file"
   _detect_backend
 
   local now
@@ -526,15 +568,18 @@ cmd_status() {
   if [[ "$_json_backend" == "jq" ]]; then
     jq -r --argjson now "$now" '
       ($now - .start_epoch) as $elapsed |
-      (($elapsed / 60) | floor) as $elapsed_min |
-      (if .max_runtime_seconds > 0 then
-        ((.max_runtime_seconds / 60) | floor | tostring) + "m"
-       else "unlimited" end) as $max_display |
+      (if .max_runtime_seconds > 0 and .max_runtime_seconds < 60 then
+        ($elapsed | tostring) + "s/" + (.max_runtime_seconds | tostring) + "s"
+       elif .max_runtime_seconds > 0 then
+        (($elapsed / 60) | floor | tostring) + "m/" + ((.max_runtime_seconds / 60) | floor | tostring) + "m"
+       else
+        (($elapsed / 60) | floor | tostring) + "m/unlimited"
+       end) as $elapsed_display |
       "session_id=" + .session_id,
       "cycles=" + (.cycles | tostring) + "/" + (.max_cycles | tostring),
       "consecutive_stuck=" + (.consecutive_stuck | tostring) + "/" + (.max_stuck | tostring),
       "elapsed_seconds=" + ($elapsed | tostring),
-      "elapsed_display=" + ($elapsed_min | tostring) + "m/" + $max_display,
+      "elapsed_display=" + $elapsed_display,
       "deep_this_cycle=" + (.deep_this_cycle | tostring) + "/" + (.max_deep_per_cycle | tostring),
       "consecutive_deep_cycles=" + (.consecutive_deep_cycles | tostring) + "/" + (.max_consecutive_deep | tostring)
     ' "$file" 2>/dev/null
@@ -545,17 +590,19 @@ with open('$file') as f:
     d = json.load(f)
 now = $now
 elapsed = now - d['start_epoch']
-elapsed_min = elapsed // 60
-if d['max_runtime_seconds'] > 0:
-    max_display = str(d['max_runtime_seconds'] // 60) + 'm'
+mrs = d['max_runtime_seconds']
+if mrs > 0 and mrs < 60:
+    elapsed_display = f'{elapsed}s/{mrs}s'
+elif mrs > 0:
+    elapsed_display = f'{elapsed // 60}m/{mrs // 60}m'
 else:
-    max_display = 'unlimited'
+    elapsed_display = f'{elapsed // 60}m/unlimited'
 lines = [
     f\"session_id={d['session_id']}\",
     f\"cycles={d['cycles']}/{d['max_cycles']}\",
     f\"consecutive_stuck={d['consecutive_stuck']}/{d['max_stuck']}\",
     f'elapsed_seconds={elapsed}',
-    f'elapsed_display={elapsed_min}m/{max_display}',
+    f'elapsed_display={elapsed_display}',
     f\"deep_this_cycle={d['deep_this_cycle']}/{d['max_deep_per_cycle']}\",
     f\"consecutive_deep_cycles={d['consecutive_deep_cycles']}/{d['max_consecutive_deep']}\",
 ]

--- a/plugins/lean4/lib/scripts/cycle_tracker.sh
+++ b/plugins/lean4/lib/scripts/cycle_tracker.sh
@@ -239,22 +239,28 @@ _parse_duration() {
 cmd_init() {
   local max_cycles="" max_stuck="" max_runtime="" max_deep_per_cycle="1" max_consecutive_deep="2"
 
+  # Track the flag name the caller actually used, for error messages
+  local name_stuck="--max-stuck" name_runtime="--max-runtime" name_consec_deep="--max-consecutive-deep"
+
   for arg in "$@"; do
     case "$arg" in
       --max-cycles=*) max_cycles="${arg#*=}" ;;
-      --max-stuck=*|--max-stuck-cycles=*) max_stuck="${arg#*=}" ;;
-      --max-runtime=*|--max-total-runtime=*) max_runtime="${arg#*=}" ;;
+      --max-stuck=*) max_stuck="${arg#*=}" ;;
+      --max-stuck-cycles=*) max_stuck="${arg#*=}"; name_stuck="--max-stuck-cycles" ;;
+      --max-runtime=*) max_runtime="${arg#*=}" ;;
+      --max-total-runtime=*) max_runtime="${arg#*=}"; name_runtime="--max-total-runtime" ;;
       --max-deep-per-cycle=*) max_deep_per_cycle="${arg#*=}" ;;
-      --max-consecutive-deep=*|--max-consecutive-deep-cycles=*) max_consecutive_deep="${arg#*=}" ;;
+      --max-consecutive-deep=*) max_consecutive_deep="${arg#*=}" ;;
+      --max-consecutive-deep-cycles=*) max_consecutive_deep="${arg#*=}"; name_consec_deep="--max-consecutive-deep-cycles" ;;
       *) echo "error=unknown argument: $arg" >&2; exit 2 ;;
     esac
   done
 
-  # Validate required
+  # Validate required — use the flag name the caller passed
   _require_positive_int "--max-cycles" "$max_cycles"
-  _require_positive_int "--max-stuck" "$max_stuck"
+  _require_positive_int "$name_stuck" "$max_stuck"
   _require_positive_int "--max-deep-per-cycle" "$max_deep_per_cycle"
-  _require_positive_int "--max-consecutive-deep" "$max_consecutive_deep"
+  _require_positive_int "$name_consec_deep" "$max_consecutive_deep"
 
   # Parse duration (optional)
   local runtime_seconds

--- a/plugins/lean4/lib/scripts/cycle_tracker.sh
+++ b/plugins/lean4/lib/scripts/cycle_tracker.sh
@@ -109,11 +109,17 @@ _resolve_env_file() {
   # Return empty so callers fall back to stdout-only.
   if [[ -L "$raw" && ! -e "$raw" ]]; then echo ""; return; fi
   # Resolve symlinks so we operate on the real target, not the link itself.
-  # realpath is preferred; fall back to readlink -f; fall back to raw path.
+  # If the path is a symlink and resolution tools are unavailable, reject it
+  # rather than operating on the link path (which would clobber the symlink).
   local resolved
   resolved=$(realpath "$raw" 2>/dev/null) \
     || resolved=$(readlink -f "$raw" 2>/dev/null) \
-    || resolved="$raw"
+    || resolved=""
+  if [[ -z "$resolved" ]]; then
+    # Resolution failed. Safe to use raw path only if it's not a symlink.
+    if [[ -L "$raw" ]]; then echo ""; return; fi
+    resolved="$raw"
+  fi
   echo "$resolved"
 }
 

--- a/plugins/lean4/lib/scripts/cycle_tracker.sh
+++ b/plugins/lean4/lib/scripts/cycle_tracker.sh
@@ -113,9 +113,14 @@ _persist_env() {
   local env_out
   env_out=$(_resolve_env_file)
   if [[ -z "$env_out" ]]; then return; fi
-  # True fallback: if the file exists but is not both readable and writable,
-  # do not touch it — rely on stdout session-id handoff instead.
+  # Guard: if the file exists, it must be readable+writable.
   if [[ -e "$env_out" && ( ! -r "$env_out" || ! -w "$env_out" ) ]]; then return; fi
+  # Guard: if the file does not exist, the parent directory must be writable.
+  if [[ ! -e "$env_out" ]]; then
+    local _pdir
+    _pdir=$(dirname "$env_out")
+    if [[ ! -d "$_pdir" || ! -w "$_pdir" ]]; then return; fi
+  fi
   if [[ -f "$env_out" ]]; then
     grep -v "^export ${var_name}=" "$env_out" > "${env_out}.tmp" 2>/dev/null || true
     mv "${env_out}.tmp" "$env_out"
@@ -264,10 +269,21 @@ cmd_init() {
   # same file even if LEAN4_ENV_FILE/CLAUDE_ENV_FILE changes between calls.
   local resolved_env_file
   resolved_env_file=$(_resolve_env_file)
-  # Only record if writable; otherwise empty = stdout-only fallback.
+  # Only record if actually writable; otherwise empty = stdout-only fallback.
   if [[ -n "$resolved_env_file" ]]; then
-    if [[ -e "$resolved_env_file" && ( ! -r "$resolved_env_file" || ! -w "$resolved_env_file" ) ]]; then
-      resolved_env_file=""
+    if [[ -e "$resolved_env_file" ]]; then
+      # Existing file: must be both readable and writable.
+      if [[ ! -r "$resolved_env_file" || ! -w "$resolved_env_file" ]]; then
+        resolved_env_file=""
+      fi
+    else
+      # File does not exist: parent directory must exist and be writable,
+      # and we must be able to create the file.
+      local parent_dir
+      parent_dir=$(dirname "$resolved_env_file")
+      if [[ ! -d "$parent_dir" || ! -w "$parent_dir" ]]; then
+        resolved_env_file=""
+      fi
     fi
   fi
 
@@ -634,16 +650,22 @@ cmd_stop() {
   local f="/tmp/${sid}.json"
   # Read the env file path that init recorded, so we clean up the right file
   # even if LEAN4_ENV_FILE/CLAUDE_ENV_FILE changed since init.
+  # Read the env file path that init recorded. If the state file is missing or
+  # corrupted, fall back to the currently resolved env file for best-effort
+  # cleanup so we don't leak stale LEAN4_SESSION_ID exports.
   local recorded_env=""
   if [[ -f "$f" ]]; then
     _detect_backend
     recorded_env=$(_json_read "$f" ".env_file" 2>/dev/null) || recorded_env=""
     if [[ "$recorded_env" == "null" ]]; then recorded_env=""; fi
   fi
+  if [[ -z "$recorded_env" ]]; then
+    recorded_env=$(_resolve_env_file)
+  fi
   rm -f "$f"
   # Also clean up any orphaned tmp files from atomic writes
   rm -f "${f}".tmp.* 2>/dev/null || true
-  # Unpersist from the recorded env file, not the currently resolved one
+  # Unpersist LEAN4_SESSION_ID from the env file
   if [[ -n "$recorded_env" && -f "$recorded_env" && -r "$recorded_env" && -w "$recorded_env" ]]; then
     grep -v "^export LEAN4_SESSION_ID=" "$recorded_env" > "${recorded_env}.tmp" 2>/dev/null || true
     mv "${recorded_env}.tmp" "$recorded_env"

--- a/plugins/lean4/lib/scripts/cycle_tracker.sh
+++ b/plugins/lean4/lib/scripts/cycle_tracker.sh
@@ -103,7 +103,15 @@ with open('$file', 'w') as f:
 # Resolves: LEAN4_ENV_FILE → CLAUDE_ENV_FILE → (none = stdout fallback)
 # ---------------------------------------------------------------------------
 _resolve_env_file() {
-  echo "${LEAN4_ENV_FILE:-${CLAUDE_ENV_FILE:-}}"
+  local raw="${LEAN4_ENV_FILE:-${CLAUDE_ENV_FILE:-}}"
+  if [[ -z "$raw" ]]; then echo ""; return; fi
+  # Resolve symlinks so we operate on the real target, not the link itself.
+  # realpath is preferred; fall back to readlink -f; fall back to raw path.
+  local resolved
+  resolved=$(realpath "$raw" 2>/dev/null) \
+    || resolved=$(readlink -f "$raw" 2>/dev/null) \
+    || resolved="$raw"
+  echo "$resolved"
 }
 
 _persist_env() {
@@ -128,18 +136,6 @@ _persist_env() {
     mv "${env_out}.tmp" "$env_out"
   fi
   printf '%s\n' "$kv" >> "$env_out" 2>/dev/null || true
-}
-
-_unpersist_env() {
-  local var_name="$1"
-  local env_out
-  env_out=$(_resolve_env_file)
-  if [[ -z "$env_out" ]]; then return; fi
-  if [[ -e "$env_out" && ( ! -r "$env_out" || ! -w "$env_out" ) ]]; then return; fi
-  if [[ -f "$env_out" ]]; then
-    grep -v "^export ${var_name}=" "$env_out" > "${env_out}.tmp" 2>/dev/null || true
-    mv "${env_out}.tmp" "$env_out"
-  fi
 }
 
 # ---------------------------------------------------------------------------

--- a/plugins/lean4/lib/scripts/cycle_tracker.sh
+++ b/plugins/lean4/lib/scripts/cycle_tracker.sh
@@ -308,7 +308,12 @@ cmd_init() {
   "cycles": 0,
   "consecutive_stuck": 0,
   "deep_this_cycle": 0,
-  "consecutive_deep_cycles": 0
+  "consecutive_deep_cycles": 0,
+  "cycles_total": 0,
+  "stuck_cycles_total": 0,
+  "deep_total": 0,
+  "claims_attempted": 0,
+  "claim_active": false
 }
 ENDJSON
   )
@@ -352,12 +357,15 @@ cmd_tick() {
   if [[ "$_json_backend" == "jq" ]]; then
     output=$(jq -r --argjson stuck_flag "$(if [[ "$stuck" == "yes" ]]; then echo 1; else echo 0; fi)" \
                     --argjson now "$now" '
-      # Update cycles
+      # Update cycles (per-claim + session total)
       .cycles += 1 |
+      .cycles_total += 1 |
 
-      # Update stuck
+      # Update stuck (per-claim consecutive + session total)
       (if $stuck_flag == 1 then .consecutive_stuck + 1 else 0 end) as $new_stuck |
       .consecutive_stuck = $new_stuck |
+      (if $stuck_flag == 1 then .stuck_cycles_total + 1 else .stuck_cycles_total end) as $new_stuck_total |
+      .stuck_cycles_total = $new_stuck_total |
 
       # Update deep
       (if .deep_this_cycle > 0 then .consecutive_deep_cycles + 1 else 0 end) as $new_consec_deep |
@@ -431,11 +439,14 @@ with open('$file') as f:
 now = $now
 stuck = bool($stuck_flag)
 
-# Update cycles
+# Update cycles (per-claim + session total)
 d['cycles'] += 1
+d['cycles_total'] += 1
 
-# Update stuck
+# Update stuck (per-claim consecutive + session total)
 d['consecutive_stuck'] = d['consecutive_stuck'] + 1 if stuck else 0
+if stuck:
+    d['stuck_cycles_total'] += 1
 
 # Update deep
 if d['deep_this_cycle'] > 0:
@@ -572,7 +583,7 @@ cmd_deep() {
   if [[ "$_json_backend" == "jq" ]]; then
     local tmp
     tmp=$(mktemp "${file}.tmp.XXXXXX")
-    jq '.deep_this_cycle += 1' "$file" > "$tmp" 2>/dev/null
+    jq '.deep_this_cycle += 1 | .deep_total += 1' "$file" > "$tmp" 2>/dev/null
     mv "$tmp" "$file"
   else
     python3 -c "
@@ -580,6 +591,99 @@ import json, tempfile, os
 with open('$file') as f:
     d = json.load(f)
 d['deep_this_cycle'] += 1
+d['deep_total'] += 1
+fd, tmp = tempfile.mkstemp(prefix=os.path.basename('$file') + '.tmp.', dir=os.path.dirname('$file'))
+with os.fdopen(fd, 'w') as f:
+    json.dump(d, f)
+os.rename(tmp, '$file')
+" 2>/dev/null
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: start-claim
+# ---------------------------------------------------------------------------
+cmd_start_claim() {
+  local file
+  file=$(_state_file)
+  _validate_state "$file"
+  _detect_backend
+
+  # Guard: fail if a claim is already active
+  local active
+  if [[ "$_json_backend" == "jq" ]]; then
+    active=$(jq -r '.claim_active' "$file" 2>/dev/null)
+  else
+    active=$(python3 -c "import json; print(json.load(open('$file'))['claim_active'])" 2>/dev/null)
+  fi
+  if [[ "$active" == "true" ]]; then
+    echo "error=start-claim called while claim_active is already true" >&2
+    exit 2
+  fi
+
+  if [[ "$_json_backend" == "jq" ]]; then
+    local tmp
+    tmp=$(mktemp "${file}.tmp.XXXXXX")
+    jq '.claim_active = true' "$file" > "$tmp" 2>/dev/null
+    mv "$tmp" "$file"
+  else
+    python3 -c "
+import json, tempfile, os
+with open('$file') as f:
+    d = json.load(f)
+d['claim_active'] = True
+fd, tmp = tempfile.mkstemp(prefix=os.path.basename('$file') + '.tmp.', dir=os.path.dirname('$file'))
+with os.fdopen(fd, 'w') as f:
+    json.dump(d, f)
+os.rename(tmp, '$file')
+" 2>/dev/null
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: reset-claim
+# ---------------------------------------------------------------------------
+cmd_reset_claim() {
+  local file
+  file=$(_state_file)
+  _validate_state "$file"
+  _detect_backend
+
+  # Guard: fail if no claim is active
+  local active
+  if [[ "$_json_backend" == "jq" ]]; then
+    active=$(jq -r '.claim_active' "$file" 2>/dev/null)
+  else
+    active=$(python3 -c "import json; print(json.load(open('$file'))['claim_active'])" 2>/dev/null)
+  fi
+  if [[ "$active" != "true" ]]; then
+    echo "error=reset-claim called while claim_active is false" >&2
+    exit 2
+  fi
+
+  if [[ "$_json_backend" == "jq" ]]; then
+    local tmp
+    tmp=$(mktemp "${file}.tmp.XXXXXX")
+    jq '
+      .claims_attempted += 1 |
+      .claim_active = false |
+      .cycles = 0 |
+      .consecutive_stuck = 0 |
+      .deep_this_cycle = 0 |
+      .consecutive_deep_cycles = 0
+    ' "$file" > "$tmp" 2>/dev/null
+    mv "$tmp" "$file"
+  else
+    python3 -c "
+import json, tempfile, os
+with open('$file') as f:
+    d = json.load(f)
+d['claims_attempted'] += 1
+d['claim_active'] = False
+d['cycles'] = 0
+d['consecutive_stuck'] = 0
+d['deep_this_cycle'] = 0
+d['consecutive_deep_cycles'] = 0
 fd, tmp = tempfile.mkstemp(prefix=os.path.basename('$file') + '.tmp.', dir=os.path.dirname('$file'))
 with os.fdopen(fd, 'w') as f:
     json.dump(d, f)
@@ -610,13 +714,20 @@ cmd_status() {
        else
         (($elapsed / 60) | floor | tostring) + "m/unlimited"
        end) as $elapsed_display |
+      # Session totals (live-accumulated, always current)
+      (.claims_attempted + (if .claim_active then 1 else 0 end)) as $claims_display |
       "session_id=" + .session_id,
+      "claim_active=" + (if .claim_active then "true" else "false" end),
       "cycles=" + (.cycles | tostring) + "/" + (.max_cycles | tostring),
       "consecutive_stuck=" + (.consecutive_stuck | tostring) + "/" + (.max_stuck | tostring),
       "elapsed_seconds=" + ($elapsed | tostring),
       "elapsed_display=" + $elapsed_display,
       "deep_this_cycle=" + (.deep_this_cycle | tostring) + "/" + (.max_deep_per_cycle | tostring),
-      "consecutive_deep_cycles=" + (.consecutive_deep_cycles | tostring) + "/" + (.max_consecutive_deep | tostring)
+      "consecutive_deep_cycles=" + (.consecutive_deep_cycles | tostring) + "/" + (.max_consecutive_deep | tostring),
+      "cycles_total=" + (.cycles_total | tostring),
+      "stuck_cycles_total=" + (.stuck_cycles_total | tostring),
+      "deep_total=" + (.deep_total | tostring),
+      "claims_attempted=" + ($claims_display | tostring)
     ' "$file" 2>/dev/null
   else
     python3 -c "
@@ -632,14 +743,20 @@ elif mrs > 0:
     elapsed_display = f'{elapsed // 60}m/{mrs // 60}m'
 else:
     elapsed_display = f'{elapsed // 60}m/unlimited'
+claims_display = d['claims_attempted'] + (1 if d.get('claim_active') else 0)
 lines = [
     f\"session_id={d['session_id']}\",
+    f\"claim_active={'true' if d.get('claim_active') else 'false'}\",
     f\"cycles={d['cycles']}/{d['max_cycles']}\",
     f\"consecutive_stuck={d['consecutive_stuck']}/{d['max_stuck']}\",
     f'elapsed_seconds={elapsed}',
     f'elapsed_display={elapsed_display}',
     f\"deep_this_cycle={d['deep_this_cycle']}/{d['max_deep_per_cycle']}\",
     f\"consecutive_deep_cycles={d['consecutive_deep_cycles']}/{d['max_consecutive_deep']}\",
+    f\"cycles_total={d['cycles_total']}\",
+    f\"stuck_cycles_total={d['stuck_cycles_total']}\",
+    f\"deep_total={d['deep_total']}\",
+    f'claims_attempted={claims_display}',
 ]
 print('\n'.join(lines))
 " 2>/dev/null
@@ -687,12 +804,14 @@ subcmd="${1:-}"
 shift || true
 
 case "$subcmd" in
-  init)     cmd_init "$@" ;;
-  tick)     cmd_tick "$@" ;;
-  can-deep) cmd_can_deep "$@" ;;
-  deep)     cmd_deep "$@" ;;
-  status)   cmd_status "$@" ;;
-  stop)     cmd_stop "$@" ;;
-  "")       echo "error=no subcommand specified (init|tick|can-deep|deep|status|stop)" >&2; exit 2 ;;
+  init)        cmd_init "$@" ;;
+  tick)        cmd_tick "$@" ;;
+  can-deep)    cmd_can_deep "$@" ;;
+  deep)        cmd_deep "$@" ;;
+  start-claim) cmd_start_claim "$@" ;;
+  reset-claim) cmd_reset_claim "$@" ;;
+  status)      cmd_status "$@" ;;
+  stop)        cmd_stop "$@" ;;
+  "")          echo "error=no subcommand specified (init|tick|can-deep|deep|start-claim|reset-claim|status|stop)" >&2; exit 2 ;;
   *)        echo "error=unknown subcommand: $subcmd" >&2; exit 2 ;;
 esac

--- a/plugins/lean4/lib/scripts/cycle_tracker.sh
+++ b/plugins/lean4/lib/scripts/cycle_tracker.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 #
 # Subcommands:
 #   init   --max-cycles=N --max-stuck=N [--max-runtime=Xm] [--max-deep-per-cycle=N] [--max-consecutive-deep=N]
+#          Aliases (long user-facing forms): --max-stuck-cycles, --max-total-runtime, --max-consecutive-deep-cycles
 #   tick   --stuck=yes|no
 #   can-deep
 #   deep
@@ -241,10 +242,10 @@ cmd_init() {
   for arg in "$@"; do
     case "$arg" in
       --max-cycles=*) max_cycles="${arg#*=}" ;;
-      --max-stuck=*) max_stuck="${arg#*=}" ;;
-      --max-runtime=*) max_runtime="${arg#*=}" ;;
+      --max-stuck=*|--max-stuck-cycles=*) max_stuck="${arg#*=}" ;;
+      --max-runtime=*|--max-total-runtime=*) max_runtime="${arg#*=}" ;;
       --max-deep-per-cycle=*) max_deep_per_cycle="${arg#*=}" ;;
-      --max-consecutive-deep=*) max_consecutive_deep="${arg#*=}" ;;
+      --max-consecutive-deep=*|--max-consecutive-deep-cycles=*) max_consecutive_deep="${arg#*=}" ;;
       *) echo "error=unknown argument: $arg" >&2; exit 2 ;;
     esac
   done

--- a/plugins/lean4/lib/scripts/cycle_tracker.sh
+++ b/plugins/lean4/lib/scripts/cycle_tracker.sh
@@ -260,11 +260,23 @@ cmd_init() {
   local now
   now=$(date +%s)
 
+  # Resolve env file once at init and record it in state, so stop uses the
+  # same file even if LEAN4_ENV_FILE/CLAUDE_ENV_FILE changes between calls.
+  local resolved_env_file
+  resolved_env_file=$(_resolve_env_file)
+  # Only record if writable; otherwise empty = stdout-only fallback.
+  if [[ -n "$resolved_env_file" ]]; then
+    if [[ -e "$resolved_env_file" && ( ! -r "$resolved_env_file" || ! -w "$resolved_env_file" ) ]]; then
+      resolved_env_file=""
+    fi
+  fi
+
   local content
   content=$(cat <<ENDJSON
 {
   "session_id": "$session_id",
   "start_epoch": $now,
+  "env_file": "$resolved_env_file",
   "max_cycles": $max_cycles,
   "max_stuck": $max_stuck,
   "max_runtime_seconds": $runtime_seconds,
@@ -280,7 +292,7 @@ ENDJSON
 
   _json_create "$state_file" "$content"
 
-  # Persist session ID
+  # Persist session ID to the resolved env file
   _persist_env "export LEAN4_SESSION_ID=\"$session_id\""
 
   echo "$session_id"
@@ -341,8 +353,8 @@ cmd_tick() {
         ] | join(",")
       ) as $violations |
 
-      # Format elapsed display — use seconds when max < 60s
-      (if .max_runtime_seconds > 0 and .max_runtime_seconds < 60 then
+      # Format elapsed display — use seconds when max is not a whole number of minutes
+      (if .max_runtime_seconds > 0 and (.max_runtime_seconds % 60) != 0 then
         ($elapsed | tostring) + "s/" + (.max_runtime_seconds | tostring) + "s"
        elif .max_runtime_seconds > 0 then
         (($elapsed / 60) | floor | tostring) + "m/" + ((.max_runtime_seconds / 60) | floor | tostring) + "m"
@@ -421,7 +433,7 @@ if d['max_runtime_seconds'] > 0 and elapsed >= d['max_runtime_seconds']:
 
 # Format display — use seconds when max < 60s
 mrs = d['max_runtime_seconds']
-if mrs > 0 and mrs < 60:
+if mrs > 0 and mrs % 60 != 0:
     elapsed_display = f'{elapsed}s/{mrs}s'
 elif mrs > 0:
     elapsed_display = f'{elapsed // 60}m/{mrs // 60}m'
@@ -568,7 +580,7 @@ cmd_status() {
   if [[ "$_json_backend" == "jq" ]]; then
     jq -r --argjson now "$now" '
       ($now - .start_epoch) as $elapsed |
-      (if .max_runtime_seconds > 0 and .max_runtime_seconds < 60 then
+      (if .max_runtime_seconds > 0 and (.max_runtime_seconds % 60) != 0 then
         ($elapsed | tostring) + "s/" + (.max_runtime_seconds | tostring) + "s"
        elif .max_runtime_seconds > 0 then
         (($elapsed / 60) | floor | tostring) + "m/" + ((.max_runtime_seconds / 60) | floor | tostring) + "m"
@@ -591,7 +603,7 @@ with open('$file') as f:
 now = $now
 elapsed = now - d['start_epoch']
 mrs = d['max_runtime_seconds']
-if mrs > 0 and mrs < 60:
+if mrs > 0 and mrs % 60 != 0:
     elapsed_display = f'{elapsed}s/{mrs}s'
 elif mrs > 0:
     elapsed_display = f'{elapsed // 60}m/{mrs // 60}m'
@@ -620,10 +632,22 @@ cmd_stop() {
     return 0
   fi
   local f="/tmp/${sid}.json"
+  # Read the env file path that init recorded, so we clean up the right file
+  # even if LEAN4_ENV_FILE/CLAUDE_ENV_FILE changed since init.
+  local recorded_env=""
+  if [[ -f "$f" ]]; then
+    _detect_backend
+    recorded_env=$(_json_read "$f" ".env_file" 2>/dev/null) || recorded_env=""
+    if [[ "$recorded_env" == "null" ]]; then recorded_env=""; fi
+  fi
   rm -f "$f"
   # Also clean up any orphaned tmp files from atomic writes
   rm -f "${f}".tmp.* 2>/dev/null || true
-  _unpersist_env "LEAN4_SESSION_ID"
+  # Unpersist from the recorded env file, not the currently resolved one
+  if [[ -n "$recorded_env" && -f "$recorded_env" && -r "$recorded_env" && -w "$recorded_env" ]]; then
+    grep -v "^export LEAN4_SESSION_ID=" "$recorded_env" > "${recorded_env}.tmp" 2>/dev/null || true
+    mv "${recorded_env}.tmp" "$recorded_env"
+  fi
 }
 
 # ---------------------------------------------------------------------------

--- a/plugins/lean4/lib/scripts/cycle_tracker.sh
+++ b/plugins/lean4/lib/scripts/cycle_tracker.sh
@@ -105,6 +105,9 @@ with open('$file', 'w') as f:
 _resolve_env_file() {
   local raw="${LEAN4_ENV_FILE:-${CLAUDE_ENV_FILE:-}}"
   if [[ -z "$raw" ]]; then echo ""; return; fi
+  # Reject broken symlinks: the link exists but its target does not.
+  # Return empty so callers fall back to stdout-only.
+  if [[ -L "$raw" && ! -e "$raw" ]]; then echo ""; return; fi
   # Resolve symlinks so we operate on the real target, not the link itself.
   # realpath is preferred; fall back to readlink -f; fall back to raw path.
   local resolved

--- a/plugins/lean4/lib/scripts/cycle_tracker.sh
+++ b/plugins/lean4/lib/scripts/cycle_tracker.sh
@@ -1,0 +1,597 @@
+#!/bin/bash
+set -euo pipefail
+
+# Session cycle/time tracker for autonomous commands (autoprove, autoformalize).
+# State is stored in a JSON file under /tmp. All mutations are atomic
+# (write-to-temp, then mv). Single-writer assumption: only the main command
+# thread writes; subagents never touch the state file.
+#
+# Subcommands:
+#   init   --max-cycles=N --max-stuck=N [--max-runtime=Xm] [--max-deep-per-cycle=N] [--max-consecutive-deep=N]
+#   tick   --stuck=yes|no
+#   can-deep
+#   deep
+#   status
+#   stop
+
+# ---------------------------------------------------------------------------
+# JSON backend: jq preferred, python3 fallback
+# ---------------------------------------------------------------------------
+_json_backend=""
+
+_detect_backend() {
+  if [[ -n "$_json_backend" ]]; then return; fi
+  if command -v jq >/dev/null 2>&1; then
+    _json_backend="jq"
+  elif command -v python3 >/dev/null 2>&1; then
+    _json_backend="python3"
+  else
+    echo "error=no JSON backend (need jq or python3)" >&2
+    exit 2
+  fi
+}
+
+_json_read() {
+  # $1 = file, $2 = jq expression (e.g., '.cycles')
+  local file="$1" expr="$2"
+  _detect_backend
+  if [[ "$_json_backend" == "jq" ]]; then
+    jq -r "$expr" "$file" 2>/dev/null
+  else
+    python3 -c "
+import json, sys
+with open('$file') as f:
+    d = json.load(f)
+# Evaluate the jq-like expression
+expr = '''$expr'''
+# Simple .field access
+parts = [p for p in expr.lstrip('.').split('.') if p]
+val = d
+for p in parts:
+    val = val[p]
+print(val)
+" 2>/dev/null
+  fi
+}
+
+_json_write() {
+  # $1 = file, $2 = python dict literal OR jq filter to apply
+  # For simplicity, always use python3 for writes (handles complex updates).
+  # For jq backend, use jq for writes too.
+  local file="$1" updates="$2"
+  _detect_backend
+  local tmp
+  tmp=$(mktemp "${file}.tmp.XXXXXX")
+  if [[ "$_json_backend" == "jq" ]]; then
+    jq "$updates" "$file" > "$tmp" 2>/dev/null
+  else
+    python3 -c "
+import json
+with open('$file') as f:
+    d = json.load(f)
+updates = $updates
+d.update(updates)
+with open('$tmp', 'w') as f:
+    json.dump(d, f)
+" 2>/dev/null
+  fi
+  mv "$tmp" "$file"
+}
+
+_json_create() {
+  # $1 = file, $2 = JSON string
+  local file="$1" content="$2"
+  _detect_backend
+  if [[ "$_json_backend" == "jq" ]]; then
+    printf '%s' "$content" | jq '.' > "$file" 2>/dev/null
+  else
+    python3 -c "
+import json
+with open('$file', 'w') as f:
+    json.dump(json.loads('''$content'''), f)
+" 2>/dev/null
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# persist_env: same pattern as bootstrap.sh
+# ---------------------------------------------------------------------------
+_persist_env() {
+  local kv="$1"
+  local var_name="${kv%%=*}"
+  var_name="${var_name#export }"
+  local env_out="${CLAUDE_ENV_FILE:-}"
+  if [[ -n "$env_out" ]]; then
+    if [[ -f "$env_out" ]]; then
+      grep -v "^export ${var_name}=" "$env_out" > "${env_out}.tmp" 2>/dev/null || true
+      mv "${env_out}.tmp" "$env_out"
+    fi
+    printf '%s\n' "$kv" >> "$env_out" 2>/dev/null || true
+  fi
+}
+
+_unpersist_env() {
+  local var_name="$1"
+  local env_out="${CLAUDE_ENV_FILE:-}"
+  if [[ -n "$env_out" && -f "$env_out" ]]; then
+    grep -v "^export ${var_name}=" "$env_out" > "${env_out}.tmp" 2>/dev/null || true
+    mv "${env_out}.tmp" "$env_out"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# State file resolution
+# ---------------------------------------------------------------------------
+_state_file() {
+  local sid="${LEAN4_SESSION_ID:-}"
+  if [[ -z "$sid" ]]; then
+    echo "error=LEAN4_SESSION_ID is not set" >&2
+    exit 2
+  fi
+  local f="/tmp/${sid}.json"
+  if [[ ! -f "$f" ]]; then
+    echo "error=state file not found: $f" >&2
+    exit 2
+  fi
+  echo "$f"
+}
+
+_read_state() {
+  local file
+  file=$(_state_file)
+  _detect_backend
+  if [[ "$_json_backend" == "jq" ]]; then
+    cat "$file"
+  else
+    python3 -c "
+import json
+with open('$file') as f:
+    print(json.dumps(json.load(f)))
+"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+_require_positive_int() {
+  local name="$1" val="$2"
+  if [[ -z "$val" ]]; then
+    echo "error=missing required parameter $name" >&2
+    exit 2
+  fi
+  if ! [[ "$val" =~ ^[0-9]+$ ]] || [[ "$val" -le 0 ]]; then
+    echo "error=$name must be a positive integer, got '$val'" >&2
+    exit 2
+  fi
+}
+
+_parse_duration() {
+  # Accepts: 120m, 30s, 2h, 120 (bare = minutes). Returns seconds.
+  local val="$1"
+  if [[ -z "$val" ]]; then
+    echo "0"
+    return
+  fi
+  if ! [[ "$val" =~ ^[0-9]+[mshMSH]?$ ]]; then
+    echo "error=invalid duration format '$val' (expected e.g. 120m, 30s, 2h, or bare number for minutes)" >&2
+    exit 2
+  fi
+  local num="${val%%[mshMSH]}"
+  local suffix="${val##*[0-9]}"
+  suffix="${suffix,,}"  # lowercase
+  case "$suffix" in
+    s) echo "$num" ;;
+    h) echo $(( num * 3600 )) ;;
+    m|"") echo $(( num * 60 )) ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: init
+# ---------------------------------------------------------------------------
+cmd_init() {
+  local max_cycles="" max_stuck="" max_runtime="" max_deep_per_cycle="1" max_consecutive_deep="2"
+
+  for arg in "$@"; do
+    case "$arg" in
+      --max-cycles=*) max_cycles="${arg#*=}" ;;
+      --max-stuck=*) max_stuck="${arg#*=}" ;;
+      --max-runtime=*) max_runtime="${arg#*=}" ;;
+      --max-deep-per-cycle=*) max_deep_per_cycle="${arg#*=}" ;;
+      --max-consecutive-deep=*) max_consecutive_deep="${arg#*=}" ;;
+      *) echo "error=unknown argument: $arg" >&2; exit 2 ;;
+    esac
+  done
+
+  # Validate required
+  _require_positive_int "--max-cycles" "$max_cycles"
+  _require_positive_int "--max-stuck" "$max_stuck"
+  _require_positive_int "--max-deep-per-cycle" "$max_deep_per_cycle"
+  _require_positive_int "--max-consecutive-deep" "$max_consecutive_deep"
+
+  # Parse duration (optional)
+  local runtime_seconds
+  runtime_seconds=$(_parse_duration "$max_runtime")
+
+  # Clean stale sessions (>24h, owned by current user)
+  find /tmp -maxdepth 1 -name 'lean4-session-*.json' -user "$(id -u)" -mmin +1440 -delete 2>/dev/null || true
+
+  # Create state file via mktemp (no race)
+  _detect_backend
+  local state_file
+  state_file=$(mktemp /tmp/lean4-session-XXXXXX.json)
+  local session_id
+  session_id=$(basename "$state_file" .json)
+
+  local now
+  now=$(date +%s)
+
+  local content
+  content=$(cat <<ENDJSON
+{
+  "session_id": "$session_id",
+  "start_epoch": $now,
+  "max_cycles": $max_cycles,
+  "max_stuck": $max_stuck,
+  "max_runtime_seconds": $runtime_seconds,
+  "max_deep_per_cycle": $max_deep_per_cycle,
+  "max_consecutive_deep": $max_consecutive_deep,
+  "cycles": 0,
+  "consecutive_stuck": 0,
+  "deep_this_cycle": 0,
+  "consecutive_deep_cycles": 0
+}
+ENDJSON
+  )
+
+  _json_create "$state_file" "$content"
+
+  # Persist session ID
+  _persist_env "export LEAN4_SESSION_ID=\"$session_id\""
+
+  echo "$session_id"
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: tick --stuck=yes|no
+# ---------------------------------------------------------------------------
+cmd_tick() {
+  local stuck=""
+  for arg in "$@"; do
+    case "$arg" in
+      --stuck=yes) stuck="yes" ;;
+      --stuck=no) stuck="no" ;;
+      --stuck=*) echo "error=--stuck must be yes or no, got '${arg#*=}'" >&2; exit 2 ;;
+      *) echo "error=unknown argument: $arg" >&2; exit 2 ;;
+    esac
+  done
+  if [[ -z "$stuck" ]]; then
+    echo "error=--stuck=yes|no is required for tick" >&2
+    exit 2
+  fi
+
+  local file
+  file=$(_state_file)
+  _detect_backend
+
+  local now
+  now=$(date +%s)
+
+  # Read current state and compute new state in one shot
+  local output
+  if [[ "$_json_backend" == "jq" ]]; then
+    output=$(jq -r --argjson stuck_flag "$(if [[ "$stuck" == "yes" ]]; then echo 1; else echo 0; fi)" \
+                    --argjson now "$now" '
+      # Update cycles
+      .cycles += 1 |
+
+      # Update stuck
+      (if $stuck_flag == 1 then .consecutive_stuck + 1 else 0 end) as $new_stuck |
+      .consecutive_stuck = $new_stuck |
+
+      # Update deep
+      (if .deep_this_cycle > 0 then .consecutive_deep_cycles + 1 else 0 end) as $new_consec_deep |
+      .consecutive_deep_cycles = $new_consec_deep |
+      .deep_this_cycle = 0 |
+
+      # Compute elapsed
+      ($now - .start_epoch) as $elapsed |
+
+      # Check violations
+      (
+        [
+          (if .cycles >= .max_cycles then "max-cycles" else empty end),
+          (if .consecutive_stuck >= .max_stuck then "max-stuck" else empty end),
+          (if .max_runtime_seconds > 0 and $elapsed >= .max_runtime_seconds then "max-runtime" else empty end)
+        ] | join(",")
+      ) as $violations |
+
+      # Format elapsed display
+      (($elapsed / 60) | floor) as $elapsed_min |
+      (if .max_runtime_seconds > 0 then
+        ((.max_runtime_seconds / 60) | floor | tostring) + "m"
+       else "unlimited" end) as $max_display |
+
+      # Output key=value, then the object for saving
+      {
+        _output: (
+          "result=" + (if ($violations | length) > 0 then "LIMIT_REACHED" else "ok" end) + "\n" +
+          (if ($violations | length) > 0 then "violation=" + $violations + "\n" else "" end) +
+          "cycles=" + (.cycles | tostring) + "/" + (.max_cycles | tostring) + "\n" +
+          "consecutive_stuck=" + (.consecutive_stuck | tostring) + "/" + (.max_stuck | tostring) + "\n" +
+          "elapsed_seconds=" + ($elapsed | tostring) + "\n" +
+          "elapsed_display=" + ($elapsed_min | tostring) + "m/" + $max_display + "\n" +
+          "deep_this_cycle=" + (.deep_this_cycle | tostring) + "/" + (.max_deep_per_cycle | tostring) + "\n" +
+          "consecutive_deep_cycles=" + (.consecutive_deep_cycles | tostring) + "/" + (.max_consecutive_deep | tostring)
+        ),
+        _state: (del(._output))
+      }
+    ' "$file" 2>/dev/null)
+
+    local display state_json
+    display=$(printf '%s' "$output" | jq -r '._output' 2>/dev/null)
+    state_json=$(printf '%s' "$output" | jq 'del(._output) | ._state' 2>/dev/null)
+
+    # Write state atomically
+    local tmp
+    tmp=$(mktemp "${file}.tmp.XXXXXX")
+    printf '%s' "$state_json" > "$tmp"
+    mv "$tmp" "$file"
+
+    # Print output
+    printf '%b\n' "$display"
+
+    # Exit code based on violations
+    if printf '%s' "$output" | jq -e '._output | test("LIMIT_REACHED")' >/dev/null 2>&1; then
+      exit 1
+    fi
+  else
+    # Python3 fallback
+    local stuck_flag
+    if [[ "$stuck" == "yes" ]]; then stuck_flag=1; else stuck_flag=0; fi
+    python3 -c "
+import json, sys
+
+with open('$file') as f:
+    d = json.load(f)
+
+now = $now
+stuck = bool($stuck_flag)
+
+# Update cycles
+d['cycles'] += 1
+
+# Update stuck
+d['consecutive_stuck'] = d['consecutive_stuck'] + 1 if stuck else 0
+
+# Update deep
+if d['deep_this_cycle'] > 0:
+    d['consecutive_deep_cycles'] += 1
+else:
+    d['consecutive_deep_cycles'] = 0
+d['deep_this_cycle'] = 0
+
+# Check violations
+elapsed = now - d['start_epoch']
+violations = []
+if d['cycles'] >= d['max_cycles']:
+    violations.append('max-cycles')
+if d['consecutive_stuck'] >= d['max_stuck']:
+    violations.append('max-stuck')
+if d['max_runtime_seconds'] > 0 and elapsed >= d['max_runtime_seconds']:
+    violations.append('max-runtime')
+
+# Format display
+elapsed_min = elapsed // 60
+if d['max_runtime_seconds'] > 0:
+    max_display = str(d['max_runtime_seconds'] // 60) + 'm'
+else:
+    max_display = 'unlimited'
+
+result = 'LIMIT_REACHED' if violations else 'ok'
+lines = ['result=' + result]
+if violations:
+    lines.append('violation=' + ','.join(violations))
+lines.extend([
+    f\"cycles={d['cycles']}/{d['max_cycles']}\",
+    f\"consecutive_stuck={d['consecutive_stuck']}/{d['max_stuck']}\",
+    f'elapsed_seconds={elapsed}',
+    f'elapsed_display={elapsed_min}m/{max_display}',
+    f\"deep_this_cycle={d['deep_this_cycle']}/{d['max_deep_per_cycle']}\",
+    f\"consecutive_deep_cycles={d['consecutive_deep_cycles']}/{d['max_consecutive_deep']}\",
+])
+
+# Write state atomically
+import tempfile, os
+fd, tmp = tempfile.mkstemp(prefix=os.path.basename('$file') + '.tmp.', dir=os.path.dirname('$file'))
+with os.fdopen(fd, 'w') as f:
+    json.dump(d, f)
+os.rename(tmp, '$file')
+
+print('\n'.join(lines))
+sys.exit(1 if violations else 0)
+" 2>/dev/null
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: can-deep
+# ---------------------------------------------------------------------------
+cmd_can_deep() {
+  local file
+  file=$(_state_file)
+  _detect_backend
+
+  local now
+  now=$(date +%s)
+
+  if [[ "$_json_backend" == "jq" ]]; then
+    jq -r --argjson now "$now" '
+      ($now - .start_epoch) as $elapsed |
+      (
+        if .deep_this_cycle >= .max_deep_per_cycle then "max-deep-per-cycle"
+        elif .consecutive_deep_cycles >= .max_consecutive_deep then "max-consecutive-deep"
+        elif .max_runtime_seconds > 0 and $elapsed >= .max_runtime_seconds then "max-runtime"
+        else "" end
+      ) as $reason |
+      "result=" + (if $reason == "" then "ok" else "denied" end),
+      (if $reason != "" then "reason=" + $reason else empty end),
+      "deep_this_cycle=" + (.deep_this_cycle | tostring) + "/" + (.max_deep_per_cycle | tostring),
+      "consecutive_deep_cycles=" + (.consecutive_deep_cycles | tostring) + "/" + (.max_consecutive_deep | tostring),
+      "elapsed_seconds=" + ($elapsed | tostring)
+    ' "$file" 2>/dev/null
+
+    # Check if denied
+    local reason
+    reason=$(jq -r --argjson now "$now" '
+      ($now - .start_epoch) as $elapsed |
+      if .deep_this_cycle >= .max_deep_per_cycle then "max-deep-per-cycle"
+      elif .consecutive_deep_cycles >= .max_consecutive_deep then "max-consecutive-deep"
+      elif .max_runtime_seconds > 0 and $elapsed >= .max_runtime_seconds then "max-runtime"
+      else "" end
+    ' "$file" 2>/dev/null)
+    if [[ -n "$reason" ]]; then exit 1; fi
+  else
+    python3 -c "
+import json, sys
+
+with open('$file') as f:
+    d = json.load(f)
+
+now = $now
+elapsed = now - d['start_epoch']
+
+reason = ''
+if d['deep_this_cycle'] >= d['max_deep_per_cycle']:
+    reason = 'max-deep-per-cycle'
+elif d['consecutive_deep_cycles'] >= d['max_consecutive_deep']:
+    reason = 'max-consecutive-deep'
+elif d['max_runtime_seconds'] > 0 and elapsed >= d['max_runtime_seconds']:
+    reason = 'max-runtime'
+
+result = 'denied' if reason else 'ok'
+lines = ['result=' + result]
+if reason:
+    lines.append('reason=' + reason)
+lines.extend([
+    f\"deep_this_cycle={d['deep_this_cycle']}/{d['max_deep_per_cycle']}\",
+    f\"consecutive_deep_cycles={d['consecutive_deep_cycles']}/{d['max_consecutive_deep']}\",
+    f'elapsed_seconds={elapsed}',
+])
+print('\n'.join(lines))
+sys.exit(1 if reason else 0)
+" 2>/dev/null
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: deep
+# ---------------------------------------------------------------------------
+cmd_deep() {
+  local file
+  file=$(_state_file)
+  _detect_backend
+
+  if [[ "$_json_backend" == "jq" ]]; then
+    local tmp
+    tmp=$(mktemp "${file}.tmp.XXXXXX")
+    jq '.deep_this_cycle += 1' "$file" > "$tmp" 2>/dev/null
+    mv "$tmp" "$file"
+  else
+    python3 -c "
+import json, tempfile, os
+with open('$file') as f:
+    d = json.load(f)
+d['deep_this_cycle'] += 1
+fd, tmp = tempfile.mkstemp(prefix=os.path.basename('$file') + '.tmp.', dir=os.path.dirname('$file'))
+with os.fdopen(fd, 'w') as f:
+    json.dump(d, f)
+os.rename(tmp, '$file')
+" 2>/dev/null
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: status
+# ---------------------------------------------------------------------------
+cmd_status() {
+  local file
+  file=$(_state_file)
+  _detect_backend
+
+  local now
+  now=$(date +%s)
+
+  if [[ "$_json_backend" == "jq" ]]; then
+    jq -r --argjson now "$now" '
+      ($now - .start_epoch) as $elapsed |
+      (($elapsed / 60) | floor) as $elapsed_min |
+      (if .max_runtime_seconds > 0 then
+        ((.max_runtime_seconds / 60) | floor | tostring) + "m"
+       else "unlimited" end) as $max_display |
+      "session_id=" + .session_id,
+      "cycles=" + (.cycles | tostring) + "/" + (.max_cycles | tostring),
+      "consecutive_stuck=" + (.consecutive_stuck | tostring) + "/" + (.max_stuck | tostring),
+      "elapsed_seconds=" + ($elapsed | tostring),
+      "elapsed_display=" + ($elapsed_min | tostring) + "m/" + $max_display,
+      "deep_this_cycle=" + (.deep_this_cycle | tostring) + "/" + (.max_deep_per_cycle | tostring),
+      "consecutive_deep_cycles=" + (.consecutive_deep_cycles | tostring) + "/" + (.max_consecutive_deep | tostring)
+    ' "$file" 2>/dev/null
+  else
+    python3 -c "
+import json
+with open('$file') as f:
+    d = json.load(f)
+now = $now
+elapsed = now - d['start_epoch']
+elapsed_min = elapsed // 60
+if d['max_runtime_seconds'] > 0:
+    max_display = str(d['max_runtime_seconds'] // 60) + 'm'
+else:
+    max_display = 'unlimited'
+lines = [
+    f\"session_id={d['session_id']}\",
+    f\"cycles={d['cycles']}/{d['max_cycles']}\",
+    f\"consecutive_stuck={d['consecutive_stuck']}/{d['max_stuck']}\",
+    f'elapsed_seconds={elapsed}',
+    f'elapsed_display={elapsed_min}m/{max_display}',
+    f\"deep_this_cycle={d['deep_this_cycle']}/{d['max_deep_per_cycle']}\",
+    f\"consecutive_deep_cycles={d['consecutive_deep_cycles']}/{d['max_consecutive_deep']}\",
+]
+print('\n'.join(lines))
+" 2>/dev/null
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: stop
+# ---------------------------------------------------------------------------
+cmd_stop() {
+  local sid="${LEAN4_SESSION_ID:-}"
+  if [[ -z "$sid" ]]; then
+    return 0
+  fi
+  local f="/tmp/${sid}.json"
+  rm -f "$f"
+  # Also clean up any orphaned tmp files from atomic writes
+  rm -f "${f}".tmp.* 2>/dev/null || true
+  _unpersist_env "LEAN4_SESSION_ID"
+}
+
+# ---------------------------------------------------------------------------
+# Main dispatch
+# ---------------------------------------------------------------------------
+subcmd="${1:-}"
+shift || true
+
+case "$subcmd" in
+  init)     cmd_init "$@" ;;
+  tick)     cmd_tick "$@" ;;
+  can-deep) cmd_can_deep "$@" ;;
+  deep)     cmd_deep "$@" ;;
+  status)   cmd_status "$@" ;;
+  stop)     cmd_stop "$@" ;;
+  "")       echo "error=no subcommand specified (init|tick|can-deep|deep|status|stop)" >&2; exit 2 ;;
+  *)        echo "error=unknown subcommand: $subcmd" >&2; exit 2 ;;
+esac

--- a/plugins/lean4/skills/lean4/SKILL.md
+++ b/plugins/lean4/skills/lean4/SKILL.md
@@ -27,13 +27,18 @@ Use this skill whenever you're editing Lean 4 proofs, debugging Lean builds, for
 | `/lean4:formalize` | Interactive formalization — drafting plus guided proving |
 | `/lean4:autoformalize` | Autonomous end-to-end formalization from informal sources |
 | `/lean4:prove` | Guided cycle-by-cycle theorem proving with explicit checkpoints |
-| `/lean4:autoprove` | Autonomous multi-cycle theorem proving with hard stop rules |
+| `/lean4:autoprove` | Autonomous multi-cycle theorem proving with explicit stop budgets |
 | `/lean4:checkpoint` | Save progress with a safe commit checkpoint |
 | `/lean4:review` | Read-only code review of Lean proofs |
 | `/lean4:refactor` | Leverage mathlib, extract helpers, simplify proof strategies |
 | `/lean4:golf` | Improve Lean proofs for directness, clarity, performance, and brevity |
 | `/lean4:learn` | Interactive teaching and mathlib exploration |
 | `/lean4:doctor` | Diagnostics, cleanup, and migration help |
+
+Slash-command inputs are raw text interpreted by the model, not host-parsed
+CLI flags. Commands with flags must parse and announce resolved inputs before
+acting; `--max-total-runtime` is a best-effort wall-clock budget, not a
+host-enforced timeout. See [command-invocation.md](references/command-invocation.md).
 
 ### Which Command?
 
@@ -94,7 +99,7 @@ Use this skill whenever you're editing Lean 4 proofs, debugging Lean builds, for
 Use `/lean4:learn` at any point to explore repo structure or navigate mathlib. Three entry points: `/lean4:draft` for skeletons, `/lean4:formalize` for interactive synthesis (draft + guided proving), `/lean4:autoformalize` for unattended source-to-proof.
 
 **Notes:**
-- `/lean4:prove` asks before each cycle; `/lean4:autoprove` loops autonomously with hard stop conditions
+- `/lean4:prove` asks before each cycle; `/lean4:autoprove` loops autonomously with explicit stop budgets
 - Both trigger `/lean4:review` at configured intervals (`--review-every`)
 - When reviews run (via `--review-every`), they act as gates: review → replan → continue. In prove, replan requires user approval; in autoprove, replan auto-continues
 - Review supports `--mode=batch` (default) or `--mode=stuck` (triage); review is always read-only
@@ -199,7 +204,7 @@ If `$LEAN4_SCRIPTS` is unset or missing, run `/lean4:doctor` and stay LSP-only u
 
 `/lean4:prove` and `/lean4:autoprove` handle most tasks:
 - **prove** — guided, asks before each cycle. Ideal for interactive sessions.
-- **autoprove** — autonomous, loops with hard stop rules. Ideal for unattended runs.
+- **autoprove** — autonomous, loops with explicit stop budgets. Ideal for unattended runs.
 
 Both share the same cycle engine (plan → work → checkpoint → review → replan → continue/stop) and follow the [LSP-first protocol](references/cycle-engine.md#lsp-first-protocol): LSP tools are normative for discovery and search; script fallback only when LSP is unavailable or exhausted. Compiler-guided repair is escalation-only — not the first response to build errors. For complex proofs, they may delegate to internal workflows for deep sorry-filling (with snapshot, rollback, and scope budgets), proof repair, or axiom elimination. You don't invoke these directly.
 

--- a/plugins/lean4/skills/lean4/references/command-invocation.md
+++ b/plugins/lean4/skills/lean4/references/command-invocation.md
@@ -1,0 +1,52 @@
+# Command Invocation Contract
+
+Slash-command inputs in this plugin are **model-parsed, not host-parsed**. The
+host passes the raw text after `/lean4:<command>` to the agent; it does **not**
+apply a schema, validate enums, coerce values, or enforce timeouts on the
+plugin's behalf.
+
+## Required Startup Behavior
+
+Any command that advertises flags must do all of the following before
+substantive work:
+
+1. Parse the raw invocation text against the command's documented input table.
+2. Emit a **Resolved Inputs** summary showing:
+   - explicit values supplied by the user
+   - defaults that were assumed
+   - coercions or ignored flags
+   - startup validation errors
+3. Refuse to start on startup validation errors. Do not partially begin a
+   session and then discover a missing required companion flag later.
+4. Maintain promised session counters explicitly (`cycles_run`,
+   `stuck_cycles`, `deep_invocations`, and similar state) rather than relying on
+   the model to remember them informally.
+
+## Enforcement Classes
+
+Document each flag according to the strongest guarantee the current architecture
+can actually provide:
+
+- **Startup-validated**: syntax, enums, required companion flags, path safety,
+  overwrite checks, and other checks that can be decided before work starts.
+- **Session-enforced**: counters and mode switches that the command re-checks at
+  safe boundaries during the session.
+- **Best-effort**: budgets that depend on wall-clock time or other values the
+  host does not enforce. These must be checked explicitly by the command, but
+  they are not kill switches.
+- **Advisory**: preferences that guide planning or presentation but are not
+  safety or stop guarantees.
+
+Never describe a **best-effort** control as a **hard stop**.
+
+## Wall-Clock Budgets
+
+`--max-total-runtime` is the clearest example of a best-effort control:
+
+- record a start timestamp before the main loop begins
+- re-check elapsed wall-clock time with `date +%s` (or equivalent) at cycle
+  boundaries and before expensive optional branches such as deep mode
+- stop before starting the next unit of work when the budget has been exhausted
+
+Do **not** claim that `--max-total-runtime` can preempt a long-running tool call
+mid-step. The host does not provide that guarantee here.

--- a/plugins/lean4/skills/lean4/references/cycle-engine.md
+++ b/plugins/lean4/skills/lean4/references/cycle-engine.md
@@ -253,7 +253,7 @@ bash "$LEAN4_SCRIPTS/cycle_tracker.sh" init \
   --max-consecutive-deep=<resolved>
 ```
 
-A failed init (exit 2) is a startup validation error — do not proceed. On success, `LEAN4_SESSION_ID` is set for subsequent calls.
+A failed init (exit 2) is a startup validation error — do not proceed. On success, the session ID is printed to stdout. If a writable env file is available (`LEAN4_ENV_FILE` or `CLAUDE_ENV_FILE`), init also persists `LEAN4_SESSION_ID` there for subsequent calls; otherwise, pass it as an env prefix (`LEAN4_SESSION_ID=<id> bash ...`).
 
 ### Cycle Boundary Protocol (Phase 6)
 

--- a/plugins/lean4/skills/lean4/references/cycle-engine.md
+++ b/plugins/lean4/skills/lean4/references/cycle-engine.md
@@ -119,9 +119,9 @@ When stuck and user declines the plan (prove) or review flags falsification (aut
 Bounded subroutine for stubborn sorries. Allows multi-file refactoring and helper extraction.
 
 **Budget enforcement:**
-- `--deep-sorry-budget` — max sorries per deep invocation
-- `--deep-time-budget` — max time per deep invocation
-- `--max-deep-per-cycle` — max deep invocations per cycle (default: 1)
+- `--deep-sorry-budget` — max sorries per deep invocation (structural — subagent receives this as scope)
+- `--deep-time-budget` — advisory: scopes deep-mode subagent work, not wall-clock enforced
+- `--max-deep-per-cycle` — max deep invocations per cycle (session-enforced via `cycle_tracker.sh` in autoprove/autoformalize)
 
 If deep budget is exhausted with no progress → stuck.
 
@@ -233,6 +233,67 @@ If no files changed during this cycle, emit:
 > No changes this cycle — skipping checkpoint
 
 Do NOT create an empty commit. Checkpoint requires a non-empty diff.
+
+## Session Tracking
+
+> This section describes the concrete Claude Code implementation of the enforcement classes defined in [command-invocation.md](command-invocation.md). The invocation contract is host-agnostic; `cycle_tracker.sh` is one implementation that fulfills it. Other hosts may provide equivalent enforcement through different mechanisms, or may rely on model-mediated tracking alone.
+
+Autonomous commands (`autoprove`, `autoformalize`) use `$LEAN4_SCRIPTS/cycle_tracker.sh` for deterministic session counter tracking. Guided commands (`prove`, `formalize`) do not — user presence provides the control loop.
+
+### Initialization
+
+After emitting the Resolved Inputs block, call:
+
+```bash
+bash "$LEAN4_SCRIPTS/cycle_tracker.sh" init \
+  --max-cycles=<resolved> \
+  --max-stuck=<resolved> \
+  --max-runtime=<resolved> \
+  --max-deep-per-cycle=<resolved> \
+  --max-consecutive-deep=<resolved>
+```
+
+A failed init (exit 2) is a startup validation error — do not proceed. On success, `LEAN4_SESSION_ID` is set for subsequent calls.
+
+### Cycle Boundary Protocol (Phase 6)
+
+At the end of every cycle, call:
+
+```bash
+bash "$LEAN4_SCRIPTS/cycle_tracker.sh" tick --stuck=yes|no
+```
+
+This is one atomic operation that:
+1. Increments the cycle counter
+2. Updates the consecutive-stuck counter (increment if `--stuck=yes`, reset to 0 if `--stuck=no`)
+3. Updates the consecutive-deep-cycles counter (increment if deep was used this cycle, reset to 0 otherwise)
+4. Resets the per-cycle deep counter
+5. Checks all limits (max-cycles, max-stuck, max-runtime)
+
+If exit code is 1 (`LIMIT_REACHED`), stop immediately and emit the structured summary.
+
+### Deep Mode Preflight
+
+Before dispatching a deep-mode subagent:
+
+1. Call `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" can-deep`
+2. If exit 1 (`denied`), handle based on the `reason` field:
+   - `reason=max-deep-per-cycle` or `reason=max-consecutive-deep`: deep denied by policy — skip deep for this sorry without marking it stuck
+   - `reason=max-runtime`: session budget exhausted — let the next `tick` trigger session stop
+3. If exit 0: call `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" deep` to record the invocation, then dispatch
+
+### On Stop
+
+Call `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" status` for the structured summary counters, then `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" stop` for cleanup.
+
+### Enforcement Levels
+
+| Level | Mechanism | Reliability | Parameters |
+|-------|-----------|-------------|------------|
+| **Startup-validated** | Fail before work starts | Guaranteed by invocation contract | enum/path/companion/numeric checks |
+| **Session-enforced** | `cycle_tracker.sh` at cycle boundaries | Protocol-dependent — reliable when command follows documented cycle boundary protocol | `--max-cycles`, `--max-stuck-cycles`, `--max-deep-per-cycle`, `--max-consecutive-deep-cycles` |
+| **Best-effort** | `cycle_tracker.sh tick` + `can-deep` | Checked at cycle boundaries and deep preflight — not a kill switch, cannot preempt mid-step | `--max-total-runtime` |
+| **Advisory** | Instruction to LLM/subagent | Model-mediated, not validated or tracked | `--deep-time-budget`, `--batch-size` |
 
 ## Falsification Artifacts
 

--- a/plugins/lean4/skills/lean4/references/cycle-engine.md
+++ b/plugins/lean4/skills/lean4/references/cycle-engine.md
@@ -282,6 +282,18 @@ Before dispatching a deep-mode subagent:
    - `reason=max-runtime`: session budget exhausted — let the next `tick` trigger session stop
 3. If exit 0: call `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" deep` to record the invocation, then dispatch
 
+### Claim Boundary Protocol (autoformalize)
+
+Autoformalize processes claims sequentially. `--max-cycles` and `--max-stuck-cycles` are per-claim; `--max-total-runtime` is per-session.
+
+**Lifecycle:** `init` → (`start-claim` → inner cycle ticks → `reset-claim`) × N-1 → `start-claim` → inner cycle ticks → `status`/`stop`
+
+- Call `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" start-claim` when dequeuing each claim
+- Call `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" reset-claim` when a claim completes or stops (before the next `start-claim`)
+- The final claim does not need `reset-claim` — session totals (`cycles_total`, `stuck_cycles_total`, `deep_total`) are accumulated live by `tick`/`deep`
+
+`status` always reflects the full session: `claims_attempted` includes the in-progress claim. Summary metrics (`Cycles run`, `Stuck cycles`, `Deep invocations`) come from session-total accumulators.
+
 ### On Stop
 
 Call `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" status` for the structured summary counters, then `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" stop` for cleanup.
@@ -290,7 +302,7 @@ Call `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" status` for the structured summary 
 
 | Level | Mechanism | Reliability | Parameters |
 |-------|-----------|-------------|------------|
-| **Startup-validated** | Fail before work starts | Guaranteed by invocation contract | enum/path/companion/numeric checks |
+| **Startup-validated** | Fail before work starts | Guaranteed when command follows invocation contract | enum/path/companion/numeric checks |
 | **Session-enforced** | `cycle_tracker.sh` at cycle boundaries | Protocol-dependent — reliable when command follows documented cycle boundary protocol | `--max-cycles`, `--max-stuck-cycles`, `--max-deep-per-cycle`, `--max-consecutive-deep-cycles` |
 | **Best-effort** | `cycle_tracker.sh tick` + `can-deep` | Checked at cycle boundaries and deep preflight — not a kill switch, cannot preempt mid-step | `--max-total-runtime` |
 | **Advisory** | Instruction to LLM/subagent | Model-mediated, not validated or tracked | `--deep-time-budget`, `--batch-size` |

--- a/plugins/lean4/tests/test_cycle_tracker.sh
+++ b/plugins/lean4/tests/test_cycle_tracker.sh
@@ -297,22 +297,33 @@ cleanup_session
 echo ""
 echo "-- Robustness --"
 
-# Corrupted state file
+# Corrupted state file — tick
 init_session --max-cycles=5 --max-stuck=2
 FILE=$(state_file)
 echo "NOT JSON" > "$FILE"
 run tick --stuck=no
-assert_exit "corrupted state file → exit 2 or nonzero" "$LAST_EXIT"
-# Accept any nonzero exit (jq gives 1, python3 gives 2)
-if [[ "$LAST_EXIT" -ne 0 ]]; then
-  echo "  PASS: corrupted state file causes nonzero exit ($LAST_EXIT)"
-  (( ++PASS ))
-else
-  echo "  FAIL: corrupted state file should cause nonzero exit"
-  (( ++FAIL ))
-fi
+assert_exit "corrupted state file tick → exit 2" 2
+assert_contains "corrupted tick error message" "corrupted state file"
+
+# Corrupted state file — can-deep
+echo "NOT JSON" > "$FILE"
+run can-deep
+assert_exit "corrupted state file can-deep → exit 2" 2
+assert_contains "corrupted can-deep error message" "corrupted state file"
+
+# Corrupted state file — deep
+echo "NOT JSON" > "$FILE"
+run deep
+assert_exit "corrupted state file deep → exit 2" 2
+assert_contains "corrupted deep error message" "corrupted state file"
+
+# Corrupted state file — status
+echo "NOT JSON" > "$FILE"
+run status
+assert_exit "corrupted state file status → exit 2" 2
+assert_contains "corrupted status error message" "corrupted state file"
 rm -f "$FILE"
-unset LEAN4_SESSION_ID
+LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
 
 # Missing state file
 export LEAN4_SESSION_ID="lean4-session-NONEXISTENT"
@@ -341,30 +352,68 @@ assert_contains "error mentions unknown" "unknown"
 
 # =========================================================================
 echo ""
-echo "-- CLAUDE_ENV_FILE fallback --"
+echo "-- Env-file fallback (LEAN4_ENV_FILE → CLAUDE_ENV_FILE → none) --"
 
-# init with CLAUDE_ENV_FILE unset
+# init with neither env file set — stdout fallback
+LEAN4_ENV_FILE=""; export LEAN4_ENV_FILE
 CLAUDE_ENV_FILE=""; export CLAUDE_ENV_FILE
 LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
 run init --max-cycles=5 --max-stuck=2
-assert_exit "init without CLAUDE_ENV_FILE succeeds" 0
-# Should still print session ID
+assert_exit "init without any env file succeeds" 0
 assert_contains "init prints session ID" "lean4-session-"
 SID="$LAST_OUT"
 export LEAN4_SESSION_ID="$SID"
-# Subsequent calls work with env prefix
 run tick --stuck=no
 assert_exit "tick works with manual session ID" 0
 cleanup_session
 
-# init with CLAUDE_ENV_FILE pointing to unwritable path
+# LEAN4_ENV_FILE takes priority over CLAUDE_ENV_FILE
+LEAN4_ENVF="/tmp/lean4-test-envfile-$$"
+CLAUDE_ENVF="/tmp/lean4-test-claude-envfile-$$"
+: > "$LEAN4_ENVF"; : > "$CLAUDE_ENVF"
+LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+export LEAN4_ENV_FILE="$LEAN4_ENVF"
+export CLAUDE_ENV_FILE="$CLAUDE_ENVF"
+run init --max-cycles=5 --max-stuck=2
+assert_exit "init with LEAN4_ENV_FILE set succeeds" 0
+if grep -q 'LEAN4_SESSION_ID' "$LEAN4_ENVF" 2>/dev/null; then
+  echo "  PASS: LEAN4_ENV_FILE used (has session ID)"
+  (( ++PASS ))
+else
+  echo "  FAIL: LEAN4_ENV_FILE not used (missing session ID)"
+  (( ++FAIL ))
+fi
+if grep -q 'LEAN4_SESSION_ID' "$CLAUDE_ENVF" 2>/dev/null; then
+  echo "  FAIL: CLAUDE_ENV_FILE was written when LEAN4_ENV_FILE was set"
+  (( ++FAIL ))
+else
+  echo "  PASS: CLAUDE_ENV_FILE untouched when LEAN4_ENV_FILE set"
+  (( ++PASS ))
+fi
+SID="$LAST_OUT"
+export LEAN4_SESSION_ID="$SID"
+run stop
+rm -f "$LEAN4_ENVF" "$CLAUDE_ENVF"
+LEAN4_ENV_FILE=""; export LEAN4_ENV_FILE
+
+# Unwritable env file — must be left untouched
 FAKE_ENV="/tmp/lean4-test-unwritable-$$"
-touch "$FAKE_ENV" && chmod 000 "$FAKE_ENV" 2>/dev/null || true
+echo "# original content" > "$FAKE_ENV"
+chmod 000 "$FAKE_ENV" 2>/dev/null || true
+FAKE_ENV_BEFORE=$(stat -c '%a %s' "$FAKE_ENV" 2>/dev/null || stat -f '%p %z' "$FAKE_ENV" 2>/dev/null)
 LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
 export CLAUDE_ENV_FILE="$FAKE_ENV"
 run init --max-cycles=5 --max-stuck=2
-assert_exit "init with unwritable CLAUDE_ENV_FILE succeeds" 0
+assert_exit "init with unwritable env file succeeds" 0
 assert_contains "init prints session ID despite unwritable env" "lean4-session-"
+FAKE_ENV_AFTER=$(stat -c '%a %s' "$FAKE_ENV" 2>/dev/null || stat -f '%p %z' "$FAKE_ENV" 2>/dev/null)
+if [[ "$FAKE_ENV_BEFORE" == "$FAKE_ENV_AFTER" ]]; then
+  echo "  PASS: unwritable env file left untouched"
+  (( ++PASS ))
+else
+  echo "  FAIL: unwritable env file was modified (before='$FAKE_ENV_BEFORE' after='$FAKE_ENV_AFTER')"
+  (( ++FAIL ))
+fi
 SID="$LAST_OUT"
 export LEAN4_SESSION_ID="$SID"
 run stop
@@ -372,11 +421,12 @@ chmod 644 "$FAKE_ENV" 2>/dev/null || true
 rm -f "$FAKE_ENV"
 LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
 
-# stop with CLAUDE_ENV_FILE unset
+# stop with no env file set
 init_session --max-cycles=5 --max-stuck=2
+LEAN4_ENV_FILE=""; export LEAN4_ENV_FILE
 CLAUDE_ENV_FILE=""; export CLAUDE_ENV_FILE
 run stop
-assert_exit "stop without CLAUDE_ENV_FILE succeeds" 0
+assert_exit "stop without env file succeeds" 0
 
 # =========================================================================
 echo ""
@@ -466,6 +516,13 @@ init_session --max-cycles=5 --max-stuck=2 --max-runtime=5
 FILE=$(state_file)
 RT=$(read_field "$FILE" "max_runtime_seconds")
 if [[ "$RT" == "300" ]]; then echo "  PASS: 5 → 300s"; (( ++PASS )); else echo "  FAIL: 5 → ${RT}s, expected 300"; (( ++FAIL )); fi
+cleanup_session
+
+# Sub-minute display: 30s budget should show Xs/30s, not 0m/0m
+init_session --max-cycles=5 --max-stuck=2 --max-runtime=30s
+run tick --stuck=no
+assert_contains "sub-minute display uses seconds" "/30s"
+assert_not_contains "sub-minute display does not use 0m" "0m/0m"
 cleanup_session
 
 # =========================================================================

--- a/plugins/lean4/tests/test_cycle_tracker.sh
+++ b/plugins/lean4/tests/test_cycle_tracker.sh
@@ -599,6 +599,21 @@ if [[ -L "$BROKEN_LINK" ]]; then
   SID="$LAST_OUT"
   export LEAN4_SESSION_ID="$SID"
   run stop
+  # Post-stop: target still must not exist, link still broken
+  if [[ -e "$BROKEN_TARGET" ]]; then
+    echo "  FAIL: stop created the broken symlink's target file"
+    (( ++FAIL ))
+  else
+    echo "  PASS: broken symlink target not created by stop"
+    (( ++PASS ))
+  fi
+  if [[ -L "$BROKEN_LINK" && ! -e "$BROKEN_LINK" ]]; then
+    echo "  PASS: broken symlink remains broken after stop"
+    (( ++PASS ))
+  else
+    echo "  FAIL: broken symlink was modified by stop"
+    (( ++FAIL ))
+  fi
   LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
   CLAUDE_ENV_FILE=""; export CLAUDE_ENV_FILE
   rm -f "$BROKEN_LINK" "$BROKEN_TARGET"

--- a/plugins/lean4/tests/test_cycle_tracker.sh
+++ b/plugins/lean4/tests/test_cycle_tracker.sh
@@ -753,6 +753,98 @@ cleanup_session
 
 # =========================================================================
 echo ""
+echo "-- Claim lifecycle (start-claim / reset-claim / session totals) --"
+
+# Basic lifecycle: init → start-claim → ticks → reset-claim → start-claim → ticks → status
+init_session --max-cycles=5 --max-stuck=3
+run start-claim
+assert_exit "start-claim succeeds" 0
+run status
+assert_contains "claim_active=true after start-claim" "claim_active=true"
+assert_contains "claims_attempted=1 (in-progress)" "claims_attempted=1"
+
+# Tick some cycles with stuck
+run tick --stuck=yes
+run tick --stuck=yes
+run tick --stuck=no
+run status
+assert_contains "cycles_total=3 after 3 ticks" "cycles_total=3"
+assert_contains "stuck_cycles_total=2 after 2 stuck ticks" "stuck_cycles_total=2"
+
+# Deep
+run deep
+run status
+assert_contains "deep_total=1 after 1 deep" "deep_total=1"
+
+# Reset claim
+run reset-claim
+assert_exit "reset-claim succeeds" 0
+run status
+assert_contains "claim_active=false after reset" "claim_active=false"
+assert_contains "claims_attempted=1 (completed)" "claims_attempted=1"
+assert_contains "per-claim cycles=0 after reset" "cycles=0/"
+assert_contains "per-claim consecutive_stuck=0 after reset" "consecutive_stuck=0/"
+assert_contains "cycles_total=3 preserved after reset" "cycles_total=3"
+assert_contains "stuck_cycles_total=2 preserved after reset" "stuck_cycles_total=2"
+assert_contains "deep_total=1 preserved after reset" "deep_total=1"
+
+# Second claim
+run start-claim
+run tick --stuck=no
+run tick --stuck=yes
+run deep
+run status
+assert_contains "cycles_total=5 after 2 more ticks" "cycles_total=5"
+assert_contains "stuck_cycles_total=3 after 1 more stuck" "stuck_cycles_total=3"
+assert_contains "deep_total=2 after 1 more deep" "deep_total=2"
+assert_contains "claims_attempted=2 (1 completed + 1 in-progress)" "claims_attempted=2"
+assert_contains "claim_active=true on second claim" "claim_active=true"
+assert_contains "per-claim cycles=2 on second claim" "cycles=2/"
+cleanup_session
+
+# Status right after init (no claim started)
+init_session --max-cycles=5 --max-stuck=3
+run status
+assert_contains "claims_attempted=0 after init" "claims_attempted=0"
+assert_contains "claim_active=false after init" "claim_active=false"
+cleanup_session
+
+# start-claim with zero cycles then reset-claim
+init_session --max-cycles=5 --max-stuck=3
+run start-claim
+run reset-claim
+assert_exit "reset-claim with zero cycles" 0
+run status
+assert_contains "claims_attempted=1 after zero-cycle claim" "claims_attempted=1"
+assert_contains "cycles_total=0 after zero-cycle claim" "cycles_total=0"
+cleanup_session
+
+# Invalid transition: double start-claim
+init_session --max-cycles=5 --max-stuck=3
+run start-claim
+run start-claim
+assert_exit "double start-claim → exit 2" 2
+assert_contains "error mentions claim_active" "claim_active"
+cleanup_session
+
+# Invalid transition: reset-claim without start-claim
+init_session --max-cycles=5 --max-stuck=3
+run reset-claim
+assert_exit "reset-claim without start-claim → exit 2" 2
+assert_contains "error mentions claim_active" "claim_active"
+cleanup_session
+
+# Invalid transition: double reset-claim
+init_session --max-cycles=5 --max-stuck=3
+run start-claim
+run reset-claim
+run reset-claim
+assert_exit "double reset-claim → exit 2" 2
+assert_contains "error mentions claim_active" "claim_active"
+cleanup_session
+
+# =========================================================================
+echo ""
 echo "-- Stale cleanup --"
 
 # Create a fake stale session file

--- a/plugins/lean4/tests/test_cycle_tracker.sh
+++ b/plugins/lean4/tests/test_cycle_tracker.sh
@@ -1,0 +1,474 @@
+#!/bin/bash
+set -euo pipefail
+
+# Comprehensive tests for cycle_tracker.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRACKER="$SCRIPT_DIR/../lib/scripts/cycle_tracker.sh"
+
+PASS=0
+FAIL=0
+
+# Helper: run tracker, capture exit code. Sets LAST_OUT and LAST_EXIT.
+LAST_OUT=""
+LAST_EXIT=0
+run() {
+  LAST_EXIT=0
+  LAST_OUT=$(bash "$TRACKER" "$@" 2>&1) || LAST_EXIT=$?
+}
+
+# Assert exit code. $1=description $2=expected exit code
+assert_exit() {
+  local desc="$1" expected="$2"
+  if [[ "$LAST_EXIT" -eq "$expected" ]]; then
+    echo "  PASS: $desc"
+    (( ++PASS ))
+  else
+    echo "  FAIL: $desc (expected exit $expected, got $LAST_EXIT)"
+    echo "        output: $LAST_OUT"
+    (( ++FAIL ))
+  fi
+}
+
+# Assert output contains string. $1=description $2=expected substring
+assert_contains() {
+  local desc="$1" expected="$2"
+  if [[ "$LAST_OUT" == *"$expected"* ]]; then
+    echo "  PASS: $desc"
+    (( ++PASS ))
+  else
+    echo "  FAIL: $desc (output missing '$expected')"
+    echo "        output: $LAST_OUT"
+    (( ++FAIL ))
+  fi
+}
+
+# Assert output does NOT contain string. $1=description $2=unexpected substring
+assert_not_contains() {
+  local desc="$1" unexpected="$2"
+  if [[ "$LAST_OUT" != *"$unexpected"* ]]; then
+    echo "  PASS: $desc"
+    (( ++PASS ))
+  else
+    echo "  FAIL: $desc (output unexpectedly contains '$unexpected')"
+    echo "        output: $LAST_OUT"
+    (( ++FAIL ))
+  fi
+}
+
+# Helper: init a session and export the ID. Args passed to init.
+# Sets LEAN4_SESSION_ID in the caller's environment.
+init_session() {
+  LEAN4_SESSION_ID=$(bash "$TRACKER" init "$@" 2>&1)
+  export LEAN4_SESSION_ID
+}
+
+# Helper: clean up current session
+cleanup_session() {
+  if [[ -n "${LEAN4_SESSION_ID:-}" ]]; then
+    bash "$TRACKER" stop 2>/dev/null || true
+  fi
+  LEAN4_SESSION_ID=""
+  export LEAN4_SESSION_ID
+}
+
+# Helper: get state file path
+state_file() {
+  echo "/tmp/${LEAN4_SESSION_ID:-}.json"
+}
+
+# Helper: read a field from state file using jq or python3
+read_field() {
+  local file="$1" field="$2"
+  if command -v jq >/dev/null 2>&1; then
+    jq -r ".$field" "$file" 2>/dev/null
+  else
+    python3 -c "import json; print(json.load(open('$file'))['$field'])" 2>/dev/null
+  fi
+}
+
+# Helper: write a field to state file
+write_field() {
+  local file="$1" field="$2" value="$3"
+  if command -v jq >/dev/null 2>&1; then
+    local tmp
+    tmp=$(mktemp "${file}.tmp.XXXXXX")
+    jq ".$field = $value" "$file" > "$tmp" 2>/dev/null
+    mv "$tmp" "$file"
+  else
+    python3 -c "
+import json, tempfile, os
+with open('$file') as f:
+    d = json.load(f)
+d['$field'] = $value
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname('$file'))
+with os.fdopen(fd, 'w') as f:
+    json.dump(d, f)
+os.rename(tmp, '$file')
+" 2>/dev/null
+  fi
+}
+
+echo "=== cycle_tracker.sh tests ==="
+
+# =========================================================================
+echo ""
+echo "-- Happy path --"
+
+init_session --max-cycles=5 --max-stuck=3 --max-runtime=60m
+assert_exit_manual() { :; }  # init succeeded if we got here
+
+# Verify state file exists with correct fields
+FILE=$(state_file)
+run status
+assert_exit "status after init" 0
+assert_contains "status shows session_id" "session_id=$LEAN4_SESSION_ID"
+assert_contains "status shows cycles=0/5" "cycles=0/5"
+assert_contains "status shows consecutive_stuck=0/3" "consecutive_stuck=0/3"
+assert_contains "status shows elapsed_display" "elapsed_display="
+assert_contains "status shows deep_this_cycle=0/1" "deep_this_cycle=0/1"
+assert_contains "status shows consecutive_deep_cycles=0/2" "consecutive_deep_cycles=0/2"
+
+# Verify JSON fields
+CYCLES=$(read_field "$FILE" "cycles")
+if [[ "$CYCLES" == "0" ]]; then
+  echo "  PASS: init state has cycles=0"
+  (( ++PASS ))
+else
+  echo "  FAIL: init state has cycles=$CYCLES, expected 0"
+  (( ++FAIL ))
+fi
+
+# tick --stuck=no
+run tick --stuck=no
+assert_exit "tick --stuck=no exits 0" 0
+assert_contains "tick shows result=ok" "result=ok"
+assert_contains "tick shows cycles=1/5" "cycles=1/5"
+assert_contains "tick shows consecutive_stuck=0/3" "consecutive_stuck=0/3"
+
+# tick --stuck=yes
+run tick --stuck=yes
+assert_exit "tick --stuck=yes exits 0 (under limit)" 0
+assert_contains "tick shows consecutive_stuck=1/3" "consecutive_stuck=1/3"
+
+# tick --stuck=no resets stuck counter
+run tick --stuck=no
+assert_exit "tick --stuck=no after stuck" 0
+assert_contains "tick resets consecutive_stuck to 0" "consecutive_stuck=0/3"
+
+# can-deep
+run can-deep
+assert_exit "can-deep allowed" 0
+assert_contains "can-deep result=ok" "result=ok"
+
+# deep
+run deep
+assert_exit "deep records invocation" 0
+DEEP_COUNT=$(read_field "$FILE" "deep_this_cycle")
+if [[ "$DEEP_COUNT" == "1" ]]; then
+  echo "  PASS: deep_this_cycle=1 after deep"
+  (( ++PASS ))
+else
+  echo "  FAIL: deep_this_cycle=$DEEP_COUNT, expected 1"
+  (( ++FAIL ))
+fi
+
+# tick after deep: updates consecutive_deep_cycles
+run tick --stuck=no
+assert_exit "tick after deep" 0
+assert_contains "consecutive_deep_cycles=1/2" "consecutive_deep_cycles=1/2"
+assert_contains "deep_this_cycle resets to 0" "deep_this_cycle=0/1"
+
+# stop
+run stop
+assert_exit "stop exits 0" 0
+if [[ ! -f "$FILE" ]]; then
+  echo "  PASS: state file removed after stop"
+  (( ++PASS ))
+else
+  echo "  FAIL: state file still exists after stop"
+  (( ++FAIL ))
+fi
+
+cleanup_session
+
+# =========================================================================
+echo ""
+echo "-- Limit reached --"
+
+# max-cycles
+init_session --max-cycles=1 --max-stuck=3
+run tick --stuck=no
+assert_exit "tick exits 1 at max-cycles" 1
+assert_contains "reports LIMIT_REACHED" "result=LIMIT_REACHED"
+assert_contains "violation=max-cycles" "violation=max-cycles"
+assert_contains "cycles=1/1" "cycles=1/1"
+cleanup_session
+
+# max-stuck
+init_session --max-cycles=10 --max-stuck=1
+run tick --stuck=yes
+assert_exit "tick exits 1 at max-stuck" 1
+assert_contains "violation=max-stuck" "violation=max-stuck"
+assert_contains "consecutive_stuck=1/1" "consecutive_stuck=1/1"
+cleanup_session
+
+# max-runtime (synthetic: set start_epoch in the past)
+init_session --max-cycles=10 --max-stuck=3 --max-runtime=1s
+FILE=$(state_file)
+PAST_EPOCH=$(( $(date +%s) - 10 ))
+write_field "$FILE" "start_epoch" "$PAST_EPOCH"
+run tick --stuck=no
+assert_exit "tick exits 1 at max-runtime" 1
+assert_contains "violation includes max-runtime" "max-runtime"
+cleanup_session
+
+# can-deep denied: max-deep-per-cycle
+init_session --max-cycles=10 --max-stuck=3 --max-deep-per-cycle=1
+run deep
+run can-deep
+assert_exit "can-deep denied at max-deep-per-cycle" 1
+assert_contains "reason=max-deep-per-cycle" "reason=max-deep-per-cycle"
+cleanup_session
+
+# can-deep denied: max-consecutive-deep
+init_session --max-cycles=10 --max-stuck=3 --max-consecutive-deep=1
+run deep
+run tick --stuck=no  # consecutive_deep_cycles becomes 1
+run can-deep
+assert_exit "can-deep denied at max-consecutive-deep" 1
+assert_contains "reason=max-consecutive-deep" "reason=max-consecutive-deep"
+cleanup_session
+
+# can-deep denied: max-runtime
+init_session --max-cycles=10 --max-stuck=3 --max-runtime=1s
+FILE=$(state_file)
+PAST_EPOCH=$(( $(date +%s) - 10 ))
+write_field "$FILE" "start_epoch" "$PAST_EPOCH"
+run can-deep
+assert_exit "can-deep denied at max-runtime" 1
+assert_contains "reason=max-runtime" "reason=max-runtime"
+cleanup_session
+
+# =========================================================================
+echo ""
+echo "-- Validation failures (init, exit 2) --"
+
+run init --max-stuck=2
+assert_exit "missing --max-cycles" 2
+assert_contains "error mentions max-cycles" "max-cycles"
+
+run init --max-cycles=5
+assert_exit "missing --max-stuck" 2
+assert_contains "error mentions max-stuck" "max-stuck"
+
+run init --max-cycles=0 --max-stuck=2
+assert_exit "--max-cycles=0 rejected" 2
+assert_contains "error: positive integer" "positive integer"
+
+run init --max-cycles=-1 --max-stuck=2
+assert_exit "--max-cycles=-1 rejected" 2
+
+run init --max-cycles=abc --max-stuck=2
+assert_exit "--max-cycles=abc rejected" 2
+assert_contains "error: positive integer" "positive integer"
+
+run init --max-cycles=5 --max-stuck=2 --max-runtime=foo
+assert_exit "--max-runtime=foo rejected" 2
+assert_contains "error: duration format" "duration format"
+
+# Valid optional omission
+init_session --max-cycles=5 --max-stuck=2
+FILE=$(state_file)
+RUNTIME=$(read_field "$FILE" "max_runtime_seconds")
+if [[ "$RUNTIME" == "0" ]]; then
+  echo "  PASS: no --max-runtime → max_runtime_seconds=0"
+  (( ++PASS ))
+else
+  echo "  FAIL: max_runtime_seconds=$RUNTIME, expected 0"
+  (( ++FAIL ))
+fi
+# tick shows unlimited
+run tick --stuck=no
+assert_contains "elapsed_display shows unlimited" "unlimited"
+cleanup_session
+
+# =========================================================================
+echo ""
+echo "-- Robustness --"
+
+# Corrupted state file
+init_session --max-cycles=5 --max-stuck=2
+FILE=$(state_file)
+echo "NOT JSON" > "$FILE"
+run tick --stuck=no
+assert_exit "corrupted state file → exit 2 or nonzero" "$LAST_EXIT"
+# Accept any nonzero exit (jq gives 1, python3 gives 2)
+if [[ "$LAST_EXIT" -ne 0 ]]; then
+  echo "  PASS: corrupted state file causes nonzero exit ($LAST_EXIT)"
+  (( ++PASS ))
+else
+  echo "  FAIL: corrupted state file should cause nonzero exit"
+  (( ++FAIL ))
+fi
+rm -f "$FILE"
+unset LEAN4_SESSION_ID
+
+# Missing state file
+export LEAN4_SESSION_ID="lean4-session-NONEXISTENT"
+run tick --stuck=no
+assert_exit "missing state file → exit 2" 2
+assert_contains "error mentions state file" "state file"
+unset LEAN4_SESSION_ID
+
+# Unset LEAN4_SESSION_ID
+LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+run tick --stuck=no
+assert_exit "unset LEAN4_SESSION_ID → exit 2" 2
+assert_contains "error mentions LEAN4_SESSION_ID" "LEAN4_SESSION_ID"
+
+# No subcommand
+run ""
+# run() will have empty subcmd error
+LAST_EXIT=0
+LAST_OUT=$(bash "$TRACKER" 2>&1) || LAST_EXIT=$?
+assert_exit "no subcommand → exit 2" 2
+
+# Unknown subcommand
+run foobar
+assert_exit "unknown subcommand → exit 2" 2
+assert_contains "error mentions unknown" "unknown"
+
+# =========================================================================
+echo ""
+echo "-- CLAUDE_ENV_FILE fallback --"
+
+# init with CLAUDE_ENV_FILE unset
+CLAUDE_ENV_FILE=""; export CLAUDE_ENV_FILE
+LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+run init --max-cycles=5 --max-stuck=2
+assert_exit "init without CLAUDE_ENV_FILE succeeds" 0
+# Should still print session ID
+assert_contains "init prints session ID" "lean4-session-"
+SID="$LAST_OUT"
+export LEAN4_SESSION_ID="$SID"
+# Subsequent calls work with env prefix
+run tick --stuck=no
+assert_exit "tick works with manual session ID" 0
+cleanup_session
+
+# init with CLAUDE_ENV_FILE pointing to unwritable path
+FAKE_ENV="/tmp/lean4-test-unwritable-$$"
+touch "$FAKE_ENV" && chmod 000 "$FAKE_ENV" 2>/dev/null || true
+LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+export CLAUDE_ENV_FILE="$FAKE_ENV"
+run init --max-cycles=5 --max-stuck=2
+assert_exit "init with unwritable CLAUDE_ENV_FILE succeeds" 0
+assert_contains "init prints session ID despite unwritable env" "lean4-session-"
+SID="$LAST_OUT"
+export LEAN4_SESSION_ID="$SID"
+run stop
+chmod 644 "$FAKE_ENV" 2>/dev/null || true
+rm -f "$FAKE_ENV"
+LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+
+# stop with CLAUDE_ENV_FILE unset
+init_session --max-cycles=5 --max-stuck=2
+CLAUDE_ENV_FILE=""; export CLAUDE_ENV_FILE
+run stop
+assert_exit "stop without CLAUDE_ENV_FILE succeeds" 0
+
+# =========================================================================
+echo ""
+echo "-- Deep-mode state machine --"
+
+# deep → deep → tick: deep_this_cycle resets, consecutive_deep_cycles=1
+init_session --max-cycles=10 --max-stuck=3 --max-deep-per-cycle=3
+FILE=$(state_file)
+run deep
+run deep
+DEEP_COUNT=$(read_field "$FILE" "deep_this_cycle")
+if [[ "$DEEP_COUNT" == "2" ]]; then
+  echo "  PASS: two deep calls → deep_this_cycle=2"
+  (( ++PASS ))
+else
+  echo "  FAIL: deep_this_cycle=$DEEP_COUNT, expected 2"
+  (( ++FAIL ))
+fi
+run tick --stuck=no
+assert_contains "after tick: deep_this_cycle=0" "deep_this_cycle=0/"
+assert_contains "after tick: consecutive_deep_cycles=1" "consecutive_deep_cycles=1/"
+
+# Non-deep cycle resets consecutive_deep_cycles
+run tick --stuck=no  # no deep this cycle
+assert_contains "non-deep cycle: consecutive_deep_cycles=0" "consecutive_deep_cycles=0/"
+
+# Two consecutive deep cycles then non-deep
+run deep
+run tick --stuck=no  # consecutive_deep=1
+assert_contains "deep cycle 1: consecutive_deep=1" "consecutive_deep_cycles=1/"
+run deep
+run tick --stuck=no  # consecutive_deep=2
+assert_contains "deep cycle 2: consecutive_deep=2" "consecutive_deep_cycles=2/"
+run tick --stuck=no  # no deep: consecutive_deep=0
+assert_contains "non-deep cycle: consecutive_deep=0" "consecutive_deep_cycles=0/"
+cleanup_session
+
+# =========================================================================
+echo ""
+echo "-- Stale cleanup --"
+
+# Create a fake stale session file
+STALE_FILE="/tmp/lean4-session-STALEFAKE.json"
+echo '{"session_id":"lean4-session-STALEFAKE"}' > "$STALE_FILE"
+# Set mtime to 25 hours ago
+touch -t "$(date -d '25 hours ago' +%Y%m%d%H%M.%S)" "$STALE_FILE" 2>/dev/null || \
+  touch -t "$(date -v-25H +%Y%m%d%H%M.%S 2>/dev/null || echo '202001010000.00')" "$STALE_FILE" 2>/dev/null || true
+
+init_session --max-cycles=5 --max-stuck=2
+if [[ ! -f "$STALE_FILE" ]]; then
+  echo "  PASS: stale session file cleaned up on init"
+  (( ++PASS ))
+else
+  echo "  FAIL: stale session file still exists after init"
+  (( ++FAIL ))
+  rm -f "$STALE_FILE"
+fi
+cleanup_session
+
+# =========================================================================
+echo ""
+echo "-- Duration parsing --"
+
+# Minutes (default)
+init_session --max-cycles=5 --max-stuck=2 --max-runtime=2m
+FILE=$(state_file)
+RT=$(read_field "$FILE" "max_runtime_seconds")
+if [[ "$RT" == "120" ]]; then echo "  PASS: 2m → 120s"; (( ++PASS )); else echo "  FAIL: 2m → ${RT}s, expected 120"; (( ++FAIL )); fi
+cleanup_session
+
+# Seconds
+init_session --max-cycles=5 --max-stuck=2 --max-runtime=30s
+FILE=$(state_file)
+RT=$(read_field "$FILE" "max_runtime_seconds")
+if [[ "$RT" == "30" ]]; then echo "  PASS: 30s → 30s"; (( ++PASS )); else echo "  FAIL: 30s → ${RT}s, expected 30"; (( ++FAIL )); fi
+cleanup_session
+
+# Hours
+init_session --max-cycles=5 --max-stuck=2 --max-runtime=2h
+FILE=$(state_file)
+RT=$(read_field "$FILE" "max_runtime_seconds")
+if [[ "$RT" == "7200" ]]; then echo "  PASS: 2h → 7200s"; (( ++PASS )); else echo "  FAIL: 2h → ${RT}s, expected 7200"; (( ++FAIL )); fi
+cleanup_session
+
+# Bare number (minutes)
+init_session --max-cycles=5 --max-stuck=2 --max-runtime=5
+FILE=$(state_file)
+RT=$(read_field "$FILE" "max_runtime_seconds")
+if [[ "$RT" == "300" ]]; then echo "  PASS: 5 → 300s"; (( ++PASS )); else echo "  FAIL: 5 → ${RT}s, expected 300"; (( ++FAIL )); fi
+cleanup_session
+
+# =========================================================================
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/plugins/lean4/tests/test_cycle_tracker.sh
+++ b/plugins/lean4/tests/test_cycle_tracker.sh
@@ -845,6 +845,71 @@ cleanup_session
 
 # =========================================================================
 echo ""
+echo "-- Python3 fallback (no jq) --"
+
+# Force python3 backend by constructing a minimal PATH without jq
+if command -v python3 >/dev/null 2>&1; then
+  ORIG_PATH="$PATH"
+  NOJQ_DIR=$(mktemp -d)
+  # Symlink only python3, bash, and coreutils essentials — no jq
+  for cmd in python3 bash date id find mktemp mv rm stat touch grep chmod ln readlink realpath dirname basename cat wc tr sed; do
+    local_cmd=$(command -v "$cmd" 2>/dev/null || true)
+    if [[ -n "$local_cmd" ]]; then ln -sf "$local_cmd" "$NOJQ_DIR/$cmd" 2>/dev/null || true; fi
+  done
+  export PATH="$NOJQ_DIR"
+
+  if command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: could not hide jq from PATH"
+  else
+    # Basic lifecycle on python3 backend
+    run init --max-cycles=5 --max-stuck=2
+    assert_exit "py3: init succeeds" 0
+    SID="$LAST_OUT"; export LEAN4_SESSION_ID="$SID"
+
+    run start-claim
+    assert_exit "py3: start-claim succeeds" 0
+
+    run tick --stuck=yes
+    assert_exit "py3: tick --stuck=yes succeeds" 0
+
+    run tick --stuck=no
+    assert_exit "py3: tick --stuck=no succeeds" 0
+
+    run status
+    assert_exit "py3: status succeeds" 0
+    assert_contains "py3: status shows claim_active=true" "claim_active=true"
+    assert_contains "py3: stuck_cycles_total=1" "stuck_cycles_total=1"
+    assert_contains "py3: cycles_total=2" "cycles_total=2"
+
+    # Double start-claim must fail
+    run start-claim
+    assert_exit "py3: double start-claim → exit 2" 2
+
+    # Reset claim
+    run reset-claim
+    assert_exit "py3: reset-claim succeeds" 0
+
+    # Double reset-claim must fail
+    run reset-claim
+    assert_exit "py3: double reset-claim → exit 2" 2
+
+    # Deep tracking
+    run start-claim
+    run deep
+    run status
+    assert_contains "py3: deep_total=1" "deep_total=1"
+
+    cleanup_session
+  fi
+
+  export PATH="$ORIG_PATH"
+  rm -rf "$NOJQ_DIR"
+else
+  echo "  SKIP: python3 not available"
+fi
+
+# =========================================================================
+echo ""
 echo "-- Stale cleanup --"
 
 # Create a fake stale session file

--- a/plugins/lean4/tests/test_cycle_tracker.sh
+++ b/plugins/lean4/tests/test_cycle_tracker.sh
@@ -867,6 +867,59 @@ cleanup_session
 
 # =========================================================================
 echo ""
+echo "-- Init flag aliases --"
+
+# Long user-facing form: --max-stuck-cycles
+run init --max-cycles=5 --max-stuck-cycles=3
+assert_exit "--max-stuck-cycles alias accepted" 0
+SID="$LAST_OUT"; export LEAN4_SESSION_ID="$SID"
+FILE=$(state_file)
+VAL=$(read_field "$FILE" "max_stuck")
+if [[ "$VAL" == "3" ]]; then echo "  PASS: --max-stuck-cycles=3 → max_stuck=3"; (( ++PASS )); else echo "  FAIL: max_stuck=$VAL, expected 3"; (( ++FAIL )); fi
+cleanup_session
+
+# Long user-facing form: --max-total-runtime
+run init --max-cycles=5 --max-stuck=2 --max-total-runtime=60m
+assert_exit "--max-total-runtime alias accepted" 0
+SID="$LAST_OUT"; export LEAN4_SESSION_ID="$SID"
+FILE=$(state_file)
+VAL=$(read_field "$FILE" "max_runtime_seconds")
+if [[ "$VAL" == "3600" ]]; then echo "  PASS: --max-total-runtime=60m → 3600s"; (( ++PASS )); else echo "  FAIL: max_runtime_seconds=$VAL, expected 3600"; (( ++FAIL )); fi
+cleanup_session
+
+# Long user-facing form: --max-consecutive-deep-cycles
+run init --max-cycles=5 --max-stuck=2 --max-consecutive-deep-cycles=4
+assert_exit "--max-consecutive-deep-cycles alias accepted" 0
+SID="$LAST_OUT"; export LEAN4_SESSION_ID="$SID"
+FILE=$(state_file)
+VAL=$(read_field "$FILE" "max_consecutive_deep")
+if [[ "$VAL" == "4" ]]; then echo "  PASS: --max-consecutive-deep-cycles=4 → max_consecutive_deep=4"; (( ++PASS )); else echo "  FAIL: max_consecutive_deep=$VAL, expected 4"; (( ++FAIL )); fi
+cleanup_session
+
+# Mixed short/long aliases in a single init call
+run init --max-cycles=10 --max-stuck-cycles=2 --max-total-runtime=30m --max-consecutive-deep-cycles=3
+assert_exit "mixed short/long aliases accepted" 0
+SID="$LAST_OUT"; export LEAN4_SESSION_ID="$SID"
+FILE=$(state_file)
+V1=$(read_field "$FILE" "max_stuck")
+V2=$(read_field "$FILE" "max_runtime_seconds")
+V3=$(read_field "$FILE" "max_consecutive_deep")
+if [[ "$V1" == "2" && "$V2" == "1800" && "$V3" == "3" ]]; then
+  echo "  PASS: mixed aliases all parsed correctly"
+  (( ++PASS ))
+else
+  echo "  FAIL: mixed aliases: max_stuck=$V1 (exp 2), max_runtime_seconds=$V2 (exp 1800), max_consecutive_deep=$V3 (exp 3)"
+  (( ++FAIL ))
+fi
+cleanup_session
+
+# Unknown args still fail (regression guard)
+run init --max-cycles=5 --max-stuck=2 --max-bogus=7
+assert_exit "unknown --max-bogus still rejected" 2
+assert_contains "error mentions unknown" "unknown"
+
+# =========================================================================
+echo ""
 echo "-- Duration parsing --"
 
 # Minutes (default)

--- a/plugins/lean4/tests/test_cycle_tracker.sh
+++ b/plugins/lean4/tests/test_cycle_tracker.sh
@@ -516,40 +516,104 @@ rm -rf "$NOWRITE_DIR"
 LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
 CLAUDE_ENV_FILE=""; export CLAUDE_ENV_FILE
 
-# stop with missing state file — must still clean env file (best-effort fallback)
+# Env file pointing to a directory — init must not leak shell errors to stdout
+LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+export CLAUDE_ENV_FILE="/tmp"
+run init --max-cycles=5 --max-stuck=2
+assert_exit "init with directory env file succeeds" 0
+LINE_COUNT=$(echo "$LAST_OUT" | wc -l | tr -d ' ')
+if [[ "$LINE_COUNT" == "1" && "$LAST_OUT" == lean4-session-* ]]; then
+  echo "  PASS: init stdout clean with directory env file"
+  (( ++PASS ))
+else
+  echo "  FAIL: init stdout polluted with directory env file ($LINE_COUNT lines, content: '$LAST_OUT')"
+  (( ++FAIL ))
+fi
+SID="$LAST_OUT"
+export LEAN4_SESSION_ID="$SID"
+run stop
+LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+CLAUDE_ENV_FILE=""; export CLAUDE_ENV_FILE
+
+# Env file pointing to a FIFO — init must not block or leak errors
+FIFO_PATH="/tmp/lean4-test-fifo-$$"
+mkfifo "$FIFO_PATH" 2>/dev/null || true
+if [[ -p "$FIFO_PATH" ]]; then
+  LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+  export CLAUDE_ENV_FILE="$FIFO_PATH"
+  run init --max-cycles=5 --max-stuck=2
+  assert_exit "init with FIFO env file succeeds" 0
+  LINE_COUNT=$(echo "$LAST_OUT" | wc -l | tr -d ' ')
+  if [[ "$LINE_COUNT" == "1" && "$LAST_OUT" == lean4-session-* ]]; then
+    echo "  PASS: init stdout clean with FIFO env file"
+    (( ++PASS ))
+  else
+    echo "  FAIL: init stdout polluted with FIFO env file ($LINE_COUNT lines, content: '$LAST_OUT')"
+    (( ++FAIL ))
+  fi
+  SID="$LAST_OUT"
+  export LEAN4_SESSION_ID="$SID"
+  run stop
+  LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+  CLAUDE_ENV_FILE=""; export CLAUDE_ENV_FILE
+  rm -f "$FIFO_PATH"
+else
+  echo "  SKIP: could not create FIFO for testing"
+fi
+
+# stop with missing state file — must clean stale export but not clobber another session
 FALLBACK_ENV="/tmp/lean4-test-fallback-env-$$"
-echo 'export LEAN4_SESSION_ID="lean4-session-GHOST"' > "$FALLBACK_ENV"
+cat > "$FALLBACK_ENV" <<'ENVEOF'
+export LEAN4_SESSION_ID="lean4-session-GHOST"
+export LEAN4_SESSION_ID="lean4-session-ACTIVE"
+ENVEOF
 export LEAN4_SESSION_ID="lean4-session-GHOST"
 export CLAUDE_ENV_FILE="$FALLBACK_ENV"
-# No state file exists for this session ID — stop must still clean env
 run stop
 assert_exit "stop with missing state file succeeds" 0
-if grep -q 'LEAN4_SESSION_ID' "$FALLBACK_ENV" 2>/dev/null; then
-  echo "  FAIL: stop with missing state leaked LEAN4_SESSION_ID in env file"
+if grep -q 'lean4-session-GHOST' "$FALLBACK_ENV" 2>/dev/null; then
+  echo "  FAIL: stop with missing state leaked stale session in env file"
   (( ++FAIL ))
 else
-  echo "  PASS: stop with missing state cleaned env file (best-effort)"
+  echo "  PASS: stop with missing state cleaned stale session (best-effort)"
   (( ++PASS ))
+fi
+if grep -q 'lean4-session-ACTIVE' "$FALLBACK_ENV" 2>/dev/null; then
+  echo "  PASS: stop with missing state preserved other session's export"
+  (( ++PASS ))
+else
+  echo "  FAIL: stop with missing state clobbered other session's export"
+  (( ++FAIL ))
 fi
 rm -f "$FALLBACK_ENV"
 LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
 CLAUDE_ENV_FILE=""; export CLAUDE_ENV_FILE
 
-# stop with corrupted state file — must still clean env file (best-effort fallback)
+# stop with corrupted state file — must clean stale export but not clobber another session
 CORRUPT_ENV="/tmp/lean4-test-corrupt-env-$$"
-echo 'export LEAN4_SESSION_ID="lean4-session-CORRUPT"' > "$CORRUPT_ENV"
+cat > "$CORRUPT_ENV" <<'ENVEOF'
+export LEAN4_SESSION_ID="lean4-session-CORRUPT"
+export LEAN4_SESSION_ID="lean4-session-ALIVE"
+ENVEOF
 CORRUPT_STATE="/tmp/lean4-session-CORRUPT.json"
 echo "NOT JSON" > "$CORRUPT_STATE"
 export LEAN4_SESSION_ID="lean4-session-CORRUPT"
 export CLAUDE_ENV_FILE="$CORRUPT_ENV"
 run stop
 assert_exit "stop with corrupted state file succeeds" 0
-if grep -q 'LEAN4_SESSION_ID' "$CORRUPT_ENV" 2>/dev/null; then
-  echo "  FAIL: stop with corrupted state leaked LEAN4_SESSION_ID in env file"
+if grep -q 'lean4-session-CORRUPT' "$CORRUPT_ENV" 2>/dev/null; then
+  echo "  FAIL: stop with corrupted state leaked stale session in env file"
   (( ++FAIL ))
 else
-  echo "  PASS: stop with corrupted state cleaned env file (best-effort)"
+  echo "  PASS: stop with corrupted state cleaned stale session (best-effort)"
   (( ++PASS ))
+fi
+if grep -q 'lean4-session-ALIVE' "$CORRUPT_ENV" 2>/dev/null; then
+  echo "  PASS: stop with corrupted state preserved other session's export"
+  (( ++PASS ))
+else
+  echo "  FAIL: stop with corrupted state clobbered other session's export"
+  (( ++FAIL ))
 fi
 rm -f "$CORRUPT_ENV" "$CORRUPT_STATE"
 LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID

--- a/plugins/lean4/tests/test_cycle_tracker.sh
+++ b/plugins/lean4/tests/test_cycle_tracker.sh
@@ -561,6 +561,68 @@ else
   echo "  SKIP: could not create FIFO for testing"
 fi
 
+# Broken symlink env file — init must not leak errors to stdout
+BROKEN_LINK="/tmp/lean4-test-broken-link-$$"
+ln -sf "/tmp/lean4-test-no-such-target-$$" "$BROKEN_LINK" 2>/dev/null || true
+if [[ -L "$BROKEN_LINK" ]]; then
+  LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+  export CLAUDE_ENV_FILE="$BROKEN_LINK"
+  run init --max-cycles=5 --max-stuck=2
+  assert_exit "init with broken symlink env file succeeds" 0
+  LINE_COUNT=$(echo "$LAST_OUT" | wc -l | tr -d ' ')
+  if [[ "$LINE_COUNT" == "1" && "$LAST_OUT" == lean4-session-* ]]; then
+    echo "  PASS: init stdout clean with broken symlink env file"
+    (( ++PASS ))
+  else
+    echo "  FAIL: init stdout polluted with broken symlink ($LINE_COUNT lines, content: '$LAST_OUT')"
+    (( ++FAIL ))
+  fi
+  SID="$LAST_OUT"
+  export LEAN4_SESSION_ID="$SID"
+  run stop
+  LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+  CLAUDE_ENV_FILE=""; export CLAUDE_ENV_FILE
+  rm -f "$BROKEN_LINK"
+else
+  echo "  SKIP: could not create broken symlink for testing"
+fi
+
+# Symlink to regular file — init must write to the real target, not destroy the link
+REAL_TARGET="/tmp/lean4-test-real-target-$$"
+LINK_PATH="/tmp/lean4-test-symlink-$$"
+: > "$REAL_TARGET"
+ln -sf "$REAL_TARGET" "$LINK_PATH" 2>/dev/null || true
+if [[ -L "$LINK_PATH" ]]; then
+  LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+  export CLAUDE_ENV_FILE="$LINK_PATH"
+  run init --max-cycles=5 --max-stuck=2
+  assert_exit "init with symlink-to-file env file succeeds" 0
+  SID="$LAST_OUT"
+  export LEAN4_SESSION_ID="$SID"
+  # The symlink must still be a symlink (not replaced by a regular file)
+  if [[ -L "$LINK_PATH" ]]; then
+    echo "  PASS: symlink preserved after init"
+    (( ++PASS ))
+  else
+    echo "  FAIL: symlink was destroyed by init"
+    (( ++FAIL ))
+  fi
+  # The real target must contain the session ID
+  if grep -q "$SID" "$REAL_TARGET" 2>/dev/null; then
+    echo "  PASS: session ID written to real target through symlink"
+    (( ++PASS ))
+  else
+    echo "  FAIL: session ID not found in real target"
+    (( ++FAIL ))
+  fi
+  run stop
+  LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+  CLAUDE_ENV_FILE=""; export CLAUDE_ENV_FILE
+  rm -f "$LINK_PATH" "$REAL_TARGET"
+else
+  echo "  SKIP: could not create symlink for testing"
+fi
+
 # stop with missing state file — must clean stale export but not clobber another session
 FALLBACK_ENV="/tmp/lean4-test-fallback-env-$$"
 cat > "$FALLBACK_ENV" <<'ENVEOF'

--- a/plugins/lean4/tests/test_cycle_tracker.sh
+++ b/plugins/lean4/tests/test_cycle_tracker.sh
@@ -561,9 +561,11 @@ else
   echo "  SKIP: could not create FIFO for testing"
 fi
 
-# Broken symlink env file — init must not leak errors to stdout
+# Broken symlink env file — must fall back cleanly, not create the target
 BROKEN_LINK="/tmp/lean4-test-broken-link-$$"
-ln -sf "/tmp/lean4-test-no-such-target-$$" "$BROKEN_LINK" 2>/dev/null || true
+BROKEN_TARGET="/tmp/lean4-test-no-such-target-$$"
+rm -f "$BROKEN_TARGET"  # ensure target does not exist
+ln -sf "$BROKEN_TARGET" "$BROKEN_LINK" 2>/dev/null || true
 if [[ -L "$BROKEN_LINK" ]]; then
   LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
   export CLAUDE_ENV_FILE="$BROKEN_LINK"
@@ -577,12 +579,29 @@ if [[ -L "$BROKEN_LINK" ]]; then
     echo "  FAIL: init stdout polluted with broken symlink ($LINE_COUNT lines, content: '$LAST_OUT')"
     (( ++FAIL ))
   fi
+  # Target file must NOT have been created
+  if [[ -e "$BROKEN_TARGET" ]]; then
+    echo "  FAIL: init created the broken symlink's target file"
+    (( ++FAIL ))
+    rm -f "$BROKEN_TARGET"
+  else
+    echo "  PASS: broken symlink target not created by init"
+    (( ++PASS ))
+  fi
+  # Link must still be broken (unchanged)
+  if [[ -L "$BROKEN_LINK" && ! -e "$BROKEN_LINK" ]]; then
+    echo "  PASS: broken symlink remains broken after init"
+    (( ++PASS ))
+  else
+    echo "  FAIL: broken symlink was modified by init"
+    (( ++FAIL ))
+  fi
   SID="$LAST_OUT"
   export LEAN4_SESSION_ID="$SID"
   run stop
   LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
   CLAUDE_ENV_FILE=""; export CLAUDE_ENV_FILE
-  rm -f "$BROKEN_LINK"
+  rm -f "$BROKEN_LINK" "$BROKEN_TARGET"
 else
   echo "  SKIP: could not create broken symlink for testing"
 fi

--- a/plugins/lean4/tests/test_cycle_tracker.sh
+++ b/plugins/lean4/tests/test_cycle_tracker.sh
@@ -393,8 +393,50 @@ fi
 SID="$LAST_OUT"
 export LEAN4_SESSION_ID="$SID"
 run stop
+# Verify stop cleaned the right file (LEAN4_ENVF, not CLAUDE_ENVF)
+if grep -q 'LEAN4_SESSION_ID' "$LEAN4_ENVF" 2>/dev/null; then
+  echo "  FAIL: stop did not clean LEAN4_ENV_FILE"
+  (( ++FAIL ))
+else
+  echo "  PASS: stop cleaned LEAN4_ENV_FILE"
+  (( ++PASS ))
+fi
 rm -f "$LEAN4_ENVF" "$CLAUDE_ENVF"
 LEAN4_ENV_FILE=""; export LEAN4_ENV_FILE
+
+# Cross-env-file cleanup: init under CLAUDE_ENV_FILE, stop under LEAN4_ENV_FILE
+# stop must clean the file init actually wrote to (CLAUDE_ENVF), not the newly resolved one
+CLAUDE_ENVF2="/tmp/lean4-test-claude-envfile2-$$"
+LEAN4_ENVF2="/tmp/lean4-test-lean4-envfile2-$$"
+: > "$CLAUDE_ENVF2"; : > "$LEAN4_ENVF2"
+LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+LEAN4_ENV_FILE=""; export LEAN4_ENV_FILE
+export CLAUDE_ENV_FILE="$CLAUDE_ENVF2"
+run init --max-cycles=5 --max-stuck=2
+assert_exit "cross-env init succeeds" 0
+SID="$LAST_OUT"
+export LEAN4_SESSION_ID="$SID"
+# Now switch env resolution: set LEAN4_ENV_FILE so _resolve_env_file would return it
+export LEAN4_ENV_FILE="$LEAN4_ENVF2"
+run stop
+# stop should have cleaned CLAUDE_ENVF2 (where init wrote), not LEAN4_ENVF2
+if grep -q 'LEAN4_SESSION_ID' "$CLAUDE_ENVF2" 2>/dev/null; then
+  echo "  FAIL: cross-env stop did not clean original env file (CLAUDE_ENV_FILE)"
+  (( ++FAIL ))
+else
+  echo "  PASS: cross-env stop cleaned original env file (CLAUDE_ENV_FILE)"
+  (( ++PASS ))
+fi
+if grep -q 'LEAN4_SESSION_ID' "$LEAN4_ENVF2" 2>/dev/null; then
+  echo "  FAIL: cross-env stop polluted new env file (LEAN4_ENV_FILE)"
+  (( ++FAIL ))
+else
+  echo "  PASS: cross-env stop did not pollute new env file (LEAN4_ENV_FILE)"
+  (( ++PASS ))
+fi
+rm -f "$CLAUDE_ENVF2" "$LEAN4_ENVF2"
+LEAN4_ENV_FILE=""; export LEAN4_ENV_FILE
+CLAUDE_ENV_FILE=""; export CLAUDE_ENV_FILE
 
 # Unwritable env file — must be left untouched
 FAKE_ENV="/tmp/lean4-test-unwritable-$$"
@@ -523,6 +565,13 @@ init_session --max-cycles=5 --max-stuck=2 --max-runtime=30s
 run tick --stuck=no
 assert_contains "sub-minute display uses seconds" "/30s"
 assert_not_contains "sub-minute display does not use 0m" "0m/0m"
+cleanup_session
+
+# Non-whole-minute display: 90s budget should show Xs/90s, not 0m/1m
+init_session --max-cycles=5 --max-stuck=2 --max-runtime=90s
+run tick --stuck=no
+assert_contains "90s budget uses seconds format" "/90s"
+assert_not_contains "90s budget does not truncate to minutes" "/1m"
 cleanup_session
 
 # =========================================================================

--- a/plugins/lean4/tests/test_cycle_tracker.sh
+++ b/plugins/lean4/tests/test_cycle_tracker.sh
@@ -470,6 +470,91 @@ CLAUDE_ENV_FILE=""; export CLAUDE_ENV_FILE
 run stop
 assert_exit "stop without env file succeeds" 0
 
+# Env file with missing parent directory — init must not leak shell errors to stdout
+MISSING_DIR_ENV="/tmp/lean4-test-nodir-$$/subdir/env.sh"
+LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+LEAN4_ENV_FILE=""; export LEAN4_ENV_FILE
+export CLAUDE_ENV_FILE="$MISSING_DIR_ENV"
+run init --max-cycles=5 --max-stuck=2
+assert_exit "init with missing-dir env file succeeds" 0
+# stdout must be exactly one line: the session ID, no shell errors
+LINE_COUNT=$(echo "$LAST_OUT" | wc -l | tr -d ' ')
+if [[ "$LINE_COUNT" == "1" && "$LAST_OUT" == lean4-session-* ]]; then
+  echo "  PASS: init stdout is clean (single session ID line)"
+  (( ++PASS ))
+else
+  echo "  FAIL: init stdout is polluted ($LINE_COUNT lines, content: '$LAST_OUT')"
+  (( ++FAIL ))
+fi
+SID="$LAST_OUT"
+export LEAN4_SESSION_ID="$SID"
+run stop
+LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+CLAUDE_ENV_FILE=""; export CLAUDE_ENV_FILE
+
+# Env file in unwritable directory — init must not leak shell errors to stdout
+NOWRITE_DIR="/tmp/lean4-test-nowritedir-$$"
+mkdir -p "$NOWRITE_DIR" && chmod 555 "$NOWRITE_DIR" 2>/dev/null || true
+NOWRITE_ENV="$NOWRITE_DIR/env.sh"
+LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+export CLAUDE_ENV_FILE="$NOWRITE_ENV"
+run init --max-cycles=5 --max-stuck=2
+assert_exit "init with unwritable-dir env file succeeds" 0
+LINE_COUNT=$(echo "$LAST_OUT" | wc -l | tr -d ' ')
+if [[ "$LINE_COUNT" == "1" && "$LAST_OUT" == lean4-session-* ]]; then
+  echo "  PASS: init stdout clean with unwritable dir"
+  (( ++PASS ))
+else
+  echo "  FAIL: init stdout polluted with unwritable dir ($LINE_COUNT lines, content: '$LAST_OUT')"
+  (( ++FAIL ))
+fi
+SID="$LAST_OUT"
+export LEAN4_SESSION_ID="$SID"
+run stop
+chmod 755 "$NOWRITE_DIR" 2>/dev/null || true
+rm -rf "$NOWRITE_DIR"
+LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+CLAUDE_ENV_FILE=""; export CLAUDE_ENV_FILE
+
+# stop with missing state file — must still clean env file (best-effort fallback)
+FALLBACK_ENV="/tmp/lean4-test-fallback-env-$$"
+echo 'export LEAN4_SESSION_ID="lean4-session-GHOST"' > "$FALLBACK_ENV"
+export LEAN4_SESSION_ID="lean4-session-GHOST"
+export CLAUDE_ENV_FILE="$FALLBACK_ENV"
+# No state file exists for this session ID — stop must still clean env
+run stop
+assert_exit "stop with missing state file succeeds" 0
+if grep -q 'LEAN4_SESSION_ID' "$FALLBACK_ENV" 2>/dev/null; then
+  echo "  FAIL: stop with missing state leaked LEAN4_SESSION_ID in env file"
+  (( ++FAIL ))
+else
+  echo "  PASS: stop with missing state cleaned env file (best-effort)"
+  (( ++PASS ))
+fi
+rm -f "$FALLBACK_ENV"
+LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+CLAUDE_ENV_FILE=""; export CLAUDE_ENV_FILE
+
+# stop with corrupted state file — must still clean env file (best-effort fallback)
+CORRUPT_ENV="/tmp/lean4-test-corrupt-env-$$"
+echo 'export LEAN4_SESSION_ID="lean4-session-CORRUPT"' > "$CORRUPT_ENV"
+CORRUPT_STATE="/tmp/lean4-session-CORRUPT.json"
+echo "NOT JSON" > "$CORRUPT_STATE"
+export LEAN4_SESSION_ID="lean4-session-CORRUPT"
+export CLAUDE_ENV_FILE="$CORRUPT_ENV"
+run stop
+assert_exit "stop with corrupted state file succeeds" 0
+if grep -q 'LEAN4_SESSION_ID' "$CORRUPT_ENV" 2>/dev/null; then
+  echo "  FAIL: stop with corrupted state leaked LEAN4_SESSION_ID in env file"
+  (( ++FAIL ))
+else
+  echo "  PASS: stop with corrupted state cleaned env file (best-effort)"
+  (( ++PASS ))
+fi
+rm -f "$CORRUPT_ENV" "$CORRUPT_STATE"
+LEAN4_SESSION_ID=""; export LEAN4_SESSION_ID
+CLAUDE_ENV_FILE=""; export CLAUDE_ENV_FILE
+
 # =========================================================================
 echo ""
 echo "-- Deep-mode state machine --"

--- a/plugins/lean4/tools/lint_docs.sh
+++ b/plugins/lean4/tools/lint_docs.sh
@@ -57,13 +57,13 @@ check_commands() {
         local max_lines=120
         case "$cmd" in
             autoformalize) max_lines=180 ;;
-            autoprove)  max_lines=250 ;;
+            autoprove)  max_lines=275 ;;
             checkpoint) max_lines=90 ;;
             doctor)     max_lines=225 ;;
             draft)      max_lines=160 ;;
             formalize)  max_lines=180 ;;
             golf)       max_lines=170 ;;
-            learn)      max_lines=180 ;;
+            learn)      max_lines=195 ;;
             prove)      max_lines=235 ;;
             refactor)   max_lines=120 ;;
             review)     max_lines=330 ;;
@@ -1530,7 +1530,53 @@ check_header_fence_examples() {
     fi
 }
 
-# Check 27: Proof-complete shortcut guard
+# Check 27: Command invocation contract coverage
+check_command_invocation_contract() {
+    log ""
+    log "Checking command invocation contract..."
+
+    local ref="$PLUGIN_ROOT/skills/lean4/references/command-invocation.md"
+    local file base
+
+    if [[ ! -f "$ref" ]]; then
+        warn "command-invocation.md: Missing shared invocation contract reference"
+        return
+    fi
+
+    if ! grep -qi 'model-parsed, not host-parsed' "$ref" 2>/dev/null; then
+        warn "command-invocation.md: Missing model-parsed vs host-parsed clarification"
+    fi
+
+    for cmd in draft formalize autoformalize prove autoprove learn; do
+        file="$PLUGIN_ROOT/commands/$cmd.md"
+        base="$cmd.md"
+        if [[ ! -f "$file" ]]; then
+            warn "$base: File not found"
+            continue
+        fi
+        if ! grep -q '^## Invocation Contract' "$file" 2>/dev/null; then
+            warn "$base: Missing Invocation Contract section"
+        fi
+    done
+
+    for file in "$PLUGIN_ROOT/README.md" "$PLUGIN_ROOT/skills/lean4/SKILL.md"; do
+        base=$(basename "$file")
+        if grep -qi 'hard stop rules' "$file" 2>/dev/null; then
+            warn "$base: Uses 'hard stop rules' wording; prefer explicit stop-budget wording"
+        fi
+    done
+
+    for file in "$PLUGIN_ROOT/commands/autoprove.md" "$PLUGIN_ROOT/commands/autoformalize.md"; do
+        base=$(basename "$file")
+        if grep -qE '^\| --max-total-runtime .*Hard stop' "$file" 2>/dev/null; then
+            warn "$base: Describes --max-total-runtime as a hard stop; it should be best-effort"
+        fi
+    done
+
+    ok "Command invocation contract checked"
+}
+
+# Check 28: Proof-complete shortcut guard
 # Prevents docs from equating empty goals_after / "no goals" with proof completion
 # without requiring diagnostic verification.
 check_proof_complete_shortcut() {
@@ -1601,6 +1647,7 @@ check_host_agnostic
 check_contribute_policy
 check_bare_slash_links
 check_header_fence_examples
+check_command_invocation_contract
 check_proof_complete_shortcut
 
 log ""

--- a/plugins/lean4/tools/lint_docs.sh
+++ b/plugins/lean4/tools/lint_docs.sh
@@ -300,7 +300,7 @@ check_cross_refs() {
     local agent_anchors="sorry-filler-deep proof-repair proof-golfer axiom-eliminator"
 
     # Valid anchors for cycle-engine.md
-    local engine_anchors="six-phase-cycle lsp-first-protocol build-target-policy review-phase replan-phase stuck-definition deep-mode checkpoint-logic falsification-artifacts repair-mode safety synthesis-outer-loop algorithm draft-commit-boundary header-fence session-generated-provenance statement-safety claim-queue file-assembly-contract review-router pre-flight-context-for-subagent-dispatch"
+    local engine_anchors="six-phase-cycle lsp-first-protocol build-target-policy review-phase replan-phase stuck-definition deep-mode checkpoint-logic session-tracking enforcement-levels falsification-artifacts repair-mode safety synthesis-outer-loop algorithm draft-commit-boundary header-fence session-generated-provenance statement-safety claim-queue file-assembly-contract review-router pre-flight-context-for-subagent-dispatch"
 
     while IFS= read -r file; do
         # Check links to command-examples.md

--- a/plugins/lean4/tools/lint_docs.sh
+++ b/plugins/lean4/tools/lint_docs.sh
@@ -300,7 +300,7 @@ check_cross_refs() {
     local agent_anchors="sorry-filler-deep proof-repair proof-golfer axiom-eliminator"
 
     # Valid anchors for cycle-engine.md
-    local engine_anchors="six-phase-cycle lsp-first-protocol build-target-policy review-phase replan-phase stuck-definition deep-mode checkpoint-logic session-tracking enforcement-levels falsification-artifacts repair-mode safety synthesis-outer-loop algorithm draft-commit-boundary header-fence session-generated-provenance statement-safety claim-queue file-assembly-contract review-router pre-flight-context-for-subagent-dispatch"
+    local engine_anchors="six-phase-cycle lsp-first-protocol build-target-policy review-phase replan-phase stuck-definition deep-mode checkpoint-logic session-tracking claim-boundary-protocol-autoformalize enforcement-levels falsification-artifacts repair-mode safety synthesis-outer-loop algorithm draft-commit-boundary header-fence session-generated-provenance statement-safety claim-queue file-assembly-contract review-router pre-flight-context-for-subagent-dispatch"
 
     while IFS= read -r file; do
         # Check links to command-examples.md

--- a/plugins/lean4/tools/test_contracts.sh
+++ b/plugins/lean4/tools/test_contracts.sh
@@ -410,6 +410,57 @@ if [[ "$dispatch_ok" -eq 1 ]]; then
     ok "Check 24: All agent dispatch names resolve to valid frontmatter names"
 fi
 
+# ── Check 25: Session tracking contract ──────────────────────────────────
+# Autonomous commands must reference cycle_tracker.sh in their Invocation Contract.
+# cycle-engine.md must have the Session Tracking section and Enforcement Levels table.
+
+check25_ok=1
+
+for cmd_file in "$AUTOPROVE" "$AUTOFORMALIZE"; do
+    base=$(basename "$cmd_file")
+    if ! grep -q 'cycle_tracker\.sh' "$cmd_file" 2>/dev/null; then
+        fail "Check 25: $base missing cycle_tracker.sh reference in Invocation Contract"
+        check25_ok=0
+    fi
+done
+
+if ! grep -q '## Session Tracking' "$CYCLE_ENGINE" 2>/dev/null; then
+    fail "Check 25: cycle-engine.md missing Session Tracking section"
+    check25_ok=0
+fi
+
+if ! grep -q 'Enforcement Levels' "$CYCLE_ENGINE" 2>/dev/null; then
+    fail "Check 25: cycle-engine.md missing Enforcement Levels table"
+    check25_ok=0
+fi
+
+# No command file should describe --max-total-runtime as "Hard stop"
+for cmd_file in "$AUTOPROVE" "$AUTOFORMALIZE"; do
+    base=$(basename "$cmd_file")
+    if grep -qE '^\| --max-total-runtime .*Hard stop' "$cmd_file" 2>/dev/null; then
+        fail "Check 25: $base describes --max-total-runtime as Hard stop"
+        check25_ok=0
+    fi
+done
+
+# --deep-time-budget should include "advisory" (case-insensitive) in all 4 commands
+for cmd_file in "$AUTOPROVE" "$AUTOFORMALIZE" \
+                "$PLUGIN_ROOT/commands/prove.md" \
+                "$FORMALIZE"; do
+    base=$(basename "$cmd_file")
+    if ! grep -i 'deep-time-budget.*advisory\|advisory.*deep-time-budget' "$cmd_file" 2>/dev/null; then
+        # Check the table row specifically
+        if ! grep 'deep-time-budget' "$cmd_file" 2>/dev/null | grep -qi 'advisory'; then
+            fail "Check 25: $base --deep-time-budget not labeled as advisory"
+            check25_ok=0
+        fi
+    fi
+done
+
+if [[ "$check25_ok" -eq 1 ]]; then
+    ok "Check 25: Session tracking contract verified across all files"
+fi
+
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [[ "$FAIL" -eq 0 ]]

--- a/plugins/lean4/tools/test_contracts.sh
+++ b/plugins/lean4/tools/test_contracts.sh
@@ -489,15 +489,6 @@ if [[ -f "$TRACKER" ]]; then
     done
 fi
 
-# cycle-engine.md Session Tracking section must use consistent flag spelling
-if grep -q '## Session Tracking' "$CYCLE_ENGINE" 2>/dev/null; then
-    if grep 'Session Tracking' -A 50 "$CYCLE_ENGINE" 2>/dev/null | grep -q 'max-stuck[^-]'; then
-        # Bare --max-stuck without -cycles suffix in the session tracking section is OK
-        # (it's the script's canonical form), but check it doesn't use the long form inconsistently
-        :
-    fi
-fi
-
 if [[ "$check25_ok" -eq 1 ]]; then
     ok "Check 25: Session tracking contract verified across all files"
 fi

--- a/plugins/lean4/tools/test_contracts.sh
+++ b/plugins/lean4/tools/test_contracts.sh
@@ -457,6 +457,47 @@ for cmd_file in "$AUTOPROVE" "$AUTOFORMALIZE" \
     fi
 done
 
+# Flag-name consistency: autoprove init contract block must reference long user-facing flags.
+# The init contract spans multiple lines around "cycle_tracker.sh init", so extract a window.
+if grep -q "cycle_tracker.sh.*init" "$AUTOPROVE" 2>/dev/null; then
+    init_block=$(grep -A 3 "cycle_tracker.sh.*init" "$AUTOPROVE" 2>/dev/null)
+    for flag in max-stuck-cycles max-total-runtime max-consecutive-deep-cycles; do
+        if ! echo "$init_block" | grep -q "$flag"; then
+            fail "Check 25: autoprove.md init contract missing --$flag"
+            check25_ok=0
+        fi
+    done
+fi
+
+# autoformalize must NOT reference autoprove-only flag --max-consecutive-deep-cycles in init contract
+if grep -q "cycle_tracker.sh.*init" "$AUTOFORMALIZE" 2>/dev/null; then
+    af_init_block=$(grep -A 3 "cycle_tracker.sh.*init" "$AUTOFORMALIZE" 2>/dev/null)
+    if echo "$af_init_block" | grep -q "max-consecutive-deep-cycles"; then
+        fail "Check 25: autoformalize.md init contract references autoprove-only --max-consecutive-deep-cycles"
+        check25_ok=0
+    fi
+fi
+
+# cycle_tracker.sh must accept the long alias forms (grep the case statement)
+TRACKER="$PLUGIN_ROOT/lib/scripts/cycle_tracker.sh"
+if [[ -f "$TRACKER" ]]; then
+    for alias in max-stuck-cycles max-total-runtime max-consecutive-deep-cycles; do
+        if ! grep -q "\-\-${alias}=" "$TRACKER" 2>/dev/null; then
+            fail "Check 25: cycle_tracker.sh init missing alias --$alias"
+            check25_ok=0
+        fi
+    done
+fi
+
+# cycle-engine.md Session Tracking section must use consistent flag spelling
+if grep -q '## Session Tracking' "$CYCLE_ENGINE" 2>/dev/null; then
+    if grep 'Session Tracking' -A 50 "$CYCLE_ENGINE" 2>/dev/null | grep -q 'max-stuck[^-]'; then
+        # Bare --max-stuck without -cycles suffix in the session tracking section is OK
+        # (it's the script's canonical form), but check it doesn't use the long form inconsistently
+        :
+    fi
+fi
+
 if [[ "$check25_ok" -eq 1 ]]; then
     ok "Check 25: Session tracking contract verified across all files"
 fi


### PR DESCRIPTION
## Summary

- Establishes an honest invocation contract: slash-command inputs are model-parsed raw text, not host-parsed CLI flags. Commands must emit Resolved Inputs, fail fast on documented startup validation errors, and label each parameter by its actual enforcement level.
- Adds `cycle_tracker.sh` — a deterministic session tracker that autonomous commands use at cycle boundaries, and for autoformalize also at claim boundaries, to enforce `--max-cycles`, `--max-stuck-cycles`, and best-effort `--max-total-runtime`.
- Relabels `--max-total-runtime` as best-effort (checked at boundaries, not a kill switch) and `--deep-time-budget` as advisory (scopes subagent work, not tracked).
- Autoformalize: `--max-cycles` and `--max-stuck-cycles` are per-claim with explicit claim lifecycle (`start-claim`/`reset-claim`); session totals are live-accumulated for the summary.

### What changed

| Area | Change |
|------|--------|
| **New: `command-invocation.md`** | Shared reference defining enforcement classes (startup-validated, session-enforced, best-effort, advisory) and the model-parsed input contract |
| **New: `cycle_tracker.sh`** | Session state tracker with `init`, `tick --stuck=yes\|no`, `can-deep`, `deep`, `start-claim`, `reset-claim`, `status`, `stop`. Input validation, short and long init-flag aliases (e.g. `--max-stuck-cycles` → `--max-stuck`), atomic writes, jq/python3 backend, symlink-safe env-file persistence (`LEAN4_ENV_FILE` → `CLAUDE_ENV_FILE` → stdout fallback). Live session totals (`cycles_total`, `stuck_cycles_total`, `deep_total`) plus claim-lifecycle state (`claims_attempted`, `claim_active`). |
| **New: `test_cycle_tracker.sh`** | 174 tests covering state machine, limits, validation, env-file edge cases (missing dir, unwritable, directory, FIFO, broken/valid symlinks, cross-env cleanup, degraded stop), deep-mode transitions, claim lifecycle, session totals, invalid transitions, init-flag aliases, duration parsing, display formatting |
| **Commands updated** | All 6 commands (draft, learn, formalize, autoformalize, prove, autoprove) get an Invocation Contract section; autoprove/autoformalize reference the tracker; `--deep-time-budget` relabeled as advisory in the 4 proving commands |
| **`cycle-engine.md`** | Session Tracking section, Claim Boundary Protocol (autoformalize), Enforcement Levels table; deep-mode budget annotations |
| **`test_contracts.sh`** | Check 25: tracker references, enforcement levels, advisory labels, init-flag consistency, and autoprove-only flag leaks |
| **`lint_docs.sh`** | New cycle-engine anchors; invocation contract check updated |
| **READMEs, SKILL.md, MIGRATION.md** | "hard stop rules" → "explicit stop budgets" throughout |

### Enforcement levels after this PR

Enforcement is contract-level in this PR — commands follow the documented protocol. A shared centralized parser is deferred to Phase 3.

| Level | Mechanism | Parameters |
|-------|-----------|------------|
| Startup-validated | Fail before work starts | enum/path/companion/numeric checks |
| Session-enforced | `cycle_tracker.sh` at cycle boundaries; for autoformalize also claim boundaries | `--max-cycles`, `--max-stuck-cycles`, and autonomous-command deep caps (`--max-deep-per-cycle`; autoprove-only: `--max-consecutive-deep-cycles`) |
| Best-effort | `cycle_tracker.sh tick` + `can-deep` | `--max-total-runtime` |
| Advisory | Instruction to LLM/subagent | `--deep-time-budget`, `--batch-size` |

### Per-claim vs per-session (autoformalize)

`--max-cycles` and `--max-stuck-cycles` are per-claim. `--max-total-runtime` is per-session. The tracker is initialized once; before each claim call `start-claim`, after each completed claim call `reset-claim`. The final claim needs no trailing `reset-claim` — session totals (`cycles_total`, `stuck_cycles_total`, `deep_total`) are live-accumulated by `tick`/`deep`.

### Scope boundary

This is Phase 1–2 of #103. It does **not** close the issue fully. Phase 3 (shared argument parser replacing model-mediated parsing) is deferred to a follow-up PR.

## Test plan

- [ ] `bash plugins/lean4/tests/test_cycle_tracker.sh` — 174 tests
- [ ] `bash plugins/lean4/tests/test_guardrails.sh` — no regressions
- [ ] `LEAN4_PLUGIN_ROOT=$(pwd)/plugins/lean4 bash plugins/lean4/tools/test_contracts.sh`
- [ ] `LEAN4_PLUGIN_ROOT=$(pwd)/plugins/lean4 bash plugins/lean4/tools/lint_docs.sh`
- [ ] Manual: `/lean4:autoprove --max-cycles=2` on a file with sorries — verify Resolved Inputs block, tracker init, `tick` output at cycle boundaries, `LIMIT_REACHED` after 2 cycles, cleanup on stop
- [ ] Manual: `/lean4:autoformalize` on 2+ claims with `--max-cycles=1` — verify `start-claim`/`reset-claim` at claim boundaries, per-claim budget reset, `claims_attempted` includes current claim in `status`, session totals accumulate across claims
