### PR TITLE
lean4: add shared slash-command parser and UserPromptSubmit validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Lean 4 theorem proving with guided + autonomous proving, LSP-first workflows, guardrails, and contribution helpers",
-    "version": "4.4.8"
+    "version": "4.4.9"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v4.4.9 (April 2026)
+
+- Add shared slash-command parser and `UserPromptSubmit` hook for pre-validation of the six parameter-heavy commands (#103, #106) — Phase 3 of the command invocation fix
+- Honest invocation contract + `cycle_tracker.sh` session tracker for explicit stop budgets (#105) — Phase 1–2 of the command invocation fix
+- Warn about OOM from large dependent type signatures (#104)
+- Fix Bash 3.2 compatibility: replace `${suffix,,}` with portable `tr` lowercase in `cycle_tracker.sh` (macOS stock bash)
+
 ## v4.4.8 (April 2026)
 
 - Document one-concurrent-editor-per-file rule for proof agents (#64)

--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ others all use the same core skill; only the invocation surface differs.
 
 Typical session: `draft` (or `formalize` / `autoformalize`) → `prove` (or `autoprove`) → `review` → `refactor` → `golf` → `checkpoint` → `git push`.
 
-CLI-like inputs are model-parsed at command startup, not host-parsed. Commands
-must announce resolved inputs, reject invalid startup configs, and treat
-wall-clock budgets as best-effort rather than host-enforced timeouts. See the
+CLI-like inputs are validated by a host-agnostic parser
+(`plugins/lean4/lib/command_args/`) for the six parameter-heavy commands. The
+Claude Code adapter pre-validates `/lean4:*` prompts via a `UserPromptSubmit`
+hook; other hosts fall back to model-parsed startup. Commands must announce
+resolved inputs, reject invalid startup configs, and treat wall-clock budgets
+as best-effort rather than host-enforced timeouts. See the
 [Command Invocation Contract](plugins/lean4/skills/lean4/references/command-invocation.md).
 
 ## How It Works

--- a/plugins/lean4/.claude-plugin/plugin.json
+++ b/plugins/lean4/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lean4",
-  "version": "4.4.8",
+  "version": "4.4.9",
   "description": "Unified Lean 4 plugin (draft, formalize, autoformalize, prove, autoprove, checkpoint, review, refactor, golf, learn, doctor) — LSP-first, scripts fallback",
   "author": {"name": "Cameron Freer", "email": "cameronfreer@gmail.com"}
 }

--- a/plugins/lean4/README.md
+++ b/plugins/lean4/README.md
@@ -40,10 +40,20 @@ Unified Lean 4 plugin for theorem proving, interactive learning, and formalizati
 git push                   # Manual, after review
 ```
 
-CLI-like inputs are model-parsed at command startup, not host-parsed. Commands
-must echo resolved inputs, reject invalid startup configs before doing work, and
-treat wall-clock budgets as best-effort. See the
+This plugin ships a host-agnostic parser (`lib/command_args/`) that covers the
+parser-decidable startup rules of the six parameter-heavy commands. The Claude
+Code adapter pre-validates `/lean4:*` prompts via a `UserPromptSubmit` hook
+that reuses the same parser; other hosts MAY invoke it via
+`lib/scripts/parse_command_args.py` but otherwise fall back to model-parsed
+startup. Commands must announce resolved inputs, reject invalid startup configs
+before doing work, and treat wall-clock budgets as best-effort. See the
 [Command Invocation Contract](skills/lean4/references/command-invocation.md).
+
+To run the parser standalone (non-Claude hosts, scripting):
+
+    python3 plugins/lean4/lib/scripts/parse_command_args.py draft -- "topic" --mode=attempt
+
+Exits 0 on success (JSON to stdout), 2 on validation errors (error JSON to stdout).
 
 ## How It Works
 

--- a/plugins/lean4/commands/autoformalize.md
+++ b/plugins/lean4/commands/autoformalize.md
@@ -2,6 +2,7 @@
 name: autoformalize
 description: Autonomous end-to-end formalization from informal sources
 user_invocable: true
+argument-hint: '--source=PATH --claim-select=POLICY --out=PATH [--max-cycles=N] [--commit=auto|checkpoint]'
 ---
 
 # Lean4 Autoformalize
@@ -18,10 +19,19 @@ Autonomous end-to-end formalization: extracts claims from a source, drafts Lean 
 
 ## Invocation Contract
 
-Slash-command inputs are raw text. Before extracting claims or drafting
-anything, parse the raw invocation text using this command's input table and
-the
+Interpret this command's inputs per the
 [Command Invocation Contract](../skills/lean4/references/command-invocation.md).
+
+**Primary path (hook-validated):** If a `validated-invocation` block for this
+command appears in context, treat it as the authoritative interpretation of
+parser-decidable inputs and do **not** re-parse the raw invocation text for
+those inputs. Start by reading all parser-decided fields from the block. Emit
+the final **Resolved Inputs** summary from the block values.
+See [Validated Invocation Block](../skills/lean4/references/command-invocation.md#validated-invocation-block-host-provided).
+
+**Fallback path (other hosts):** If no `validated-invocation` block is present,
+parse the raw invocation text against this command's input table before
+extracting claims or drafting anything.
 
 Startup requirements:
 

--- a/plugins/lean4/commands/autoformalize.md
+++ b/plugins/lean4/commands/autoformalize.md
@@ -2,7 +2,7 @@
 name: autoformalize
 description: Autonomous end-to-end formalization from informal sources
 user_invocable: true
-argument-hint: '--source=PATH --claim-select=POLICY --out=PATH [--max-cycles=N] [--commit=auto|checkpoint]'
+argument-hint: '--source=PATH --claim-select=POLICY --out=PATH [--max-cycles=N] [--commit=auto|never]'
 ---
 
 # Lean4 Autoformalize

--- a/plugins/lean4/commands/autoprove.md
+++ b/plugins/lean4/commands/autoprove.md
@@ -2,7 +2,7 @@
 name: autoprove
 description: Autonomous multi-cycle theorem proving with explicit stop budgets
 user_invocable: true
-argument-hint: '[scope] [--max-cycles=N] [--max-total-runtime=DURATION] [--commit=auto|checkpoint] [--deep=never|stuck]'
+argument-hint: '[scope] [--max-cycles=N] [--max-total-runtime=DURATION] [--commit=auto|never] [--deep=never|stuck]'
 ---
 
 # Lean4 Autoprove

--- a/plugins/lean4/commands/autoprove.md
+++ b/plugins/lean4/commands/autoprove.md
@@ -2,6 +2,7 @@
 name: autoprove
 description: Autonomous multi-cycle theorem proving with explicit stop budgets
 user_invocable: true
+argument-hint: '[scope] [--max-cycles=N] [--max-total-runtime=DURATION] [--commit=auto|checkpoint] [--deep=never|stuck]'
 ---
 
 # Lean4 Autoprove
@@ -19,9 +20,19 @@ Autonomous multi-cycle theorem proving. Runs cycles automatically with explicit 
 
 ## Invocation Contract
 
-Slash-command inputs are raw text. Before Phase 1, parse the raw invocation
-text using this command's input table and the
+Interpret this command's inputs per the
 [Command Invocation Contract](../skills/lean4/references/command-invocation.md).
+
+**Primary path (hook-validated):** If a `validated-invocation` block for this
+command appears in context, treat it as the authoritative interpretation of
+parser-decidable inputs and do **not** re-parse the raw invocation text for
+those inputs. Start by reading all parser-decided fields from the block. Emit
+the final **Resolved Inputs** summary from the block values.
+See [Validated Invocation Block](../skills/lean4/references/command-invocation.md#validated-invocation-block-host-provided).
+
+**Fallback path (other hosts):** If no `validated-invocation` block is present,
+parse the raw invocation text against this command's input table before
+Phase 1.
 
 Startup requirements:
 

--- a/plugins/lean4/commands/draft.md
+++ b/plugins/lean4/commands/draft.md
@@ -2,6 +2,7 @@
 name: draft
 description: Draft Lean declaration skeletons from informal claims
 user_invocable: true
+argument-hint: '[topic] [--mode=skeleton|attempt] [--source=PATH] [--output=chat|scratch|file]'
 ---
 
 # Lean4 Draft
@@ -20,9 +21,19 @@ Draft Lean 4 declaration skeletons from informal mathematical claims. Produces s
 
 ## Invocation Contract
 
-Slash-command inputs are raw text. Before claim acquisition, parse the raw
-invocation text using this command's input table and the
+Interpret this command's inputs per the
 [Command Invocation Contract](../skills/lean4/references/command-invocation.md).
+
+**Primary path (hook-validated):** If a `validated-invocation` block for this
+command appears in context, treat it as the authoritative interpretation of
+parser-decidable inputs and do **not** re-parse the raw invocation text for
+those inputs. Start by reading all parser-decided fields from the block. Emit
+the final **Resolved Inputs** summary from the block values.
+See [Validated Invocation Block](../skills/lean4/references/command-invocation.md#validated-invocation-block-host-provided).
+
+**Fallback path (other hosts):** If no `validated-invocation` block is present,
+parse the raw invocation text against this command's input table before
+claim acquisition.
 
 Startup requirements:
 

--- a/plugins/lean4/commands/formalize.md
+++ b/plugins/lean4/commands/formalize.md
@@ -2,6 +2,7 @@
 name: formalize
 description: Interactive formalization — drafting plus guided proving
 user_invocable: true
+argument-hint: '[topic] [--rigor=axiomatic|sorry-free|best-effort] [--source=PATH] [--output=chat|scratch|file]'
 ---
 
 # Lean4 Formalize
@@ -22,9 +23,19 @@ Interactive formalization: draft Lean skeletons from informal claims, then prove
 
 ## Invocation Contract
 
-Slash-command inputs are raw text. Before drafting or proving, parse the raw
-invocation text using this command's input table and the
+Interpret this command's inputs per the
 [Command Invocation Contract](../skills/lean4/references/command-invocation.md).
+
+**Primary path (hook-validated):** If a `validated-invocation` block for this
+command appears in context, treat it as the authoritative interpretation of
+parser-decidable inputs and do **not** re-parse the raw invocation text for
+those inputs. Start by reading all parser-decided fields from the block. Emit
+the final **Resolved Inputs** summary from the block values.
+See [Validated Invocation Block](../skills/lean4/references/command-invocation.md#validated-invocation-block-host-provided).
+
+**Fallback path (other hosts):** If no `validated-invocation` block is present,
+parse the raw invocation text against this command's input table before
+drafting or proving.
 
 Startup requirements:
 

--- a/plugins/lean4/commands/formalize.md
+++ b/plugins/lean4/commands/formalize.md
@@ -2,7 +2,7 @@
 name: formalize
 description: Interactive formalization — drafting plus guided proving
 user_invocable: true
-argument-hint: '[topic] [--rigor=axiomatic|sorry-free|best-effort] [--source=PATH] [--output=chat|scratch|file]'
+argument-hint: '[topic] [--rigor=checked|sketch|axiomatic] [--source=PATH] [--output=chat|scratch|file]'
 ---
 
 # Lean4 Formalize

--- a/plugins/lean4/commands/learn.md
+++ b/plugins/lean4/commands/learn.md
@@ -2,7 +2,7 @@
 name: learn
 description: Interactive teaching and mathlib exploration
 user_invocable: true
-argument-hint: '[topic] [--mode=explore|guided|drill|mathlib] [--style=lecture|socratic|game] [--source=PATH]'
+argument-hint: '[topic] [--mode=auto|repo|mathlib] [--style=tour|socratic|exercise|game] [--source=PATH]'
 ---
 
 # Lean4 Learn

--- a/plugins/lean4/commands/learn.md
+++ b/plugins/lean4/commands/learn.md
@@ -2,6 +2,7 @@
 name: learn
 description: Interactive teaching and mathlib exploration
 user_invocable: true
+argument-hint: '[topic] [--mode=explore|guided|drill|mathlib] [--style=lecture|socratic|game] [--source=PATH]'
 ---
 
 # Lean4 Learn
@@ -25,9 +26,22 @@ Interactive teaching and mathlib exploration. Adapts to beginner, intermediate, 
 
 ## Invocation Contract
 
-Slash-command inputs are raw text. Before discovery begins, parse the raw
-invocation text using this command's input table and the
+Interpret this command's inputs per the
 [Command Invocation Contract](../skills/lean4/references/command-invocation.md).
+
+**Primary path (hook-validated):** If a `validated-invocation` block for this
+command appears in context, treat it as the authoritative interpretation of
+parser-decidable inputs and do **not** re-parse the raw invocation text for
+those inputs. Start by reading all parser-decided fields from the block. Then,
+if this command has repo-dependent startup rules (the `--mode=mathlib` scope
+coercion depends on local-declaration resolution), apply them using runtime
+context (LSP, grep). Emit the final **Resolved Inputs** summary from the
+combined result.
+See [Validated Invocation Block](../skills/lean4/references/command-invocation.md#validated-invocation-block-host-provided).
+
+**Fallback path (other hosts):** If no `validated-invocation` block is present,
+parse the raw invocation text against this command's input table before
+discovery.
 
 Startup requirements:
 

--- a/plugins/lean4/commands/prove.md
+++ b/plugins/lean4/commands/prove.md
@@ -2,7 +2,7 @@
 name: prove
 description: Guided cycle-by-cycle theorem proving with explicit checkpoints
 user_invocable: true
-argument-hint: '[scope] [--planning=ask|skip|always] [--deep=never|stuck|ask] [--commit=ask|auto|checkpoint]'
+argument-hint: '[scope] [--planning=ask|on|off] [--deep=never|stuck|ask] [--commit=ask|auto|never]'
 ---
 
 # Lean4 Prove

--- a/plugins/lean4/commands/prove.md
+++ b/plugins/lean4/commands/prove.md
@@ -2,6 +2,7 @@
 name: prove
 description: Guided cycle-by-cycle theorem proving with explicit checkpoints
 user_invocable: true
+argument-hint: '[scope] [--planning=ask|skip|always] [--deep=never|stuck|ask] [--commit=ask|auto|checkpoint]'
 ---
 
 # Lean4 Prove
@@ -19,9 +20,19 @@ Guided, cycle-by-cycle theorem proving. Asks before each cycle, supports deep es
 
 ## Invocation Contract
 
-Slash-command inputs are raw text. Before Phase 1, parse the raw invocation
-text using this command's input table and the
+Interpret this command's inputs per the
 [Command Invocation Contract](../skills/lean4/references/command-invocation.md).
+
+**Primary path (hook-validated):** If a `validated-invocation` block for this
+command appears in context, treat it as the authoritative interpretation of
+parser-decidable inputs and do **not** re-parse the raw invocation text for
+those inputs. Start by reading all parser-decided fields from the block. Emit
+the final **Resolved Inputs** summary from the block values.
+See [Validated Invocation Block](../skills/lean4/references/command-invocation.md#validated-invocation-block-host-provided).
+
+**Fallback path (other hosts):** If no `validated-invocation` block is present,
+parse the raw invocation text against this command's input table before
+Phase 1.
 
 Startup requirements:
 

--- a/plugins/lean4/hooks/hooks.json
+++ b/plugins/lean4/hooks/hooks.json
@@ -5,6 +5,9 @@
       "matcher": "startup",
       "hooks": [{"type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/bootstrap.sh", "timeout": 10}]
     }],
+    "UserPromptSubmit": [{
+      "hooks": [{"type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate_user_prompt.py", "timeout": 5}]
+    }],
     "PreToolUse": [{
       "matcher": "Bash",
       "hooks": [{"type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/guardrails.sh", "timeout": 5}]

--- a/plugins/lean4/hooks/validate_user_prompt.py
+++ b/plugins/lean4/hooks/validate_user_prompt.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Claude UserPromptSubmit hook for /lean4:* slash commands.
+
+Validates slash-command inputs before the model sees the prompt.
+Hard parse errors block the prompt; successful parses inject a
+validated-invocation block via additionalContext.
+
+Fails OPEN on any internal error — a Python bug must NEVER prevent
+a user from running a command.
+"""
+import json
+import os
+import sys
+
+# Resolve plugin root from CLAUDE_PLUGIN_ROOT (set by Claude Code at hook time)
+# or fall back to the script's own location when invoked directly.
+# hooks/validate_user_prompt.py -> dirname = hooks -> parent = plugin root.
+_PLUGIN_ROOT = os.environ.get("CLAUDE_PLUGIN_ROOT") or os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__))
+)
+_LIB_ROOT = os.path.join(_PLUGIN_ROOT, "lib")
+if _LIB_ROOT not in sys.path:
+    sys.path.insert(0, _LIB_ROOT)
+
+# Pre-import gate: only the six parser-covered commands go through the parser.
+# Uncovered commands pass through without importing command_args.
+_COVERED_COMMANDS = {"draft", "learn", "formalize", "autoformalize", "prove", "autoprove"}
+
+
+def _emit(obj: dict) -> None:
+    json.dump(obj, sys.stdout)
+    sys.stdout.write("\n")
+
+
+def _passthrough() -> None:
+    sys.exit(0)
+
+
+def _emit_warning(message: str) -> None:
+    _emit({
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": message,
+        }
+    })
+
+
+def main() -> None:
+    # 1. Read stdin JSON
+    try:
+        raw = sys.stdin.read()
+        if not raw.strip():
+            return _passthrough()
+        payload = json.loads(raw)
+    except Exception:
+        return _passthrough()
+
+    # 2. Check /lean4: prefix
+    prompt = (payload.get("prompt") or "").lstrip()
+    if not prompt.startswith("/lean4:"):
+        return _passthrough()
+
+    # 3. Extract command name
+    head, _, tail = prompt.partition(" ")
+    name = head[len("/lean4:"):]
+    if not name:
+        return _passthrough()
+
+    # 4. Pre-import covered-command gate
+    if name not in _COVERED_COMMANDS:
+        return _passthrough()
+
+    # 5. Import command_args (fail-open on import failure)
+    try:
+        from command_args import COMMAND_SPECS, parse_invocation, format_validated_block
+    except Exception:
+        return _emit_warning(
+            "[lean4 parser unavailable — fell back to model parsing. "
+            "Please report this as a bug.]"
+        )
+
+    # 6. Look up spec (defensive — should always succeed after gate)
+    spec = COMMAND_SPECS.get(name)
+    if spec is None:
+        return _passthrough()
+
+    # 7. Normalize cwd from payload
+    cwd = os.path.abspath(payload.get("cwd") or os.getcwd())
+
+    # 8. Run parser (fail-open on exception)
+    try:
+        result = parse_invocation(spec, tail, cwd=cwd)
+    except Exception:
+        return _emit_warning(
+            f"[lean4 parser crashed for /lean4:{name} — falling back to "
+            "model parsing. Stack trace suppressed.]"
+        )
+
+    # 9. Hard parse errors → block
+    if result.errors:
+        reason = f"Lean4 /{name} rejected:\n- " + "\n- ".join(result.errors)
+        return _emit({"decision": "block", "reason": reason})
+
+    # 10. Success → write artifact + emit validated block
+    session_id = payload.get("session_id")
+    if session_id:
+        try:
+            out_dir = os.environ.get("CLAUDE_SESSION_DIR") or os.path.join(
+                __import__("tempfile").gettempdir()
+            )
+            os.makedirs(out_dir, exist_ok=True)
+            artifact_path = os.path.join(out_dir, f"lean4_invocation_{session_id}.json")
+            with open(artifact_path, "w") as f:
+                json.dump(result.to_dict(), f)
+        except Exception:
+            pass  # artifact is best-effort
+
+    block = format_validated_block(result)
+    _emit({
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": block,
+        }
+    })
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/lean4/hooks/validate_user_prompt.py
+++ b/plugins/lean4/hooks/validate_user_prompt.py
@@ -60,8 +60,11 @@ def main() -> None:
     if not prompt.startswith("/lean4:"):
         return _passthrough()
 
-    # 3. Extract command name
-    head, _, tail = prompt.partition(" ")
+    # 3. Extract command name — split on any whitespace (space, tab, newline)
+    # so /lean4:draft<TAB>... and /lean4:draft<NEWLINE>... are handled.
+    parts = prompt.split(None, 1)
+    head = parts[0]
+    tail = parts[1] if len(parts) > 1 else ""
     name = head[len("/lean4:"):]
     if not name:
         return _passthrough()

--- a/plugins/lean4/lib/command_args/__init__.py
+++ b/plugins/lean4/lib/command_args/__init__.py
@@ -1,0 +1,46 @@
+"""Host-agnostic slash-command parser for the lean4 plugin.
+
+Public surface:
+    COMMAND_SPECS     - dict of per-command specs
+    parse_invocation  - runtime parser entry point
+    format_validated_block  - ParseResult -> fenced markdown
+    parse_validated_block   - fenced markdown -> ParseResult (inverse)
+    ParseContext, ParseResult, ResolvedFlag, FlagSpec, CommandSpec,
+    PositionalSpec, Coercion, CrossValidation, and Literal aliases.
+"""
+from .formatter import format_validated_block, parse_validated_block
+from .parser import parse_invocation
+from .specs import COMMAND_SPECS
+from .types import (
+    Coercion,
+    CommandSpec,
+    CrossValidation,
+    EnforcementClass,
+    FlagSpec,
+    FlagType,
+    ParseContext,
+    ParseResult,
+    PositionalSpec,
+    ResolvedFlag,
+    Severity,
+    Source,
+)
+
+__all__ = [
+    "COMMAND_SPECS",
+    "parse_invocation",
+    "format_validated_block",
+    "parse_validated_block",
+    "Coercion",
+    "CommandSpec",
+    "CrossValidation",
+    "EnforcementClass",
+    "FlagSpec",
+    "FlagType",
+    "ParseContext",
+    "ParseResult",
+    "PositionalSpec",
+    "ResolvedFlag",
+    "Severity",
+    "Source",
+]

--- a/plugins/lean4/lib/command_args/coercions.py
+++ b/plugins/lean4/lib/command_args/coercions.py
@@ -1,0 +1,654 @@
+"""Named coercion and cross-validation functions for all lean4 slash commands.
+
+Every function here encodes a parser-decidable rule documented in the
+command markdown files under ``plugins/lean4/commands/*.md``.
+
+**Naming convention:**
+
+* ``snake_case`` — bare callable (CoerceFn or ValidateFn).  These are what
+  ``Coercion.fn`` / ``CrossValidation.fn`` fields expect.
+* ``UPPER_CASE`` — the corresponding ``Coercion`` or ``CrossValidation``
+  record, ready to attach to a ``FlagSpec`` or ``CommandSpec``.
+
+Coercion functions have signature:
+    (value, options, ctx) -> (new_value, optional_note)
+
+Validation functions have signature:
+    (options, ctx) -> list[str]
+"""
+from __future__ import annotations
+
+import os
+from typing import Mapping
+
+from .types import Coercion, CrossValidation, ParseContext
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Coercion callables + records
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+# -- commit_ask_to_auto ----------------------------------------------------
+
+def commit_ask_to_auto(
+    value: object, options: Mapping[str, object], ctx: ParseContext,
+) -> tuple[object, str | None]:
+    """autoprove: --commit=ask -> auto (no interactive prompting)."""
+    if value == "ask":
+        return (
+            "auto",
+            "\u26a0 --commit=ask requires interactive confirmation. "
+            "Using auto for unattended operation.",
+        )
+    return value, None
+
+
+COMMIT_ASK_TO_AUTO = Coercion(
+    rule_id="commit_ask_to_auto",
+    fn=commit_ask_to_auto,
+    doc_phrases=(
+        "--commit=ask requires interactive confirmation",
+        "ask` coerced to `auto",
+    ),
+    summary="autoprove: coerce --commit=ask to auto for unattended operation",
+)
+
+
+# -- review_source_external_to_internal ------------------------------------
+
+def review_source_external_to_internal(
+    value: object, options: Mapping[str, object], ctx: ParseContext,
+) -> tuple[object, str | None]:
+    """autoprove/autoformalize: --review-source=external|both -> internal."""
+    if value in ("external", "both"):
+        return (
+            "internal",
+            f"\u26a0 --review-source={value} requires interactive handoff. "
+            "Using internal review for unattended operation.",
+        )
+    return value, None
+
+
+REVIEW_SOURCE_EXTERNAL_TO_INTERNAL = Coercion(
+    rule_id="review_source_external_to_internal",
+    fn=review_source_external_to_internal,
+    doc_phrases=(
+        "--review-source=external requires interactive handoff",
+        "coerces to `internal`",
+    ),
+    summary="autoprove/autoformalize: coerce external/both review to internal",
+)
+
+
+# -- deep_ask_to_stuck -----------------------------------------------------
+
+def deep_ask_to_stuck(
+    value: object, options: Mapping[str, object], ctx: ParseContext,
+) -> tuple[object, str | None]:
+    """autoprove: --deep=ask -> stuck (no interactive prompting)."""
+    if value == "ask":
+        return (
+            "stuck",
+            "\u26a0 --deep=ask requires interactive prompting. "
+            "Using stuck for unattended operation.",
+        )
+    return value, None
+
+
+DEEP_ASK_TO_STUCK = Coercion(
+    rule_id="deep_ask_to_stuck",
+    fn=deep_ask_to_stuck,
+    doc_phrases=(
+        "`ask` coerced to `stuck`",
+        "ask` is coerced to `stuck`",
+    ),
+    summary="autoprove: coerce --deep=ask to stuck for unattended operation",
+)
+
+
+# -- deep_rollback_safety --------------------------------------------------
+
+def deep_rollback_safety(
+    value: object, options: Mapping[str, object], ctx: ParseContext,
+) -> tuple[object, str | None]:
+    """autoprove: --deep-rollback=never -> on-regression (safety)."""
+    if value == "never":
+        return (
+            "on-regression",
+            "\u26a0 --deep-rollback=never is unsafe for autonomous operation. "
+            "Coerced to on-regression.",
+        )
+    return value, None
+
+
+DEEP_ROLLBACK_SAFETY = Coercion(
+    rule_id="deep_rollback_safety",
+    fn=deep_rollback_safety,
+    doc_phrases=(
+        "--deep-rollback=never",
+        "coerced to `on-regression`",
+    ),
+    summary="autoprove: coerce --deep-rollback=never to on-regression",
+)
+
+
+# -- deep_regression_gate_safety -------------------------------------------
+
+def deep_regression_gate_safety(
+    value: object, options: Mapping[str, object], ctx: ParseContext,
+) -> tuple[object, str | None]:
+    """autoprove: --deep-regression-gate=off -> strict (safety)."""
+    if value == "off":
+        return (
+            "strict",
+            "\u26a0 --deep-regression-gate=off is unsafe for autonomous operation. "
+            "Coerced to strict.",
+        )
+    return value, None
+
+
+DEEP_REGRESSION_GATE_SAFETY = Coercion(
+    rule_id="deep_regression_gate_safety",
+    fn=deep_regression_gate_safety,
+    doc_phrases=(
+        "--deep-regression-gate=off",
+        "coerced to `strict`",
+    ),
+    summary="autoprove: coerce --deep-regression-gate=off to strict",
+)
+
+
+# -- intent_auto_collapse --------------------------------------------------
+
+def intent_auto_collapse(
+    value: object, options: Mapping[str, object], ctx: ParseContext,
+) -> tuple[object, str | None]:
+    """draft/formalize: --intent=auto -> usage (collapse internals/authoring).
+
+    After inference, draft/formalize coerce internals/authoring to usage.
+    At the parser level, auto is coerced to usage since the inference step
+    will happen at runtime; the parser pre-collapses to usage.
+    """
+    if value == "auto":
+        return (
+            "usage",
+            "\u26a0 --intent=auto coerced to usage "
+            "(internals/authoring not defined for this command).",
+        )
+    if value in ("internals", "authoring"):
+        return (
+            "usage",
+            f"\u26a0 --intent={value} coerced to usage "
+            "(not defined for this command).",
+        )
+    return value, None
+
+
+INTENT_AUTO_COLLAPSE = Coercion(
+    rule_id="intent_auto_collapse",
+    fn=intent_auto_collapse,
+    doc_phrases=(
+        "coerce `internals` \u2192 `usage` and `authoring` \u2192 `usage`",
+        "intent=auto` inference",
+    ),
+    summary="draft/formalize: collapse --intent=auto/internals/authoring to usage",
+)
+
+
+# -- track_without_game_ignore ---------------------------------------------
+
+def track_without_game_ignore(
+    value: object, options: Mapping[str, object], ctx: ParseContext,
+) -> tuple[object, str | None]:
+    """learn: --track without --style=game -> coerce to None (warn + ignore)."""
+    style = options.get("--style")
+    if value is not None and style != "game":
+        return (
+            None,
+            "\u26a0 --track is only valid with --style=game. Ignored.",
+        )
+    return value, None
+
+
+TRACK_WITHOUT_GAME_IGNORE = Coercion(
+    rule_id="track_without_game_ignore",
+    fn=track_without_game_ignore,
+    doc_phrases=(
+        "--track` without `--style=game` \u2192 warn + ignore",
+        "--track` without `--style=game`",
+    ),
+    summary="learn: ignore --track when --style is not game",
+)
+
+
+# -- scope_mathlib_coerce --------------------------------------------------
+
+def scope_mathlib_coerce(
+    value: object, options: Mapping[str, object], ctx: ParseContext,
+) -> tuple[object, str | None]:
+    """learn: --mode=mathlib + --scope=file|changed|project -> coerce to topic."""
+    mode = options.get("--mode")
+    if mode == "mathlib" and value in ("file", "changed", "project"):
+        return (
+            "topic",
+            f"\u26a0 --scope={value} is not compatible with --mode=mathlib. "
+            "Coerced to topic.",
+        )
+    return value, None
+
+
+SCOPE_MATHLIB_COERCE = Coercion(
+    rule_id="scope_mathlib_coerce",
+    fn=scope_mathlib_coerce,
+    doc_phrases=(
+        "--mode=mathlib` + `--scope=file|changed|project` \u2192 warn + coerce to `topic`",
+    ),
+    summary="learn: coerce scope to topic when mode is mathlib",
+)
+
+
+# -- interactive_without_socratic_ignore -----------------------------------
+
+def interactive_without_socratic_ignore(
+    value: object, options: Mapping[str, object], ctx: ParseContext,
+) -> tuple[object, str | None]:
+    """learn: --interactive without --style=socratic -> coerce to False."""
+    style = options.get("--style")
+    if value is True and style != "socratic":
+        return (
+            False,
+            "\u26a0 --interactive is only valid with --style=socratic. Ignored.",
+        )
+    return value, None
+
+
+INTERACTIVE_WITHOUT_SOCRATIC_IGNORE = Coercion(
+    rule_id="interactive_without_socratic_ignore",
+    fn=interactive_without_socratic_ignore,
+    doc_phrases=(
+        "Valid only with `--style=socratic`; ignored with warning otherwise",
+    ),
+    summary="learn: ignore --interactive when --style is not socratic",
+)
+
+
+# -- formalize_statement_policy_coerce -------------------------------------
+
+def formalize_statement_policy_coerce(
+    value: object, options: Mapping[str, object], ctx: ParseContext,
+) -> tuple[object, str | None]:
+    """autoprove: --formalize=restage|auto with --statement-policy=preserve
+    -> coerce to rewrite-generated-only."""
+    formalize = options.get("--formalize")
+    if formalize in ("restage", "auto") and value == "preserve":
+        return (
+            "rewrite-generated-only",
+            "\u26a0 --statement-policy=preserve with --formalize="
+            f"{formalize} coerced to rewrite-generated-only.",
+        )
+    return value, None
+
+
+FORMALIZE_STATEMENT_POLICY_COERCE = Coercion(
+    rule_id="formalize_statement_policy_coerce",
+    fn=formalize_statement_policy_coerce,
+    doc_phrases=(
+        "coerces `preserve` \u2192 `rewrite-generated-only`",
+        "--formalize=restage|auto` with default `--statement-policy`",
+    ),
+    summary="autoprove: coerce statement-policy from preserve when formalize active",
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Cross-validation callables + records
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+# -- topic_or_source_required ----------------------------------------------
+
+def topic_or_source_required(
+    options: Mapping[str, object], ctx: ParseContext,
+) -> list[str]:
+    """draft/formalize: at least one of topic or --source must be given.
+
+    The parser stores positionals separately from options.  The positional
+    ``topic`` presence is conveyed via the ``__positional_topic`` sentinel
+    that the parser injects into the flags mapping at cross-validation time.
+    """
+    source = options.get("--source")
+    topic_present = bool(options.get("__positional_topic"))
+    if not source and not topic_present:
+        return ["At least one of topic or --source must be given."]
+    return []
+
+
+TOPIC_OR_SOURCE_REQUIRED = CrossValidation(
+    rule_id="topic_or_source_required",
+    fn=topic_or_source_required,
+    severity="error",
+    doc_phrases=(
+        "At least one of `topic` or `--source` must be given",
+        "omitting both is a startup validation error",
+    ),
+    summary="draft/formalize: require topic or --source",
+)
+
+
+# -- output_file_requires_out ----------------------------------------------
+
+def output_file_requires_out(
+    options: Mapping[str, object], ctx: ParseContext,
+) -> list[str]:
+    """draft/learn/formalize: --output=file without --out -> error."""
+    output = options.get("--output")
+    out = options.get("--out")
+    if output == "file" and not out:
+        return ["--output=file requires --out to specify the target path."]
+    return []
+
+
+OUTPUT_FILE_REQUIRES_OUT = CrossValidation(
+    rule_id="output_file_requires_out",
+    fn=output_file_requires_out,
+    severity="error",
+    doc_phrases=(
+        "--output=file` without `--out` \u2192 startup validation error",
+        "Required when `--output=file`",
+    ),
+    summary="--output=file requires --out path",
+)
+
+
+# -- output_file_overwrite_check -------------------------------------------
+
+def output_file_overwrite_check(
+    options: Mapping[str, object], ctx: ParseContext,
+) -> list[str]:
+    """--output=file + existing target + no --overwrite -> error."""
+    output = options.get("--output")
+    out = options.get("--out")
+    overwrite = options.get("--overwrite")
+    if output == "file" and out:
+        target = os.path.join(ctx.cwd, str(out))
+        if os.path.exists(target) and not overwrite:
+            return [
+                f"--output=file target {out!s} already exists. "
+                "Use --overwrite to replace it."
+            ]
+    return []
+
+
+OUTPUT_FILE_OVERWRITE_CHECK = CrossValidation(
+    rule_id="output_file_overwrite_check",
+    fn=output_file_overwrite_check,
+    severity="error",
+    doc_phrases=(
+        "--output=file` with existing target and no `--overwrite` \u2192 startup validation error",
+        "existing target \u2192 startup validation error",
+    ),
+    summary="block file overwrite without --overwrite flag",
+)
+
+
+# -- statement_policy_preserve_warning -------------------------------------
+
+def statement_policy_preserve_warning(
+    options: Mapping[str, object], ctx: ParseContext,
+) -> list[str]:
+    """autoformalize/autoprove: --statement-policy=preserve -> warn."""
+    policy = options.get("--statement-policy")
+    if policy == "preserve":
+        return [
+            "\u26a0 --statement-policy=preserve: stuck redraft path becomes "
+            "manual intervention, not automatic rewrite."
+        ]
+    return []
+
+
+STATEMENT_POLICY_PRESERVE_WARNING = CrossValidation(
+    rule_id="statement_policy_preserve_warning",
+    fn=statement_policy_preserve_warning,
+    severity="warning",
+    doc_phrases=(
+        "--statement-policy=preserve` is respected but warns",
+        "stuck redraft path becomes manual intervention",
+    ),
+    summary="warn that preserve policy limits autonomous redrafting",
+)
+
+
+# -- source_overrides_scope_warning ----------------------------------------
+
+def source_overrides_scope_warning(
+    options: Mapping[str, object], ctx: ParseContext,
+) -> list[str]:
+    """learn: --source + --scope=file|changed|project -> warn."""
+    source = options.get("--source")
+    scope = options.get("--scope")
+    if source and scope in ("file", "changed", "project"):
+        return ["\u26a0 --source overrides --scope for initial discovery."]
+    return []
+
+
+SOURCE_OVERRIDES_SCOPE_WARNING = CrossValidation(
+    rule_id="source_overrides_scope_warning",
+    fn=source_overrides_scope_warning,
+    severity="warning",
+    doc_phrases=(
+        "--source` + `--scope=file|changed|project` \u2192 warn",
+        "source overrides scope for initial discovery",
+    ),
+    summary="learn: warn that --source overrides --scope",
+)
+
+
+# -- claim_select_requires_source ------------------------------------------
+
+def claim_select_requires_source(
+    options: Mapping[str, object], ctx: ParseContext,
+) -> list[str]:
+    """draft/formalize: --claim-select without --source -> error."""
+    claim_select = options.get("--claim-select")
+    source = options.get("--source")
+    if claim_select is not None and not source:
+        return ["--claim-select requires --source (nothing to select from)."]
+    return []
+
+
+CLAIM_SELECT_REQUIRES_SOURCE = CrossValidation(
+    rule_id="claim_select_requires_source",
+    fn=claim_select_requires_source,
+    severity="error",
+    doc_phrases=(
+        "--claim-select` without `--source` \u2192 startup validation error",
+        "nothing to select from",
+    ),
+    summary="--claim-select requires --source",
+)
+
+
+# -- formalize_auto_requires_source ----------------------------------------
+
+def formalize_auto_requires_source(
+    options: Mapping[str, object], ctx: ParseContext,
+) -> list[str]:
+    """autoprove: --formalize=auto requires --source."""
+    formalize = options.get("--formalize")
+    source = options.get("--source")
+    if formalize == "auto" and not source:
+        return ["--formalize=auto requires --source."]
+    return []
+
+
+FORMALIZE_AUTO_REQUIRES_SOURCE = CrossValidation(
+    rule_id="formalize_auto_requires_source",
+    fn=formalize_auto_requires_source,
+    severity="error",
+    doc_phrases=("--formalize=auto` requires `--source`",),
+    summary="autoprove: --formalize=auto requires --source",
+)
+
+
+# -- formalize_auto_requires_claim_select ----------------------------------
+
+def formalize_auto_requires_claim_select(
+    options: Mapping[str, object], ctx: ParseContext,
+) -> list[str]:
+    """autoprove: --formalize=auto with --source requires --claim-select."""
+    formalize = options.get("--formalize")
+    source = options.get("--source")
+    claim_select = options.get("--claim-select")
+    if formalize == "auto" and source and not claim_select:
+        return ["--formalize=auto with --source requires --claim-select."]
+    return []
+
+
+FORMALIZE_AUTO_REQUIRES_CLAIM_SELECT = CrossValidation(
+    rule_id="formalize_auto_requires_claim_select",
+    fn=formalize_auto_requires_claim_select,
+    severity="error",
+    doc_phrases=(
+        "--formalize=auto` with `--source` requires `--claim-select`",
+        "no unattended guessing",
+    ),
+    summary="autoprove: --formalize=auto requires --claim-select",
+)
+
+
+# -- formalize_auto_requires_out -------------------------------------------
+
+def formalize_auto_requires_out(
+    options: Mapping[str, object], ctx: ParseContext,
+) -> list[str]:
+    """autoprove: --formalize=auto requires --formalize-out."""
+    formalize = options.get("--formalize")
+    out = options.get("--formalize-out")
+    if formalize == "auto" and not out:
+        return [
+            "--formalize=auto requires --formalize-out when no existing "
+            "target file is in scope."
+        ]
+    return []
+
+
+FORMALIZE_AUTO_REQUIRES_OUT = CrossValidation(
+    rule_id="formalize_auto_requires_out",
+    fn=formalize_auto_requires_out,
+    severity="error",
+    doc_phrases=("--formalize=auto` requires `--formalize-out`",),
+    summary="autoprove: --formalize=auto requires --formalize-out",
+)
+
+
+# -- formalize_restage_source_warning --------------------------------------
+
+def formalize_restage_source_warning(
+    options: Mapping[str, object], ctx: ParseContext,
+) -> list[str]:
+    """autoprove: --formalize=restage + --source -> warn (source ignored)."""
+    formalize = options.get("--formalize")
+    source = options.get("--source")
+    if formalize == "restage" and source:
+        return ["\u26a0 --source is ignored with --formalize=restage."]
+    return []
+
+
+FORMALIZE_RESTAGE_SOURCE_WARNING = CrossValidation(
+    rule_id="formalize_restage_source_warning",
+    fn=formalize_restage_source_warning,
+    severity="warning",
+    doc_phrases=(
+        "--formalize=restage` does NOT require `--source`",
+        "`--source` is ignored if provided (warn)",
+    ),
+    summary="autoprove: warn that --source is ignored with --formalize=restage",
+)
+
+
+# -- formalize_never_source_warning ----------------------------------------
+
+def formalize_never_source_warning(
+    options: Mapping[str, object], ctx: ParseContext,
+) -> list[str]:
+    """autoprove: --formalize=never + --source -> warn (source ignored)."""
+    formalize = options.get("--formalize")
+    source = options.get("--source")
+    if formalize == "never" and source:
+        return ["\u26a0 --source is ignored without --formalize."]
+    return []
+
+
+FORMALIZE_NEVER_SOURCE_WARNING = CrossValidation(
+    rule_id="formalize_never_source_warning",
+    fn=formalize_never_source_warning,
+    severity="warning",
+    doc_phrases=("--formalize=never` ignores `--source` (warn if provided)",),
+    summary="autoprove: warn that --source is ignored without --formalize",
+)
+
+
+# -- autoformalize_source_required -----------------------------------------
+
+def autoformalize_source_required(
+    options: Mapping[str, object], ctx: ParseContext,
+) -> list[str]:
+    """autoformalize: --source is required."""
+    source = options.get("--source")
+    if not source:
+        return ["--source is required for autoformalize."]
+    return []
+
+
+AUTOFORMALIZE_SOURCE_REQUIRED = CrossValidation(
+    rule_id="autoformalize_source_required",
+    fn=autoformalize_source_required,
+    severity="error",
+    doc_phrases=("--source` is required",),
+    summary="autoformalize: require --source",
+)
+
+
+# -- autoformalize_claim_select_required -----------------------------------
+
+def autoformalize_claim_select_required(
+    options: Mapping[str, object], ctx: ParseContext,
+) -> list[str]:
+    """autoformalize: --claim-select is required."""
+    claim_select = options.get("--claim-select")
+    if not claim_select:
+        return ["--claim-select is required for autoformalize."]
+    return []
+
+
+AUTOFORMALIZE_CLAIM_SELECT_REQUIRED = CrossValidation(
+    rule_id="autoformalize_claim_select_required",
+    fn=autoformalize_claim_select_required,
+    severity="error",
+    doc_phrases=(
+        "--claim-select` is required",
+        "no unattended guessing",
+    ),
+    summary="autoformalize: require --claim-select",
+)
+
+
+# -- autoformalize_out_required --------------------------------------------
+
+def autoformalize_out_required(
+    options: Mapping[str, object], ctx: ParseContext,
+) -> list[str]:
+    """autoformalize: --out is required."""
+    out = options.get("--out")
+    if not out:
+        return ["--out is required for autoformalize."]
+    return []
+
+
+AUTOFORMALIZE_OUT_REQUIRED = CrossValidation(
+    rule_id="autoformalize_out_required",
+    fn=autoformalize_out_required,
+    severity="error",
+    doc_phrases=("--out` is required",),
+    summary="autoformalize: require --out",
+)

--- a/plugins/lean4/lib/command_args/formatter.py
+++ b/plugins/lean4/lib/command_args/formatter.py
@@ -1,0 +1,152 @@
+"""Format ParseResult as a validated-invocation block and parse it back."""
+from __future__ import annotations
+
+from .types import EnforcementClass, ParseResult, ResolvedFlag, Source
+
+
+def format_validated_block(result: ParseResult) -> str:
+    """Serialize a ParseResult into a fenced validated-invocation markdown block."""
+    lines: list[str] = []
+    lines.append("```validated-invocation")
+    lines.append(f"command: {result.command}")
+    lines.append(f"raw_tail: {result.raw_tail}")
+
+    # Positionals
+    lines.append("positionals:")
+    if result.positionals:
+        for name, value in result.positionals.items():
+            lines.append(f"  {name}: {value}")
+    else:
+        lines.append("  (none)")
+
+    # Options — structured per-flag entries
+    lines.append("options:")
+    for name, rf in result.options.items():
+        lines.append(f"  {name}:")
+        lines.append(f"    value: {_format_value(rf.value)}")
+        lines.append(f"    source: {rf.source}")
+        lines.append(f"    enforcement: {rf.enforcement}")
+        if rf.coerced_from is not None:
+            lines.append(f"    coerced_from: {_format_value(rf.coerced_from)}")
+
+    # Coercions
+    lines.append("coercions:")
+    if result.coercions:
+        for note in result.coercions:
+            lines.append(f"  - {note}")
+    else:
+        lines.append("  (none)")
+
+    # Warnings
+    lines.append("warnings:")
+    if result.warnings:
+        for note in result.warnings:
+            lines.append(f"  - {note}")
+    else:
+        lines.append("  (none)")
+
+    # Errors
+    lines.append(f"errors: {result.errors!r}")
+
+    lines.append("```")
+    return "\n".join(lines)
+
+
+def parse_validated_block(text: str) -> ParseResult:
+    """Parse a validated-invocation fenced block back into a ParseResult.
+
+    This is the exact inverse of format_validated_block.
+    """
+    # Extract the block content between the fences
+    block_lines = _extract_block_lines(text)
+
+    result = ParseResult(command="", raw_tail="")
+    section = None
+
+    i = 0
+    while i < len(block_lines):
+        line = block_lines[i]
+
+        if line.startswith("command: "):
+            result.command = line[len("command: "):]
+        elif line.startswith("raw_tail: "):
+            result.raw_tail = line[len("raw_tail: "):]
+        elif line == "positionals:":
+            section = "positionals"
+        elif line == "options:":
+            section = "options"
+        elif line == "coercions:":
+            section = "coercions"
+        elif line == "warnings:":
+            section = "warnings"
+        elif line.startswith("errors: "):
+            import ast
+            result.errors = ast.literal_eval(line[len("errors: "):])
+        elif section == "positionals" and line.startswith("  ") and line.strip() != "(none)":
+            key, _, val = line.strip().partition(": ")
+            result.positionals[key] = val
+        elif section == "options" and line.startswith("  ") and not line.startswith("    "):
+            # New flag entry
+            flag_name = line.strip().rstrip(":")
+            flag_data: dict[str, str] = {}
+            i += 1
+            while i < len(block_lines) and block_lines[i].startswith("    "):
+                sub_line = block_lines[i].strip()
+                sub_key, _, sub_val = sub_line.partition(": ")
+                flag_data[sub_key] = sub_val
+                i += 1
+            result.options[flag_name] = ResolvedFlag(
+                value=_parse_value(flag_data.get("value", "None")),
+                source=flag_data.get("source", "default"),  # type: ignore[arg-type]
+                enforcement=flag_data.get("enforcement", "startup-validated"),  # type: ignore[arg-type]
+                coerced_from=_parse_value(flag_data["coerced_from"]) if "coerced_from" in flag_data else None,
+            )
+            continue  # already advanced i past the sub-entries
+        elif section == "coercions" and line.startswith("  - "):
+            result.coercions.append(line[4:])
+        elif section == "warnings" and line.startswith("  - "):
+            result.warnings.append(line[4:])
+
+        i += 1
+
+    return result
+
+
+def _extract_block_lines(text: str) -> list[str]:
+    """Extract lines between ```validated-invocation and ``` fences."""
+    lines = text.split("\n")
+    in_block = False
+    block_lines: list[str] = []
+    for line in lines:
+        if line.strip() == "```validated-invocation":
+            in_block = True
+            continue
+        if in_block and line.strip() == "```":
+            break
+        if in_block:
+            block_lines.append(line)
+    return block_lines
+
+
+def _format_value(v: object) -> str:
+    """Format a value for the block. None becomes 'None', strings are unquoted."""
+    if v is None:
+        return "None"
+    if isinstance(v, bool):
+        return str(v).lower()
+    return str(v)
+
+
+def _parse_value(s: str) -> object:
+    """Parse a value string from the block back into a Python object."""
+    if s == "None":
+        return None
+    if s == "true":
+        return True
+    if s == "false":
+        return False
+    try:
+        return int(s)
+    except ValueError:
+        pass
+    return s

--- a/plugins/lean4/lib/command_args/formatter.py
+++ b/plugins/lean4/lib/command_args/formatter.py
@@ -1,122 +1,60 @@
-"""Format ParseResult as a validated-invocation block and parse it back."""
+"""Format ParseResult as a validated-invocation block and parse it back.
+
+The block is a fenced markdown block with the label ``validated-invocation``
+containing pretty-printed JSON from ``result.to_dict()``. Using real JSON
+inside the fence eliminates the ad-hoc escaping problems of the previous
+line-based format (multiline input, embedded fences, string/int ambiguity).
+"""
 from __future__ import annotations
 
-from .types import EnforcementClass, ParseResult, ResolvedFlag, Source
+import json
+
+from .types import ParseResult, ResolvedFlag
 
 
 def format_validated_block(result: ParseResult) -> str:
-    """Serialize a ParseResult into a fenced validated-invocation markdown block."""
-    lines: list[str] = []
-    lines.append("```validated-invocation")
-    lines.append(f"command: {result.command}")
-    lines.append(f"raw_tail: {result.raw_tail}")
+    """Serialize a ParseResult into a fenced validated-invocation block.
 
-    # Positionals
-    lines.append("positionals:")
-    if result.positionals:
-        for name, value in result.positionals.items():
-            lines.append(f"  {name}: {value}")
-    else:
-        lines.append("  (none)")
-
-    # Options — structured per-flag entries
-    lines.append("options:")
-    for name, rf in result.options.items():
-        lines.append(f"  {name}:")
-        lines.append(f"    value: {_format_value(rf.value)}")
-        lines.append(f"    source: {rf.source}")
-        lines.append(f"    enforcement: {rf.enforcement}")
-        if rf.coerced_from is not None:
-            lines.append(f"    coerced_from: {_format_value(rf.coerced_from)}")
-
-    # Coercions
-    lines.append("coercions:")
-    if result.coercions:
-        for note in result.coercions:
-            lines.append(f"  - {note}")
-    else:
-        lines.append("  (none)")
-
-    # Warnings
-    lines.append("warnings:")
-    if result.warnings:
-        for note in result.warnings:
-            lines.append(f"  - {note}")
-    else:
-        lines.append("  (none)")
-
-    # Errors
-    lines.append(f"errors: {result.errors!r}")
-
-    lines.append("```")
-    return "\n".join(lines)
+    The block body is pretty-printed JSON from ``result.to_dict()``.
+    """
+    body = json.dumps(result.to_dict(), indent=2, ensure_ascii=False)
+    return f"```validated-invocation\n{body}\n```"
 
 
 def parse_validated_block(text: str) -> ParseResult:
     """Parse a validated-invocation fenced block back into a ParseResult.
 
-    This is the exact inverse of format_validated_block.
+    This is the exact inverse of ``format_validated_block``.
     """
-    # Extract the block content between the fences
-    block_lines = _extract_block_lines(text)
+    json_str = _extract_block_body(text)
+    data = json.loads(json_str)
 
-    result = ParseResult(command="", raw_tail="")
-    section = None
+    positionals: dict[str, str] = data.get("positionals", {})
+    options: dict[str, ResolvedFlag] = {}
+    for name, rf_data in data.get("options", {}).items():
+        options[name] = ResolvedFlag(
+            value=rf_data["value"],
+            source=rf_data["source"],
+            enforcement=rf_data["enforcement"],
+            coerced_from=rf_data.get("coerced_from"),
+        )
 
-    i = 0
-    while i < len(block_lines):
-        line = block_lines[i]
-
-        if line.startswith("command: "):
-            result.command = line[len("command: "):]
-        elif line.startswith("raw_tail: "):
-            result.raw_tail = line[len("raw_tail: "):]
-        elif line == "positionals:":
-            section = "positionals"
-        elif line == "options:":
-            section = "options"
-        elif line == "coercions:":
-            section = "coercions"
-        elif line == "warnings:":
-            section = "warnings"
-        elif line.startswith("errors: "):
-            import ast
-            result.errors = ast.literal_eval(line[len("errors: "):])
-        elif section == "positionals" and line.startswith("  ") and line.strip() != "(none)":
-            key, _, val = line.strip().partition(": ")
-            result.positionals[key] = val
-        elif section == "options" and line.startswith("  ") and not line.startswith("    "):
-            # New flag entry
-            flag_name = line.strip().rstrip(":")
-            flag_data: dict[str, str] = {}
-            i += 1
-            while i < len(block_lines) and block_lines[i].startswith("    "):
-                sub_line = block_lines[i].strip()
-                sub_key, _, sub_val = sub_line.partition(": ")
-                flag_data[sub_key] = sub_val
-                i += 1
-            result.options[flag_name] = ResolvedFlag(
-                value=_parse_value(flag_data.get("value", "None")),
-                source=flag_data.get("source", "default"),  # type: ignore[arg-type]
-                enforcement=flag_data.get("enforcement", "startup-validated"),  # type: ignore[arg-type]
-                coerced_from=_parse_value(flag_data["coerced_from"]) if "coerced_from" in flag_data else None,
-            )
-            continue  # already advanced i past the sub-entries
-        elif section == "coercions" and line.startswith("  - "):
-            result.coercions.append(line[4:])
-        elif section == "warnings" and line.startswith("  - "):
-            result.warnings.append(line[4:])
-
-        i += 1
-
-    return result
+    return ParseResult(
+        command=data["command"],
+        raw_tail=data["raw_tail"],
+        positionals=positionals,
+        options=options,
+        coercions=data.get("coercions", []),
+        warnings=data.get("warnings", []),
+        errors=data.get("errors", []),
+    )
 
 
-def _extract_block_lines(text: str) -> list[str]:
-    """Extract lines between ```validated-invocation and ``` fences."""
+def _extract_block_body(text: str) -> str:
+    """Extract the JSON body between ```validated-invocation and ``` fences."""
     lines = text.split("\n")
     in_block = False
-    block_lines: list[str] = []
+    body_lines: list[str] = []
     for line in lines:
         if line.strip() == "```validated-invocation":
             in_block = True
@@ -124,41 +62,7 @@ def _extract_block_lines(text: str) -> list[str]:
         if in_block and line.strip() == "```":
             break
         if in_block:
-            block_lines.append(line)
-    return block_lines
-
-
-def _format_value(v: object) -> str:
-    """Format a value for the block with unambiguous type encoding.
-
-    Strings are double-quoted so they survive round-trip without being
-    reinterpreted as None, bool, or int. This makes the block a truly
-    lossless serialization: draft --source=123 stays the string "123",
-    not the integer 123.
-    """
-    if v is None:
-        return "None"
-    if isinstance(v, bool):
-        return str(v).lower()
-    if isinstance(v, int):
-        return str(v)
-    # All strings are quoted to prevent ambiguity with None/true/false/int
-    return f'"{v}"'
-
-
-def _parse_value(s: str) -> object:
-    """Parse a value string from the block back into a Python object."""
-    if s == "None":
-        return None
-    if s == "true":
-        return True
-    if s == "false":
-        return False
-    # Quoted string — strip quotes and return as str
-    if len(s) >= 2 and s.startswith('"') and s.endswith('"'):
-        return s[1:-1]
-    try:
-        return int(s)
-    except ValueError:
-        pass
-    return s
+            body_lines.append(line)
+    if not body_lines:
+        raise ValueError("No validated-invocation block found in text")
+    return "\n".join(body_lines)

--- a/plugins/lean4/lib/command_args/formatter.py
+++ b/plugins/lean4/lib/command_args/formatter.py
@@ -129,12 +129,21 @@ def _extract_block_lines(text: str) -> list[str]:
 
 
 def _format_value(v: object) -> str:
-    """Format a value for the block. None becomes 'None', strings are unquoted."""
+    """Format a value for the block with unambiguous type encoding.
+
+    Strings are double-quoted so they survive round-trip without being
+    reinterpreted as None, bool, or int. This makes the block a truly
+    lossless serialization: draft --source=123 stays the string "123",
+    not the integer 123.
+    """
     if v is None:
         return "None"
     if isinstance(v, bool):
         return str(v).lower()
-    return str(v)
+    if isinstance(v, int):
+        return str(v)
+    # All strings are quoted to prevent ambiguity with None/true/false/int
+    return f'"{v}"'
 
 
 def _parse_value(s: str) -> object:
@@ -145,6 +154,9 @@ def _parse_value(s: str) -> object:
         return True
     if s == "false":
         return False
+    # Quoted string — strip quotes and return as str
+    if len(s) >= 2 and s.startswith('"') and s.endswith('"'):
+        return s[1:-1]
     try:
         return int(s)
     except ValueError:

--- a/plugins/lean4/lib/command_args/parser.py
+++ b/plugins/lean4/lib/command_args/parser.py
@@ -211,19 +211,24 @@ def _validate_type(fs: FlagSpec, raw_value: object) -> tuple[object, str | None]
 
 
 def _parse_duration(flag_name: str, raw_value: object) -> tuple[object, str | None]:
-    """Parse a duration string like '10m', '2h', '120s' into minutes (int)."""
+    """Parse a duration string like '30s', '10m', '2h' into seconds (int).
+
+    Seconds are the native unit of cycle_tracker.sh, which accepts and
+    preserves second-level budgets. Storing in seconds avoids the lossy
+    floor-to-minutes bug where 30s → 0m effectively disables the cap.
+    """
     s = str(raw_value).strip().lower()
     if not s:
         return raw_value, f"{flag_name}: empty duration"
 
-    # Try pure numeric (interpreted as minutes)
+    # Try pure numeric (interpreted as seconds for consistency)
     try:
         return int(s), None
     except ValueError:
         pass
 
-    # Try suffix-based
-    suffixes = {"s": 1 / 60, "m": 1, "h": 60}
+    # Try suffix-based — all converted to seconds
+    suffixes = {"s": 1, "m": 60, "h": 3600}
     for suffix, multiplier in suffixes.items():
         if s.endswith(suffix):
             try:

--- a/plugins/lean4/lib/command_args/parser.py
+++ b/plugins/lean4/lib/command_args/parser.py
@@ -220,30 +220,37 @@ def _validate_type(fs: FlagSpec, raw_value: object) -> tuple[object, str | None]
 
 
 def _parse_duration(flag_name: str, raw_value: object) -> tuple[object, str | None]:
-    """Parse a duration string like '30s', '10m', '2h' into seconds (int).
+    """Validate and normalize a duration string like '30s', '10m', '2h'.
 
-    Seconds are the native unit of cycle_tracker.sh, which accepts and
-    preserves second-level budgets. Storing in seconds avoids the lossy
-    floor-to-minutes bug where 30s → 0m effectively disables the cap.
+    Returns the duration as a suffix-bearing string (e.g. "900s", "15m")
+    so the downstream consumer (cycle_tracker.sh) always receives an
+    explicit unit. cycle_tracker.sh interprets bare numbers as minutes,
+    so we never emit bare integers — that avoids the ambiguity where
+    the parser means seconds but the tracker reads minutes.
+
+    Accepted input forms: '30s', '15m', '2h', bare number (= minutes,
+    normalized to '<N>m').
     """
     s = str(raw_value).strip().lower()
     if not s:
         return raw_value, f"{flag_name}: empty duration"
 
-    # Try pure numeric (interpreted as seconds for consistency)
+    # Try pure numeric — interpreted as minutes (matches tracker convention),
+    # normalized to explicit '<N>m' suffix.
     try:
-        return int(s), None
+        n = int(s)
+        return f"{n}m", None
     except ValueError:
         pass
 
-    # Try suffix-based — all converted to seconds
-    suffixes = {"s": 1, "m": 60, "h": 3600}
-    for suffix, multiplier in suffixes.items():
-        if s.endswith(suffix):
-            try:
-                num = float(s[:-1])
-                return int(num * multiplier), None
-            except ValueError:
-                pass
+    # Try suffix-based — validate and pass through with original suffix.
+    valid_suffixes = {"s", "m", "h"}
+    if s[-1] in valid_suffixes:
+        try:
+            float(s[:-1])
+            # Valid — return as-is (already has explicit suffix)
+            return s, None
+        except ValueError:
+            pass
 
     return raw_value, f"{flag_name}: invalid duration {raw_value!r}; expected e.g. '10m', '2h', '120s'"

--- a/plugins/lean4/lib/command_args/parser.py
+++ b/plugins/lean4/lib/command_args/parser.py
@@ -243,13 +243,20 @@ def _parse_duration(flag_name: str, raw_value: object) -> tuple[object, str | No
     except ValueError:
         pass
 
-    # Try suffix-based — validate and pass through with original suffix.
+    # Try suffix-based — validate as integer prefix + suffix to match
+    # cycle_tracker.sh's _parse_duration which requires ^[0-9]+[mshMSH]?$.
     valid_suffixes = {"s", "m", "h"}
     if s[-1] in valid_suffixes:
-        try:
-            float(s[:-1])
-            # Valid — return as-is (already has explicit suffix)
+        prefix = s[:-1]
+        if prefix.isdigit():
             return s, None
+        # Reject fractional values — tracker only accepts integers.
+        try:
+            float(prefix)
+            return raw_value, (
+                f"{flag_name}: fractional duration {raw_value!r} not supported; "
+                "use an integer with s/m/h suffix (e.g. 90s, 15m, 2h)"
+            )
         except ValueError:
             pass
 

--- a/plugins/lean4/lib/command_args/parser.py
+++ b/plugins/lean4/lib/command_args/parser.py
@@ -1,0 +1,235 @@
+"""Core parser: parse_invocation(spec, raw_tail, *, cwd) -> ParseResult."""
+from __future__ import annotations
+
+import os
+from typing import Mapping
+
+from .tokenizer import normalize_flags, tokenize
+from .types import (
+    CommandSpec,
+    FlagSpec,
+    ParseContext,
+    ParseResult,
+    ResolvedFlag,
+)
+
+
+def parse_invocation(spec: CommandSpec, raw_tail: str, *, cwd: str) -> ParseResult:
+    """Parse a slash-command raw tail against a CommandSpec.
+
+    Args:
+        spec: The command's specification.
+        raw_tail: Everything after ``/lean4:<name> ``.
+        cwd: Absolute path to the user's workspace cwd.
+
+    Returns:
+        A ParseResult with all flags resolved, defaults applied, coercions run,
+        and cross-validations evaluated.
+    """
+    cwd = os.path.abspath(cwd)
+    ctx = ParseContext(cwd=cwd)
+    result = ParseResult(command=spec.name, raw_tail=raw_tail)
+
+    # Build lookup tables
+    flag_by_name: dict[str, FlagSpec] = {}
+    for fs in spec.flags:
+        flag_by_name[fs.name] = fs
+        for alias in fs.aliases:
+            flag_by_name[alias] = fs
+
+    # Tokenize
+    try:
+        tokens = normalize_flags(tokenize(raw_tail))
+    except ValueError as e:
+        result.errors.append(str(e))
+        return result
+
+    # Parse tokens into positionals and raw flag values
+    positional_idx = 0
+    raw_flags: dict[str, str | bool] = {}
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if token.startswith("--"):
+            canonical_spec = flag_by_name.get(token)
+            if canonical_spec is None:
+                result.errors.append(f"Unknown flag: {token}")
+                i += 1
+                continue
+            canonical_name = canonical_spec.name
+            if canonical_spec.type == "bool":
+                raw_flags[canonical_name] = True
+            else:
+                if i + 1 >= len(tokens):
+                    result.errors.append(f"Flag {token} requires a value")
+                    i += 1
+                    continue
+                raw_flags[canonical_name] = tokens[i + 1]
+                i += 1
+        else:
+            # Positional
+            if positional_idx < len(spec.positionals):
+                ps = spec.positionals[positional_idx]
+                result.positionals[ps.name] = token
+                positional_idx += 1
+            else:
+                result.errors.append(
+                    f"Unexpected positional argument: {token!r}"
+                )
+        i += 1
+
+    if result.errors:
+        return result
+
+    # Build the raw options dict for coercions/validations to read
+    raw_options: dict[str, object] = {}
+    for fs in spec.flags:
+        if fs.name in raw_flags:
+            raw_options[fs.name] = raw_flags[fs.name]
+        else:
+            raw_options[fs.name] = fs.default
+
+    # Validate and resolve each flag
+    for fs in spec.flags:
+        user_supplied = fs.name in raw_flags
+        raw_value = raw_flags.get(fs.name, fs.default)
+
+        # Type validation
+        parsed_value, type_error = _validate_type(fs, raw_value)
+        if type_error:
+            result.errors.append(type_error)
+            continue
+
+        # Coercion
+        coerced = False
+        coerced_from = None
+        if user_supplied and fs.coerce is not None:
+            try:
+                new_value, note = fs.coerce.fn(parsed_value, raw_options, ctx)
+            except Exception as e:
+                result.errors.append(f"Coercion error for {fs.name}: {e}")
+                continue
+            if new_value != parsed_value:
+                coerced_from = parsed_value
+                parsed_value = new_value
+                coerced = True
+            if note:
+                result.coercions.append(note)
+
+        # Determine source
+        if coerced:
+            source = "coerced"
+        elif user_supplied:
+            source = "explicit"
+        else:
+            source = "default"
+
+        result.options[fs.name] = ResolvedFlag(
+            value=parsed_value,
+            source=source,
+            enforcement=fs.enforcement,
+            coerced_from=coerced_from,
+        )
+
+    if result.errors:
+        return result
+
+    # Companion-flag checks (requires / forbidden_with)
+    for fs in spec.flags:
+        if fs.name not in raw_flags:
+            continue
+        for req in fs.requires:
+            if req not in raw_flags:
+                result.errors.append(
+                    f"{fs.name} requires {req}"
+                )
+        for forbidden in fs.forbidden_with:
+            if forbidden in raw_flags:
+                result.errors.append(
+                    f"{fs.name} is incompatible with {forbidden}"
+                )
+
+    # Cross-validations — inject positionals as __positional_<name> sentinels
+    # so cross-validation functions can check for positional presence.
+    resolved_values: dict[str, object] = {
+        name: rf.value for name, rf in result.options.items()
+    }
+    for pos_name, pos_value in result.positionals.items():
+        resolved_values[f"__positional_{pos_name}"] = pos_value
+    for cv in spec.cross_validations:
+        try:
+            messages = cv.fn(resolved_values, ctx)
+        except Exception as e:
+            result.errors.append(f"Validation error ({cv.rule_id}): {e}")
+            continue
+        if cv.severity == "error":
+            result.errors.extend(messages)
+        else:
+            result.warnings.extend(messages)
+
+    return result
+
+
+def _validate_type(fs: FlagSpec, raw_value: object) -> tuple[object, str | None]:
+    """Validate and parse a raw flag value according to its type spec."""
+    if raw_value is None:
+        return None, None
+
+    if fs.type == "bool":
+        if isinstance(raw_value, bool):
+            return raw_value, None
+        s = str(raw_value).lower()
+        if s in ("true", "1", "yes"):
+            return True, None
+        if s in ("false", "0", "no"):
+            return False, None
+        return raw_value, f"{fs.name}: invalid boolean value {raw_value!r}"
+
+    if fs.type == "enum":
+        s = str(raw_value)
+        if s not in fs.enum_values:
+            valid = ", ".join(fs.enum_values)
+            return raw_value, f"{fs.name}: invalid value {s!r}; valid values: {valid}"
+        return s, None
+
+    if fs.type == "int":
+        try:
+            n = int(raw_value)
+        except (ValueError, TypeError):
+            return raw_value, f"{fs.name}: expected integer, got {raw_value!r}"
+        if fs.int_min is not None and n < fs.int_min:
+            return n, f"{fs.name}: value {n} is below minimum {fs.int_min}"
+        if fs.int_max is not None and n > fs.int_max:
+            return n, f"{fs.name}: value {n} is above maximum {fs.int_max}"
+        return n, None
+
+    if fs.type == "duration":
+        return _parse_duration(fs.name, raw_value)
+
+    # path and freeform: pass through as string
+    return str(raw_value) if raw_value is not None else None, None
+
+
+def _parse_duration(flag_name: str, raw_value: object) -> tuple[object, str | None]:
+    """Parse a duration string like '10m', '2h', '120s' into minutes (int)."""
+    s = str(raw_value).strip().lower()
+    if not s:
+        return raw_value, f"{flag_name}: empty duration"
+
+    # Try pure numeric (interpreted as minutes)
+    try:
+        return int(s), None
+    except ValueError:
+        pass
+
+    # Try suffix-based
+    suffixes = {"s": 1 / 60, "m": 1, "h": 60}
+    for suffix, multiplier in suffixes.items():
+        if s.endswith(suffix):
+            try:
+                num = float(s[:-1])
+                return int(num * multiplier), None
+            except ValueError:
+                pass
+
+    return raw_value, f"{flag_name}: invalid duration {raw_value!r}; expected e.g. '10m', '2h', '120s'"

--- a/plugins/lean4/lib/command_args/parser.py
+++ b/plugins/lean4/lib/command_args/parser.py
@@ -58,7 +58,16 @@ def parse_invocation(spec: CommandSpec, raw_tail: str, *, cwd: str) -> ParseResu
                 continue
             canonical_name = canonical_spec.name
             if canonical_spec.type == "bool":
-                raw_flags[canonical_name] = True
+                # Bool flags: if next token looks like a bool value, consume it.
+                # This handles both --flag (presence = true) and --flag=false
+                # (expanded to --flag false by normalize_flags).
+                if i + 1 < len(tokens) and tokens[i + 1].lower() in (
+                    "true", "false", "1", "0", "yes", "no",
+                ):
+                    raw_flags[canonical_name] = tokens[i + 1]
+                    i += 1
+                else:
+                    raw_flags[canonical_name] = True
             else:
                 if i + 1 >= len(tokens):
                     result.errors.append(f"Flag {token} requires a value")

--- a/plugins/lean4/lib/command_args/specs/__init__.py
+++ b/plugins/lean4/lib/command_args/specs/__init__.py
@@ -1,0 +1,21 @@
+"""Per-command specs, assembled into COMMAND_SPECS."""
+from __future__ import annotations
+
+from ..types import CommandSpec
+
+# Import specs as they are added.  Each module exposes a single SPEC: CommandSpec.
+from .autoformalize import SPEC as _autoformalize
+from .autoprove import SPEC as _autoprove
+from .draft import SPEC as _draft
+from .formalize import SPEC as _formalize
+from .learn import SPEC as _learn
+from .prove import SPEC as _prove
+
+COMMAND_SPECS: dict[str, CommandSpec] = {
+    _autoformalize.name: _autoformalize,
+    _autoprove.name: _autoprove,
+    _draft.name: _draft,
+    _formalize.name: _formalize,
+    _learn.name: _learn,
+    _prove.name: _prove,
+}

--- a/plugins/lean4/lib/command_args/specs/_common.py
+++ b/plugins/lean4/lib/command_args/specs/_common.py
@@ -1,0 +1,356 @@
+"""Shared FlagSpec fragments reused across multiple command specs.
+
+Each function returns a FlagSpec (or list of FlagSpecs) so per-command
+overrides can customize defaults, coercions, or enforcement classes.
+"""
+from __future__ import annotations
+
+from ..types import Coercion, FlagSpec
+
+# ---------------------------------------------------------------------------
+# Output flags: --output, --out, --overwrite
+# ---------------------------------------------------------------------------
+
+
+def output_flag(
+    *,
+    default: str = "chat",
+    enum_values: tuple[str, ...] = ("chat", "scratch", "file"),
+) -> FlagSpec:
+    """--output flag shared by draft, learn, formalize."""
+    return FlagSpec(
+        name="--output",
+        type="enum",
+        enum_values=enum_values,
+        default=default,
+        enforcement="startup-validated",
+    )
+
+
+def out_flag() -> FlagSpec:
+    """--out path flag.  Required when --output=file (enforced by cross-validation)."""
+    return FlagSpec(
+        name="--out",
+        type="path",
+        default=None,
+        enforcement="startup-validated",
+        notes="Required when --output=file; enforced via cross-validation, not requires",
+    )
+
+
+def overwrite_flag() -> FlagSpec:
+    """--overwrite flag."""
+    return FlagSpec(
+        name="--overwrite",
+        type="bool",
+        default=False,
+        enforcement="startup-validated",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Intent / presentation
+# ---------------------------------------------------------------------------
+
+
+def intent_flag(
+    *,
+    default: str = "auto",
+    enum_values: tuple[str, ...] = ("auto", "usage", "internals", "authoring", "math"),
+    coerce: Coercion | None = None,
+) -> FlagSpec:
+    """--intent flag.  Default and enum_values vary by command."""
+    return FlagSpec(
+        name="--intent",
+        type="enum",
+        enum_values=enum_values,
+        default=default,
+        enforcement="startup-validated",
+        coerce=coerce,
+    )
+
+
+def presentation_flag(*, default: str = "auto") -> FlagSpec:
+    """--presentation flag."""
+    return FlagSpec(
+        name="--presentation",
+        type="enum",
+        enum_values=("informal", "supporting", "formal", "auto"),
+        default=default,
+        enforcement="startup-validated",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Source / claim-select
+# ---------------------------------------------------------------------------
+
+
+def source_flag(*, required: bool = False) -> FlagSpec:
+    """--source flag for file/URL/PDF input."""
+    return FlagSpec(
+        name="--source",
+        type="path",
+        default=None,
+        enforcement="startup-validated",
+        notes="required" if required else "",
+    )
+
+
+def claim_select_flag(*, requires: tuple[str, ...] = ()) -> FlagSpec:
+    """--claim-select noninteractive selection policy.
+
+    ``requires`` is set only when the relationship is truly unconditional
+    (e.g. in draft/formalize where --claim-select always needs --source).
+    For autoformalize/autoprove where --claim-select is independently
+    required, use a CrossValidation instead.
+    """
+    return FlagSpec(
+        name="--claim-select",
+        type="freeform",
+        default=None,
+        enforcement="startup-validated",
+        requires=requires,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deep-mode family
+# ---------------------------------------------------------------------------
+
+
+def deep_flag(
+    *,
+    default: str = "never",
+    enum_values: tuple[str, ...] = ("never", "ask", "stuck", "always"),
+    coerce: Coercion | None = None,
+) -> FlagSpec:
+    """--deep flag.  Default and coerce vary by command."""
+    return FlagSpec(
+        name="--deep",
+        type="enum",
+        enum_values=enum_values,
+        default=default,
+        enforcement="startup-validated",
+        coerce=coerce,
+    )
+
+
+def deep_sorry_budget_flag(*, default: int = 1) -> FlagSpec:
+    return FlagSpec(
+        name="--deep-sorry-budget",
+        type="int",
+        default=default,
+        int_min=1,
+        enforcement="session-enforced",
+    )
+
+
+def deep_time_budget_flag(*, default: str = "10m") -> FlagSpec:
+    return FlagSpec(
+        name="--deep-time-budget",
+        type="duration",
+        default=default,
+        enforcement="advisory",
+        notes="Advisory: scopes deep-mode subagent work. Not tracked or enforced.",
+    )
+
+
+def max_deep_per_cycle_flag(*, default: int = 1) -> FlagSpec:
+    return FlagSpec(
+        name="--max-deep-per-cycle",
+        type="int",
+        default=default,
+        int_min=1,
+        enforcement="session-enforced",
+    )
+
+
+def deep_snapshot_flag(*, default: str = "stash") -> FlagSpec:
+    return FlagSpec(
+        name="--deep-snapshot",
+        type="enum",
+        enum_values=("stash",),
+        default=default,
+        enforcement="startup-validated",
+        notes="V1: stash only",
+    )
+
+
+def deep_rollback_flag(
+    *,
+    default: str = "on-regression",
+    coerce: Coercion | None = None,
+) -> FlagSpec:
+    return FlagSpec(
+        name="--deep-rollback",
+        type="enum",
+        enum_values=("on-regression", "on-no-improvement", "always", "never"),
+        default=default,
+        enforcement="startup-validated",
+        coerce=coerce,
+    )
+
+
+def deep_scope_flag(*, default: str = "target") -> FlagSpec:
+    return FlagSpec(
+        name="--deep-scope",
+        type="enum",
+        enum_values=("target", "cross-file"),
+        default=default,
+        enforcement="startup-validated",
+    )
+
+
+def deep_max_files_flag(*, default: int = 1) -> FlagSpec:
+    return FlagSpec(
+        name="--deep-max-files",
+        type="int",
+        default=default,
+        int_min=1,
+        enforcement="session-enforced",
+    )
+
+
+def deep_max_lines_flag(*, default: int = 120) -> FlagSpec:
+    return FlagSpec(
+        name="--deep-max-lines",
+        type="int",
+        default=default,
+        int_min=1,
+        enforcement="session-enforced",
+    )
+
+
+def deep_regression_gate_flag(
+    *,
+    default: str = "strict",
+    coerce: Coercion | None = None,
+) -> FlagSpec:
+    return FlagSpec(
+        name="--deep-regression-gate",
+        type="enum",
+        enum_values=("strict", "off"),
+        default=default,
+        enforcement="startup-validated",
+        coerce=coerce,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Max-* family (session stop budgets)
+# ---------------------------------------------------------------------------
+
+
+def max_cycles_flag(*, default: int = 20) -> FlagSpec:
+    return FlagSpec(
+        name="--max-cycles",
+        type="int",
+        default=default,
+        int_min=1,
+        enforcement="session-enforced",
+    )
+
+
+def max_total_runtime_flag(*, default: str = "120m") -> FlagSpec:
+    return FlagSpec(
+        name="--max-total-runtime",
+        type="duration",
+        default=default,
+        enforcement="best-effort",
+        notes="Best-effort wall-clock session budget",
+    )
+
+
+def max_stuck_cycles_flag(*, default: int = 3) -> FlagSpec:
+    return FlagSpec(
+        name="--max-stuck-cycles",
+        type="int",
+        default=default,
+        int_min=1,
+        enforcement="session-enforced",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Common: --commit, --golf
+# ---------------------------------------------------------------------------
+
+
+def commit_flag(
+    *,
+    default: str = "ask",
+    enum_values: tuple[str, ...] = ("ask", "auto", "never"),
+    coerce: Coercion | None = None,
+) -> FlagSpec:
+    return FlagSpec(
+        name="--commit",
+        type="enum",
+        enum_values=enum_values,
+        default=default,
+        enforcement="startup-validated",
+        coerce=coerce,
+    )
+
+
+def golf_flag(
+    *,
+    default: str = "prompt",
+    enum_values: tuple[str, ...] = ("prompt", "auto", "never"),
+) -> FlagSpec:
+    return FlagSpec(
+        name="--golf",
+        type="enum",
+        enum_values=enum_values,
+        default=default,
+        enforcement="startup-validated",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Level flag (shared across draft, learn, formalize)
+# ---------------------------------------------------------------------------
+
+
+def level_flag(*, default: str = "intermediate") -> FlagSpec:
+    return FlagSpec(
+        name="--level",
+        type="enum",
+        enum_values=("beginner", "intermediate", "expert"),
+        default=default,
+        enforcement="startup-validated",
+    )
+
+
+def verify_flag(*, default: str = "best-effort") -> FlagSpec:
+    return FlagSpec(
+        name="--verify",
+        type="enum",
+        enum_values=("best-effort", "strict"),
+        default=default,
+        enforcement="startup-validated",
+        notes="Verification strictness for key claims",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience constants
+#
+# Pre-instantiated FlagSpec objects for specs that use them as-is
+# (e.g. learn.py, formalize.py).  Commands that need custom defaults or
+# coercions should call the factory functions directly.
+# ---------------------------------------------------------------------------
+
+FLAG_LEVEL = level_flag()
+FLAG_OUTPUT = output_flag()
+FLAG_OUT = out_flag()
+FLAG_OVERWRITE = overwrite_flag()
+FLAG_PRESENTATION = presentation_flag()
+FLAG_SOURCE = source_flag()
+FLAG_VERIFY = verify_flag()
+
+# learn uses the full 5-value intent enum with auto default
+FLAG_INTENT_LEARN = intent_flag(
+    default="auto",
+    enum_values=("auto", "usage", "internals", "authoring", "math"),
+)

--- a/plugins/lean4/lib/command_args/specs/autoformalize.py
+++ b/plugins/lean4/lib/command_args/specs/autoformalize.py
@@ -1,0 +1,379 @@
+"""Spec for /lean4:autoformalize — autonomous end-to-end formalization."""
+from __future__ import annotations
+
+from typing import Mapping
+
+from ..types import (
+    Coercion,
+    CommandSpec,
+    CrossValidation,
+    FlagSpec,
+    ParseContext,
+)
+
+
+# ---------------------------------------------------------------------------
+# Autoformalize-specific coercions
+# ---------------------------------------------------------------------------
+
+def _review_source_coerce(
+    value: object,
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> tuple[object, str | None]:
+    """--review-source=external|both -> coerced to internal."""
+    if value in ("external", "both"):
+        return "internal", (
+            "--review-source=external requires interactive handoff. "
+            "Using internal review for unattended operation."
+        )
+    return value, None
+
+
+REVIEW_SOURCE_COERCION = Coercion(
+    rule_id="autoformalize-review-source-to-internal",
+    fn=_review_source_coerce,
+    doc_phrases=(
+        "coerced from external/both -- see autoprove",
+        "--review-source=external requires interactive handoff",
+    ),
+    summary="Coerce --review-source=external|both to internal for unattended operation.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Autoformalize-specific cross-validations
+# ---------------------------------------------------------------------------
+
+def _source_required(
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> list[str]:
+    """--source is required; error if missing."""
+    if not flags.get("--source"):
+        return ["--source is required; error if missing."]
+    return []
+
+
+SOURCE_REQUIRED = CrossValidation(
+    rule_id="autoformalize-source-required",
+    fn=_source_required,
+    severity="error",
+    doc_phrases=(
+        "--source is required; error if missing.",
+    ),
+    summary="Require --source for autoformalize.",
+)
+
+
+def _claim_select_required(
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> list[str]:
+    """--claim-select is required; error if missing."""
+    if not flags.get("--claim-select"):
+        return ["--claim-select is required; error if missing (no unattended guessing)."]
+    return []
+
+
+CLAIM_SELECT_REQUIRED = CrossValidation(
+    rule_id="autoformalize-claim-select-required",
+    fn=_claim_select_required,
+    severity="error",
+    doc_phrases=(
+        "--claim-select is required; error if missing (no unattended guessing).",
+    ),
+    summary="Require --claim-select for autoformalize.",
+)
+
+
+def _out_required(
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> list[str]:
+    """--out is required; error if missing."""
+    if not flags.get("--out"):
+        return ["--out is required when no existing target file is in scope; error if missing."]
+    return []
+
+
+OUT_REQUIRED = CrossValidation(
+    rule_id="autoformalize-out-required",
+    fn=_out_required,
+    severity="error",
+    doc_phrases=(
+        "--out is required when no existing target file is in scope; error if missing.",
+    ),
+    summary="Require --out for autoformalize.",
+)
+
+
+def _statement_policy_preserve_warn(
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> list[str]:
+    """--statement-policy=preserve warns that stuck redraft becomes manual."""
+    if flags.get("--statement-policy") == "preserve":
+        return [
+            "--statement-policy=preserve: "
+            "stuck redraft path becomes manual intervention, not automatic rewrite."
+        ]
+    return []
+
+
+STATEMENT_POLICY_PRESERVE_WARNING = CrossValidation(
+    rule_id="autoformalize-statement-policy-preserve-warning",
+    fn=_statement_policy_preserve_warn,
+    severity="warning",
+    doc_phrases=(
+        "--statement-policy=preserve is respected but warns: "
+        "stuck redraft path becomes manual intervention, not automatic rewrite.",
+    ),
+    summary="Warn when --statement-policy=preserve (stuck redraft becomes manual).",
+)
+
+
+# ---------------------------------------------------------------------------
+# Flag definitions
+# ---------------------------------------------------------------------------
+
+FLAG_SOURCE = FlagSpec(
+    name="--source",
+    type="freeform",
+    default=None,
+    enforcement="startup-validated",
+    notes="File path, URL, or PDF for claim extraction. Required.",
+)
+
+FLAG_CLAIM_SELECT = FlagSpec(
+    name="--claim-select",
+    type="freeform",
+    default=None,
+    enforcement="startup-validated",
+    notes='first | named:"..." | regex:"...". Required.',
+)
+
+FLAG_OUT = FlagSpec(
+    name="--out",
+    type="path",
+    default=None,
+    enforcement="startup-validated",
+    notes="Target file for formalized claims. Required.",
+)
+
+FLAG_STATEMENT_POLICY = FlagSpec(
+    name="--statement-policy",
+    type="enum",
+    enum_values=("preserve", "rewrite-generated-only", "adjacent-drafts"),
+    default="rewrite-generated-only",
+    enforcement="startup-validated",
+)
+
+FLAG_RIGOR = FlagSpec(
+    name="--rigor",
+    type="enum",
+    enum_values=("sketch", "checked"),
+    default="sketch",
+    enforcement="startup-validated",
+)
+
+FLAG_DRAFT_MODE = FlagSpec(
+    name="--draft-mode",
+    type="enum",
+    enum_values=("skeleton", "attempt"),
+    default="skeleton",
+    enforcement="startup-validated",
+    notes="Passed to draft phase",
+)
+
+FLAG_DRAFT_ELAB_CHECK = FlagSpec(
+    name="--draft-elab-check",
+    type="enum",
+    enum_values=("best-effort", "strict"),
+    default="best-effort",
+    enforcement="startup-validated",
+    notes="Passed to draft phase",
+)
+
+FLAG_MAX_CYCLES = FlagSpec(
+    name="--max-cycles",
+    type="int",
+    default=20,
+    int_min=1,
+    enforcement="session-enforced",
+    notes="Per claim",
+)
+
+FLAG_MAX_TOTAL_RUNTIME = FlagSpec(
+    name="--max-total-runtime",
+    type="duration",
+    default="120m",
+    enforcement="best-effort",
+    notes="Best-effort wall-clock session budget (per session)",
+)
+
+FLAG_MAX_STUCK_CYCLES = FlagSpec(
+    name="--max-stuck-cycles",
+    type="int",
+    default=3,
+    int_min=1,
+    enforcement="session-enforced",
+    notes="Per claim",
+)
+
+FLAG_DEEP = FlagSpec(
+    name="--deep",
+    type="enum",
+    enum_values=("never", "stuck", "always"),
+    default="stuck",
+    enforcement="startup-validated",
+)
+
+FLAG_DEEP_SORRY_BUDGET = FlagSpec(
+    name="--deep-sorry-budget",
+    type="int",
+    default=2,
+    int_min=1,
+    enforcement="session-enforced",
+)
+
+FLAG_DEEP_TIME_BUDGET = FlagSpec(
+    name="--deep-time-budget",
+    type="duration",
+    default="20m",
+    enforcement="advisory",
+    notes="Scopes deep-mode subagent work. Not tracked or enforced by session tracker.",
+)
+
+FLAG_MAX_DEEP_PER_CYCLE = FlagSpec(
+    name="--max-deep-per-cycle",
+    type="int",
+    default=1,
+    int_min=0,
+    enforcement="session-enforced",
+)
+
+FLAG_DEEP_SNAPSHOT = FlagSpec(
+    name="--deep-snapshot",
+    type="enum",
+    enum_values=("stash",),
+    default="stash",
+    enforcement="startup-validated",
+    notes="V1: stash only",
+)
+
+FLAG_DEEP_ROLLBACK = FlagSpec(
+    name="--deep-rollback",
+    type="enum",
+    enum_values=("on-regression", "on-no-improvement", "always", "never"),
+    default="on-regression",
+    enforcement="startup-validated",
+)
+
+FLAG_DEEP_SCOPE = FlagSpec(
+    name="--deep-scope",
+    type="enum",
+    enum_values=("target", "cross-file"),
+    default="target",
+    enforcement="startup-validated",
+)
+
+FLAG_DEEP_MAX_FILES = FlagSpec(
+    name="--deep-max-files",
+    type="int",
+    default=2,
+    int_min=1,
+    enforcement="session-enforced",
+)
+
+FLAG_DEEP_MAX_LINES = FlagSpec(
+    name="--deep-max-lines",
+    type="int",
+    default=200,
+    int_min=1,
+    enforcement="session-enforced",
+)
+
+FLAG_DEEP_REGRESSION_GATE = FlagSpec(
+    name="--deep-regression-gate",
+    type="enum",
+    enum_values=("strict", "off"),
+    default="strict",
+    enforcement="startup-validated",
+)
+
+FLAG_COMMIT = FlagSpec(
+    name="--commit",
+    type="enum",
+    enum_values=("auto", "never"),
+    default="auto",
+    enforcement="startup-validated",
+)
+
+FLAG_GOLF = FlagSpec(
+    name="--golf",
+    type="enum",
+    enum_values=("prompt", "auto", "never"),
+    default="never",
+    enforcement="startup-validated",
+)
+
+FLAG_REVIEW_SOURCE = FlagSpec(
+    name="--review-source",
+    type="enum",
+    enum_values=("internal", "external", "both", "none"),
+    default="internal",
+    enforcement="startup-validated",
+    coerce=REVIEW_SOURCE_COERCION,
+    notes="Coerced from external/both to internal (see autoprove docs)",
+)
+
+FLAG_REVIEW_EVERY = FlagSpec(
+    name="--review-every",
+    type="freeform",
+    default="checkpoint",
+    enforcement="startup-validated",
+    notes="N (sorries), checkpoint, or never",
+)
+
+
+# ---------------------------------------------------------------------------
+# Spec
+# ---------------------------------------------------------------------------
+
+SPEC = CommandSpec(
+    name="autoformalize",
+    positionals=(),
+    flags=(
+        FLAG_SOURCE,
+        FLAG_CLAIM_SELECT,
+        FLAG_OUT,
+        FLAG_STATEMENT_POLICY,
+        FLAG_RIGOR,
+        FLAG_DRAFT_MODE,
+        FLAG_DRAFT_ELAB_CHECK,
+        FLAG_MAX_CYCLES,
+        FLAG_MAX_TOTAL_RUNTIME,
+        FLAG_MAX_STUCK_CYCLES,
+        FLAG_DEEP,
+        FLAG_DEEP_SORRY_BUDGET,
+        FLAG_DEEP_TIME_BUDGET,
+        FLAG_MAX_DEEP_PER_CYCLE,
+        FLAG_DEEP_SNAPSHOT,
+        FLAG_DEEP_ROLLBACK,
+        FLAG_DEEP_SCOPE,
+        FLAG_DEEP_MAX_FILES,
+        FLAG_DEEP_MAX_LINES,
+        FLAG_DEEP_REGRESSION_GATE,
+        FLAG_COMMIT,
+        FLAG_GOLF,
+        FLAG_REVIEW_SOURCE,
+        FLAG_REVIEW_EVERY,
+    ),
+    cross_validations=(
+        SOURCE_REQUIRED,
+        CLAIM_SELECT_REQUIRED,
+        OUT_REQUIRED,
+        STATEMENT_POLICY_PRESERVE_WARNING,
+    ),
+)

--- a/plugins/lean4/lib/command_args/specs/autoprove.py
+++ b/plugins/lean4/lib/command_args/specs/autoprove.py
@@ -1,0 +1,611 @@
+"""Spec for /lean4:autoprove — autonomous multi-cycle theorem proving."""
+from __future__ import annotations
+
+from typing import Mapping
+
+from ..types import (
+    Coercion,
+    CommandSpec,
+    CrossValidation,
+    FlagSpec,
+    ParseContext,
+    PositionalSpec,
+)
+
+
+# ---------------------------------------------------------------------------
+# Autoprove-specific coercions
+# ---------------------------------------------------------------------------
+
+def _commit_ask_coerce(
+    value: object,
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> tuple[object, str | None]:
+    """--commit=ask -> coerced to auto (no interactive confirmation)."""
+    if value == "ask":
+        return "auto", (
+            "--commit=ask requires interactive confirmation. "
+            "Using auto for unattended operation."
+        )
+    return value, None
+
+
+COMMIT_ASK_COERCION = Coercion(
+    rule_id="autoprove-commit-ask-to-auto",
+    fn=_commit_ask_coerce,
+    doc_phrases=(
+        "--commit=ask requires interactive confirmation. Using auto for unattended operation.",
+        "--commit=ask is coerced to auto",
+    ),
+    summary="Coerce --commit=ask to auto for unattended autoprove.",
+)
+
+
+def _review_source_coerce(
+    value: object,
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> tuple[object, str | None]:
+    """--review-source=external|both -> coerced to internal."""
+    if value in ("external", "both"):
+        return "internal", (
+            "--review-source=external requires interactive handoff. "
+            "Using internal review for unattended operation."
+        )
+    return value, None
+
+
+REVIEW_SOURCE_COERCION = Coercion(
+    rule_id="autoprove-review-source-to-internal",
+    fn=_review_source_coerce,
+    doc_phrases=(
+        "--review-source=external requires interactive handoff. "
+        "Using internal review for unattended operation.",
+        "autoprove coerces to internal at startup",
+    ),
+    summary="Coerce --review-source=external|both to internal for unattended operation.",
+)
+
+
+def _deep_ask_coerce(
+    value: object,
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> tuple[object, str | None]:
+    """--deep=ask -> coerced to stuck (no interactive prompting)."""
+    if value == "ask":
+        return "stuck", (
+            "--deep=ask requires interactive prompting. "
+            "Using stuck for unattended operation."
+        )
+    return value, None
+
+
+DEEP_ASK_COERCION = Coercion(
+    rule_id="autoprove-deep-ask-to-stuck",
+    fn=_deep_ask_coerce,
+    doc_phrases=(
+        "ask is coerced to stuck (no interactive prompting in autoprove)",
+        "`ask` coerced to `stuck`",
+    ),
+    summary="Coerce --deep=ask to stuck for unattended autoprove.",
+)
+
+
+def _deep_rollback_never_coerce(
+    value: object,
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> tuple[object, str | None]:
+    """--deep-rollback=never -> coerced to on-regression (safety)."""
+    if value == "never":
+        return "on-regression", (
+            "--deep-rollback=never is unsafe. "
+            "Using on-regression for safety."
+        )
+    return value, None
+
+
+DEEP_ROLLBACK_NEVER_COERCION = Coercion(
+    rule_id="autoprove-deep-rollback-never-to-on-regression",
+    fn=_deep_rollback_never_coerce,
+    doc_phrases=(
+        "--deep-rollback=never -> coerced to on-regression",
+        "Deep safety coercions",
+    ),
+    summary="Coerce --deep-rollback=never to on-regression for safety.",
+)
+
+
+def _deep_regression_gate_off_coerce(
+    value: object,
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> tuple[object, str | None]:
+    """--deep-regression-gate=off -> coerced to strict (safety)."""
+    if value == "off":
+        return "strict", (
+            "--deep-regression-gate=off is unsafe. "
+            "Using strict for safety."
+        )
+    return value, None
+
+
+DEEP_REGRESSION_GATE_OFF_COERCION = Coercion(
+    rule_id="autoprove-deep-regression-gate-off-to-strict",
+    fn=_deep_regression_gate_off_coerce,
+    doc_phrases=(
+        "--deep-regression-gate=off -> coerced to strict",
+        "Deep safety coercions",
+    ),
+    summary="Coerce --deep-regression-gate=off to strict for safety.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Autoprove-specific cross-validations
+# ---------------------------------------------------------------------------
+
+def _statement_policy_preserve_warn(
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> list[str]:
+    """--statement-policy=preserve warns that stuck restage becomes manual."""
+    formalize = flags.get("--formalize")
+    policy = flags.get("--statement-policy")
+    if policy == "preserve" and formalize in ("restage", "auto"):
+        return [
+            "--statement-policy=preserve with --formalize: "
+            "stuck restage becomes manual intervention, not automatic rewrite."
+        ]
+    return []
+
+
+STATEMENT_POLICY_PRESERVE_WARNING = CrossValidation(
+    rule_id="autoprove-statement-policy-preserve-warning",
+    fn=_statement_policy_preserve_warn,
+    severity="warning",
+    doc_phrases=(
+        "Explicit --statement-policy=preserve is respected but warns: "
+        "stuck restage becomes manual intervention, not automatic rewrite.",
+    ),
+    summary="Warn when --statement-policy=preserve with active formalize mode.",
+)
+
+
+def _formalize_auto_requires_source(
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> list[str]:
+    """--formalize=auto requires --source."""
+    if flags.get("--formalize") == "auto" and not flags.get("--source"):
+        return ["--formalize=auto requires --source; error if missing."]
+    return []
+
+
+FORMALIZE_AUTO_REQUIRES_SOURCE = CrossValidation(
+    rule_id="autoprove-formalize-auto-requires-source",
+    fn=_formalize_auto_requires_source,
+    severity="error",
+    doc_phrases=(
+        "--formalize=auto requires --source; error if missing.",
+    ),
+    summary="Require --source when --formalize=auto.",
+)
+
+
+def _formalize_auto_requires_claim_select(
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> list[str]:
+    """--formalize=auto with --source requires --claim-select."""
+    formalize = flags.get("--formalize")
+    source = flags.get("--source")
+    claim_select = flags.get("--claim-select")
+    if formalize == "auto" and source and not claim_select:
+        return [
+            "--formalize=auto with --source requires --claim-select; "
+            "error if missing (no unattended guessing)."
+        ]
+    return []
+
+
+FORMALIZE_AUTO_REQUIRES_CLAIM_SELECT = CrossValidation(
+    rule_id="autoprove-formalize-auto-requires-claim-select",
+    fn=_formalize_auto_requires_claim_select,
+    severity="error",
+    doc_phrases=(
+        "--formalize=auto with --source requires --claim-select; "
+        "error if missing (no unattended guessing).",
+    ),
+    summary="Require --claim-select when --formalize=auto with --source.",
+)
+
+
+def _formalize_auto_requires_formalize_out(
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> list[str]:
+    """--formalize=auto requires --formalize-out."""
+    if flags.get("--formalize") == "auto" and not flags.get("--formalize-out"):
+        return [
+            "--formalize=auto requires --formalize-out when no existing "
+            "target file is in scope; error if missing."
+        ]
+    return []
+
+
+FORMALIZE_AUTO_REQUIRES_FORMALIZE_OUT = CrossValidation(
+    rule_id="autoprove-formalize-auto-requires-formalize-out",
+    fn=_formalize_auto_requires_formalize_out,
+    severity="error",
+    doc_phrases=(
+        "--formalize=auto requires --formalize-out when no existing target file is in scope",
+    ),
+    summary="Require --formalize-out when --formalize=auto.",
+)
+
+
+def _formalize_restage_ignores_source(
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> list[str]:
+    """--formalize=restage ignores --source (warn if provided)."""
+    if flags.get("--formalize") == "restage" and flags.get("--source"):
+        return ["--formalize=restage ignores --source (operates on existing scope)."]
+    return []
+
+
+FORMALIZE_RESTAGE_IGNORES_SOURCE = CrossValidation(
+    rule_id="autoprove-formalize-restage-ignores-source",
+    fn=_formalize_restage_ignores_source,
+    severity="warning",
+    doc_phrases=(
+        "--formalize=restage does NOT require --source",
+        "--source is ignored if provided (warn)",
+    ),
+    summary="Warn that --formalize=restage ignores --source.",
+)
+
+
+def _formalize_never_ignores_source(
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> list[str]:
+    """--formalize=never ignores --source (warn if provided)."""
+    if flags.get("--formalize") == "never" and flags.get("--source"):
+        return ["--formalize=never ignores --source."]
+    return []
+
+
+FORMALIZE_NEVER_IGNORES_SOURCE = CrossValidation(
+    rule_id="autoprove-formalize-never-ignores-source",
+    fn=_formalize_never_ignores_source,
+    severity="warning",
+    doc_phrases=(
+        "--formalize=never ignores --source (warn if provided)",
+    ),
+    summary="Warn that --formalize=never ignores --source.",
+)
+
+
+def _statement_policy_formalize_coerce(
+    value: object,
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> tuple[object, str | None]:
+    """--formalize=restage|auto with preserve default -> rewrite-generated-only."""
+    formalize = flags.get("--formalize")
+    if value == "preserve" and formalize in ("restage", "auto"):
+        return "rewrite-generated-only", (
+            "--statement-policy defaulted to preserve but --formalize="
+            f"{formalize} active; coercing to rewrite-generated-only."
+        )
+    return value, None
+
+
+STATEMENT_POLICY_FORMALIZE_COERCION = Coercion(
+    rule_id="autoprove-statement-policy-formalize-default-coerce",
+    fn=_statement_policy_formalize_coerce,
+    doc_phrases=(
+        "--formalize=restage|auto with default --statement-policy coerces "
+        "preserve -> rewrite-generated-only at startup (warn)",
+    ),
+    summary="Coerce --statement-policy default from preserve to rewrite-generated-only when formalize active.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Flag definitions
+# ---------------------------------------------------------------------------
+
+FLAG_REPAIR_ONLY = FlagSpec(
+    name="--repair-only",
+    type="bool",
+    default=False,
+    enforcement="startup-validated",
+    notes="Fix build errors only, skip sorry-filling",
+)
+
+FLAG_PLANNING = FlagSpec(
+    name="--planning",
+    type="enum",
+    enum_values=("on", "off"),
+    default="on",
+    enforcement="startup-validated",
+)
+
+FLAG_REVIEW_SOURCE = FlagSpec(
+    name="--review-source",
+    type="enum",
+    enum_values=("internal", "external", "both", "none"),
+    default="internal",
+    enforcement="startup-validated",
+    coerce=REVIEW_SOURCE_COERCION,
+)
+
+FLAG_REVIEW_EVERY = FlagSpec(
+    name="--review-every",
+    type="freeform",
+    default="checkpoint",
+    enforcement="startup-validated",
+    notes="N (sorries), checkpoint, or never",
+)
+
+FLAG_CHECKPOINT = FlagSpec(
+    name="--checkpoint",
+    type="bool",
+    default=True,
+    enforcement="startup-validated",
+)
+
+FLAG_DEEP = FlagSpec(
+    name="--deep",
+    type="enum",
+    enum_values=("never", "ask", "stuck", "always"),
+    default="stuck",
+    enforcement="startup-validated",
+    coerce=DEEP_ASK_COERCION,
+    notes="ask coerced to stuck for unattended operation",
+)
+
+FLAG_DEEP_SORRY_BUDGET = FlagSpec(
+    name="--deep-sorry-budget",
+    type="int",
+    default=2,
+    int_min=1,
+    enforcement="session-enforced",
+)
+
+FLAG_DEEP_TIME_BUDGET = FlagSpec(
+    name="--deep-time-budget",
+    type="duration",
+    default="20m",
+    enforcement="advisory",
+    notes="Scopes deep-mode subagent work. Not tracked or enforced by session tracker.",
+)
+
+FLAG_MAX_DEEP_PER_CYCLE = FlagSpec(
+    name="--max-deep-per-cycle",
+    type="int",
+    default=1,
+    int_min=0,
+    enforcement="session-enforced",
+)
+
+FLAG_MAX_CONSECUTIVE_DEEP_CYCLES = FlagSpec(
+    name="--max-consecutive-deep-cycles",
+    type="int",
+    default=2,
+    int_min=1,
+    enforcement="session-enforced",
+)
+
+FLAG_DEEP_SNAPSHOT = FlagSpec(
+    name="--deep-snapshot",
+    type="enum",
+    enum_values=("stash",),
+    default="stash",
+    enforcement="startup-validated",
+    notes="V1: stash only",
+)
+
+FLAG_DEEP_ROLLBACK = FlagSpec(
+    name="--deep-rollback",
+    type="enum",
+    enum_values=("on-regression", "on-no-improvement", "always", "never"),
+    default="on-regression",
+    enforcement="startup-validated",
+    coerce=DEEP_ROLLBACK_NEVER_COERCION,
+)
+
+FLAG_DEEP_SCOPE = FlagSpec(
+    name="--deep-scope",
+    type="enum",
+    enum_values=("target", "cross-file"),
+    default="target",
+    enforcement="startup-validated",
+)
+
+FLAG_DEEP_MAX_FILES = FlagSpec(
+    name="--deep-max-files",
+    type="int",
+    default=2,
+    int_min=1,
+    enforcement="session-enforced",
+)
+
+FLAG_DEEP_MAX_LINES = FlagSpec(
+    name="--deep-max-lines",
+    type="int",
+    default=200,
+    int_min=1,
+    enforcement="session-enforced",
+)
+
+FLAG_DEEP_REGRESSION_GATE = FlagSpec(
+    name="--deep-regression-gate",
+    type="enum",
+    enum_values=("strict", "off"),
+    default="strict",
+    enforcement="startup-validated",
+    coerce=DEEP_REGRESSION_GATE_OFF_COERCION,
+)
+
+FLAG_BATCH_SIZE = FlagSpec(
+    name="--batch-size",
+    type="int",
+    default=2,
+    int_min=1,
+    enforcement="advisory",
+    notes="Sorries to attempt per cycle (advisory)",
+)
+
+FLAG_COMMIT = FlagSpec(
+    name="--commit",
+    type="enum",
+    enum_values=("auto", "ask", "never"),
+    default="auto",
+    enforcement="startup-validated",
+    coerce=COMMIT_ASK_COERCION,
+    notes="ask coerced to auto for unattended operation",
+)
+
+FLAG_GOLF = FlagSpec(
+    name="--golf",
+    type="enum",
+    enum_values=("prompt", "auto", "never"),
+    default="never",
+    enforcement="startup-validated",
+)
+
+FLAG_MAX_CYCLES = FlagSpec(
+    name="--max-cycles",
+    type="int",
+    default=20,
+    int_min=1,
+    enforcement="session-enforced",
+)
+
+FLAG_MAX_TOTAL_RUNTIME = FlagSpec(
+    name="--max-total-runtime",
+    type="duration",
+    default="120m",
+    enforcement="best-effort",
+    notes="Best-effort wall-clock session budget",
+)
+
+FLAG_MAX_STUCK_CYCLES = FlagSpec(
+    name="--max-stuck-cycles",
+    type="int",
+    default=3,
+    int_min=1,
+    enforcement="session-enforced",
+)
+
+FLAG_FORMALIZE = FlagSpec(
+    name="--formalize",
+    type="enum",
+    enum_values=("never", "restage", "auto"),
+    default="never",
+    enforcement="startup-validated",
+    notes="deprecated: use /lean4:autoformalize",
+)
+
+FLAG_SOURCE = FlagSpec(
+    name="--source",
+    type="freeform",
+    default=None,
+    enforcement="startup-validated",
+    notes="File path, URL, or PDF for claim extraction. Required when --formalize=auto. (deprecated)",
+)
+
+FLAG_CLAIM_SELECT = FlagSpec(
+    name="--claim-select",
+    type="freeform",
+    default=None,
+    enforcement="startup-validated",
+    notes='first | named:"..." | regex:"...". Required when --formalize=auto. (deprecated)',
+)
+
+FLAG_FORMALIZE_RIGOR = FlagSpec(
+    name="--formalize-rigor",
+    type="enum",
+    enum_values=("sketch", "checked"),
+    default="sketch",
+    enforcement="startup-validated",
+    notes="deprecated: use /lean4:autoformalize --rigor",
+)
+
+FLAG_STATEMENT_POLICY = FlagSpec(
+    name="--statement-policy",
+    type="enum",
+    enum_values=("preserve", "rewrite-generated-only", "adjacent-drafts"),
+    default="preserve",
+    enforcement="startup-validated",
+    coerce=STATEMENT_POLICY_FORMALIZE_COERCION,
+    notes="Default becomes rewrite-generated-only when --formalize=restage|auto. (deprecated)",
+)
+
+FLAG_FORMALIZE_OUT = FlagSpec(
+    name="--formalize-out",
+    type="path",
+    default=None,
+    enforcement="startup-validated",
+    notes="Target file for formalized claims. Required if no existing target in scope. (deprecated)",
+)
+
+
+# ---------------------------------------------------------------------------
+# Spec
+# ---------------------------------------------------------------------------
+
+SPEC = CommandSpec(
+    name="autoprove",
+    positionals=(
+        PositionalSpec(
+            name="scope",
+            required=False,
+            notes="Specific file or theorem to focus on; defaults to all",
+        ),
+    ),
+    flags=(
+        FLAG_REPAIR_ONLY,
+        FLAG_PLANNING,
+        FLAG_REVIEW_SOURCE,
+        FLAG_REVIEW_EVERY,
+        FLAG_CHECKPOINT,
+        FLAG_DEEP,
+        FLAG_DEEP_SORRY_BUDGET,
+        FLAG_DEEP_TIME_BUDGET,
+        FLAG_MAX_DEEP_PER_CYCLE,
+        FLAG_MAX_CONSECUTIVE_DEEP_CYCLES,
+        FLAG_DEEP_SNAPSHOT,
+        FLAG_DEEP_ROLLBACK,
+        FLAG_DEEP_SCOPE,
+        FLAG_DEEP_MAX_FILES,
+        FLAG_DEEP_MAX_LINES,
+        FLAG_DEEP_REGRESSION_GATE,
+        FLAG_BATCH_SIZE,
+        FLAG_COMMIT,
+        FLAG_GOLF,
+        FLAG_MAX_CYCLES,
+        FLAG_MAX_TOTAL_RUNTIME,
+        FLAG_MAX_STUCK_CYCLES,
+        FLAG_FORMALIZE,
+        FLAG_SOURCE,
+        FLAG_CLAIM_SELECT,
+        FLAG_FORMALIZE_RIGOR,
+        FLAG_STATEMENT_POLICY,
+        FLAG_FORMALIZE_OUT,
+    ),
+    cross_validations=(
+        STATEMENT_POLICY_PRESERVE_WARNING,
+        FORMALIZE_AUTO_REQUIRES_SOURCE,
+        FORMALIZE_AUTO_REQUIRES_CLAIM_SELECT,
+        FORMALIZE_AUTO_REQUIRES_FORMALIZE_OUT,
+        FORMALIZE_RESTAGE_IGNORES_SOURCE,
+        FORMALIZE_NEVER_IGNORES_SOURCE,
+    ),
+)

--- a/plugins/lean4/lib/command_args/specs/draft.py
+++ b/plugins/lean4/lib/command_args/specs/draft.py
@@ -1,0 +1,100 @@
+"""CommandSpec for /lean4:draft -- draft Lean declaration skeletons from informal claims."""
+from __future__ import annotations
+
+from ..coercions import (
+    CLAIM_SELECT_REQUIRES_SOURCE,
+    INTENT_AUTO_COLLAPSE,
+    OUTPUT_FILE_OVERWRITE_CHECK,
+    OUTPUT_FILE_REQUIRES_OUT,
+    TOPIC_OR_SOURCE_REQUIRED,
+)
+from ..types import CommandSpec, FlagSpec, PositionalSpec
+from ._common import (
+    claim_select_flag,
+    intent_flag,
+    level_flag,
+    out_flag,
+    output_flag,
+    overwrite_flag,
+    presentation_flag,
+    source_flag,
+)
+
+# ---------------------------------------------------------------------------
+# Draft-specific flags
+# ---------------------------------------------------------------------------
+
+FLAG_MODE = FlagSpec(
+    name="--mode",
+    type="enum",
+    enum_values=("skeleton", "attempt"),
+    default="skeleton",
+    enforcement="startup-validated",
+    notes=(
+        "skeleton: sorry-stubbed declarations only. "
+        "attempt: adds a proof-attempt loop before finalizing."
+    ),
+)
+
+FLAG_ELAB_CHECK = FlagSpec(
+    name="--elab-check",
+    type="enum",
+    enum_values=("best-effort", "strict"),
+    default="best-effort",
+    enforcement="startup-validated",
+    notes="Elaboration check strictness for drafted skeletons.",
+)
+
+# Intent for draft: only auto, usage, math (internals/authoring collapsed).
+# The coercion on --intent handles auto -> usage and internals/authoring -> usage.
+FLAG_INTENT = intent_flag(
+    default="math",
+    enum_values=("auto", "usage", "math"),
+    coerce=INTENT_AUTO_COLLAPSE,
+)
+
+# Claim-select unconditionally requires --source in draft context.
+FLAG_CLAIM_SELECT = claim_select_flag(requires=("--source",))
+
+
+# ---------------------------------------------------------------------------
+# Spec
+# ---------------------------------------------------------------------------
+
+SPEC = CommandSpec(
+    name="draft",
+    positionals=(
+        PositionalSpec(
+            name="topic",
+            required=False,
+            notes=(
+                "Informal claim to draft. Optional when --source provides it. "
+                "At least one of topic or --source must be given."
+            ),
+        ),
+    ),
+    flags=(
+        FLAG_MODE,
+        FLAG_ELAB_CHECK,
+        level_flag(),
+        output_flag(),
+        out_flag(),
+        overwrite_flag(),
+        source_flag(),
+        FLAG_INTENT,
+        presentation_flag(),
+        FLAG_CLAIM_SELECT,
+    ),
+    cross_validations=(
+        # At least one of topic or --source must be given
+        TOPIC_OR_SOURCE_REQUIRED,
+        # --output=file without --out -> startup validation error
+        OUTPUT_FILE_REQUIRES_OUT,
+        # --output=file + existing target + no --overwrite -> startup validation error
+        OUTPUT_FILE_OVERWRITE_CHECK,
+        # --claim-select without --source -> startup validation error
+        # (Also enforced via FlagSpec.requires for the unconditional case,
+        #  but the CrossValidation gives a clearer error message.)
+        CLAIM_SELECT_REQUIRES_SOURCE,
+    ),
+)

--- a/plugins/lean4/lib/command_args/specs/formalize.py
+++ b/plugins/lean4/lib/command_args/specs/formalize.py
@@ -1,0 +1,302 @@
+"""Spec for /lean4:formalize — interactive formalization (draft + prove)."""
+from __future__ import annotations
+
+from typing import Mapping
+
+from ..types import (
+    Coercion,
+    CommandSpec,
+    CrossValidation,
+    FlagSpec,
+    ParseContext,
+    PositionalSpec,
+)
+from ..coercions import intent_auto_collapse
+from . import _common
+
+
+# ---------------------------------------------------------------------------
+# Formalize-specific coercions
+# ---------------------------------------------------------------------------
+
+INTENT_AUTO_COLLAPSE = Coercion(
+    rule_id="formalize-intent-auto-collapse",
+    fn=intent_auto_collapse,
+    doc_phrases=(
+        "--intent=auto inference: coerce internals -> usage and authoring -> usage",
+        "formalize does not define behavior for internals or authoring intents",
+    ),
+    summary=(
+        "After auto-inference, collapse internals/authoring to usage "
+        "(formalize only supports usage and math intents)."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Formalize-specific cross-validations
+# ---------------------------------------------------------------------------
+
+def _topic_or_source_full_validate(
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> list[str]:
+    """Cross-validation for: at least one of topic or --source required.
+
+    Convention: the parser injects positionals into the cross-validation
+    mapping as ``__positional_<name>`` keys so that cross-validators can
+    inspect them.  This validator expects ``__positional_topic`` to be set
+    to the topic string (or absent/falsy when the user omitted the topic
+    positional).  If the parser does not yet inject positionals this way,
+    a small patch to ``parse_invocation`` is needed (add positionals into
+    ``resolved_values`` before running cross-validations).
+    """
+    has_topic = bool(flags.get("__positional_topic"))
+    has_source = bool(flags.get("--source"))
+    if not has_topic and not has_source:
+        return [
+            "At least one of topic (positional) or --source must be given"
+        ]
+    return []
+
+
+TOPIC_OR_SOURCE = CrossValidation(
+    rule_id="formalize-topic-or-source",
+    fn=_topic_or_source_full_validate,
+    severity="error",
+    doc_phrases=(
+        "At least one of topic or --source must be given; "
+        "omitting both is a startup validation error.",
+    ),
+    summary="Require at least one of positional topic or --source.",
+)
+
+
+def _output_file_requires_out_validate(
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> list[str]:
+    """--output=file without --out -> startup validation error."""
+    if flags.get("--output") == "file" and not flags.get("--out"):
+        return ["--output=file requires --out to specify an output path"]
+    return []
+
+
+OUTPUT_FILE_REQUIRES_OUT = CrossValidation(
+    rule_id="formalize-output-file-requires-out",
+    fn=_output_file_requires_out_validate,
+    severity="error",
+    doc_phrases=(
+        "--output=file without --out -> startup validation error",
+    ),
+    summary="Require --out when --output=file.",
+)
+
+
+def _overwrite_check_validate(
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> list[str]:
+    """--output=file with existing target and no --overwrite -> error."""
+    import os
+
+    if flags.get("--output") != "file":
+        return []
+    out = flags.get("--out")
+    if not out:
+        return []  # handled by output-file-requires-out
+    overwrite = flags.get("--overwrite")
+    target = os.path.join(ctx.cwd, str(out))
+    if os.path.exists(target) and not overwrite:
+        return [
+            f"--output=file target {out!r} already exists; "
+            "pass --overwrite to allow overwriting"
+        ]
+    return []
+
+
+OVERWRITE_CHECK = CrossValidation(
+    rule_id="formalize-overwrite-check",
+    fn=_overwrite_check_validate,
+    severity="error",
+    doc_phrases=(
+        "--output=file with existing target and no --overwrite -> startup validation error",
+    ),
+    summary="Block overwrite of existing output file unless --overwrite is set.",
+)
+
+
+def _claim_select_requires_source_validate(
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> list[str]:
+    """--claim-select without --source -> startup validation error."""
+    claim_select = flags.get("--claim-select")
+    source = flags.get("--source")
+    if claim_select and not source:
+        return [
+            "--claim-select requires --source (nothing to select from)"
+        ]
+    return []
+
+
+CLAIM_SELECT_REQUIRES_SOURCE = CrossValidation(
+    rule_id="formalize-claim-select-requires-source",
+    fn=_claim_select_requires_source_validate,
+    severity="error",
+    doc_phrases=(
+        "--claim-select without --source -> startup validation error (nothing to select from).",
+    ),
+    summary="--claim-select is meaningless without --source.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Formalize-specific flags
+# ---------------------------------------------------------------------------
+
+FLAG_RIGOR = FlagSpec(
+    name="--rigor",
+    type="enum",
+    enum_values=("checked", "sketch", "axiomatic"),
+    default="checked",
+    enforcement="startup-validated",
+)
+
+FLAG_VERIFY = _common.FLAG_VERIFY
+
+FLAG_LEVEL = _common.FLAG_LEVEL
+
+FLAG_OUTPUT = _common.FLAG_OUTPUT
+FLAG_OUT = _common.FLAG_OUT
+FLAG_OVERWRITE = _common.FLAG_OVERWRITE
+
+FLAG_SOURCE = _common.FLAG_SOURCE
+
+FLAG_INTENT_FORMALIZE = FlagSpec(
+    name="--intent",
+    type="enum",
+    enum_values=("auto", "usage", "math"),
+    default="math",
+    enforcement="startup-validated",
+    coerce=INTENT_AUTO_COLLAPSE,
+    notes=(
+        "formalize only supports usage and math; "
+        "internals/authoring are collapsed to usage via coercion"
+    ),
+)
+
+FLAG_PRESENTATION = _common.FLAG_PRESENTATION
+
+FLAG_CLAIM_SELECT = FlagSpec(
+    name="--claim-select",
+    type="freeform",
+    default=None,
+    enforcement="startup-validated",
+    notes='first | named:"..." | regex:"...". Noninteractive claim selection from --source.',
+)
+
+FLAG_DRAFT_MODE = FlagSpec(
+    name="--draft-mode",
+    type="enum",
+    enum_values=("skeleton", "attempt"),
+    default="attempt",
+    enforcement="startup-validated",
+    notes="Mode for the draft phase (default is attempt in formalize context)",
+)
+
+FLAG_DRAFT_ELAB_CHECK = FlagSpec(
+    name="--draft-elab-check",
+    type="enum",
+    enum_values=("best-effort", "strict"),
+    default="best-effort",
+    enforcement="startup-validated",
+    notes="Elaboration check for the draft phase",
+)
+
+FLAG_DEEP = FlagSpec(
+    name="--deep",
+    type="enum",
+    enum_values=("never", "ask", "stuck", "always"),
+    default="never",
+    enforcement="startup-validated",
+    notes="Deep mode for prove phase",
+)
+
+FLAG_DEEP_SORRY_BUDGET = FlagSpec(
+    name="--deep-sorry-budget",
+    type="int",
+    default=1,
+    enforcement="session-enforced",
+    int_min=0,
+    notes="Max sorries per deep invocation",
+)
+
+FLAG_DEEP_TIME_BUDGET = FlagSpec(
+    name="--deep-time-budget",
+    type="duration",
+    default=10,  # 10 minutes
+    enforcement="best-effort",
+    notes="Advisory: scopes deep-mode subagent work. Not tracked or enforced.",
+)
+
+FLAG_COMMIT = FlagSpec(
+    name="--commit",
+    type="enum",
+    enum_values=("ask", "auto", "never"),
+    default="ask",
+    enforcement="startup-validated",
+    notes="Commit policy (inert in standalone formalize — no staging or committing)",
+)
+
+FLAG_GOLF = FlagSpec(
+    name="--golf",
+    type="enum",
+    enum_values=("prompt", "auto", "never"),
+    default="prompt",
+    enforcement="startup-validated",
+)
+
+
+# ---------------------------------------------------------------------------
+# Spec
+# ---------------------------------------------------------------------------
+
+SPEC = CommandSpec(
+    name="formalize",
+    positionals=(
+        PositionalSpec(
+            name="topic",
+            required=False,
+            notes=(
+                "Informal claim to formalize. Optional when --source provides it. "
+                "At least one of topic or --source must be given."
+            ),
+        ),
+    ),
+    flags=(
+        FLAG_RIGOR,
+        FLAG_VERIFY,
+        FLAG_LEVEL,
+        FLAG_OUTPUT,
+        FLAG_OUT,
+        FLAG_OVERWRITE,
+        FLAG_SOURCE,
+        FLAG_INTENT_FORMALIZE,
+        FLAG_PRESENTATION,
+        FLAG_CLAIM_SELECT,
+        FLAG_DRAFT_MODE,
+        FLAG_DRAFT_ELAB_CHECK,
+        FLAG_DEEP,
+        FLAG_DEEP_SORRY_BUDGET,
+        FLAG_DEEP_TIME_BUDGET,
+        FLAG_COMMIT,
+        FLAG_GOLF,
+    ),
+    cross_validations=(
+        TOPIC_OR_SOURCE,
+        OUTPUT_FILE_REQUIRES_OUT,
+        OVERWRITE_CHECK,
+        CLAIM_SELECT_REQUIRES_SOURCE,
+    ),
+)

--- a/plugins/lean4/lib/command_args/specs/formalize.py
+++ b/plugins/lean4/lib/command_args/specs/formalize.py
@@ -235,8 +235,8 @@ FLAG_DEEP_SORRY_BUDGET = FlagSpec(
 FLAG_DEEP_TIME_BUDGET = FlagSpec(
     name="--deep-time-budget",
     type="duration",
-    default=10,  # 10 minutes
-    enforcement="best-effort",
+    default="10m",
+    enforcement="advisory",
     notes="Advisory: scopes deep-mode subagent work. Not tracked or enforced.",
 )
 

--- a/plugins/lean4/lib/command_args/specs/learn.py
+++ b/plugins/lean4/lib/command_args/specs/learn.py
@@ -1,0 +1,256 @@
+"""Spec for /lean4:learn — interactive teaching and mathlib exploration."""
+from __future__ import annotations
+
+from typing import Mapping
+
+from ..types import (
+    Coercion,
+    CommandSpec,
+    CrossValidation,
+    FlagSpec,
+    ParseContext,
+    PositionalSpec,
+)
+from . import _common
+
+
+# ---------------------------------------------------------------------------
+# Learn-specific coercions
+# ---------------------------------------------------------------------------
+
+def _track_without_game_coerce(
+    value: object,
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> tuple[object, str | None]:
+    """--track without --style=game -> warn + reset to default (None)."""
+    if flags.get("--style") != "game":
+        return None, "--track ignored: only valid with --style=game"
+    return value, None
+
+
+TRACK_WITHOUT_GAME = Coercion(
+    rule_id="learn-track-without-game-ignore",
+    fn=_track_without_game_coerce,
+    doc_phrases=(
+        "--track without --style=game -> warn + ignore",
+        "Valid only with --style=game; ignored with warning otherwise.",
+    ),
+    summary="Reset --track to default when --style is not game.",
+)
+
+
+def _interactive_without_socratic_coerce(
+    value: object,
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> tuple[object, str | None]:
+    """--interactive without --style=socratic -> warn + reset to default (False)."""
+    if flags.get("--style") != "socratic":
+        return False, "--interactive ignored: only valid with --style=socratic"
+    return value, None
+
+
+INTERACTIVE_WITHOUT_SOCRATIC = Coercion(
+    rule_id="learn-interactive-without-socratic-ignore",
+    fn=_interactive_without_socratic_coerce,
+    doc_phrases=(
+        "--interactive without --style=socratic -> warn + ignore",
+        "Valid only with --style=socratic; ignored with warning otherwise.",
+    ),
+    summary="Reset --interactive to False when --style is not socratic.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Learn-specific cross-validations
+# ---------------------------------------------------------------------------
+
+def _source_overrides_scope_validate(
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> list[str]:
+    """--source + --scope=file|changed|project -> warning."""
+    source = flags.get("--source")
+    scope = flags.get("--scope")
+    if source and scope in ("file", "changed", "project"):
+        return ["--source overrides --scope for initial discovery"]
+    return []
+
+
+SOURCE_OVERRIDES_SCOPE = CrossValidation(
+    rule_id="learn-source-overrides-scope",
+    fn=_source_overrides_scope_validate,
+    severity="warning",
+    doc_phrases=(
+        '--source + --scope=file|changed|project -> warn "source overrides scope for initial discovery"',
+    ),
+    summary="Warn that --source takes priority over file/changed/project scope.",
+)
+
+
+def _output_file_requires_out_validate(
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> list[str]:
+    """--output=file without --out -> startup validation error."""
+    if flags.get("--output") == "file" and not flags.get("--out"):
+        return ["--output=file requires --out to specify an output path"]
+    return []
+
+
+OUTPUT_FILE_REQUIRES_OUT = CrossValidation(
+    rule_id="learn-output-file-requires-out",
+    fn=_output_file_requires_out_validate,
+    severity="error",
+    doc_phrases=(
+        "--output=file without --out -> startup validation error",
+    ),
+    summary="Require --out when --output=file.",
+)
+
+
+def _overwrite_check_validate(
+    flags: Mapping[str, object],
+    ctx: ParseContext,
+) -> list[str]:
+    """--output=file with existing target and no --overwrite -> error."""
+    import os
+
+    if flags.get("--output") != "file":
+        return []
+    out = flags.get("--out")
+    if not out:
+        return []  # handled by output-file-requires-out
+    overwrite = flags.get("--overwrite")
+    target = os.path.join(ctx.cwd, str(out))
+    if os.path.exists(target) and not overwrite:
+        return [
+            f"--output=file target {out!r} already exists; "
+            "pass --overwrite to allow overwriting"
+        ]
+    return []
+
+
+OVERWRITE_CHECK = CrossValidation(
+    rule_id="learn-overwrite-check",
+    fn=_overwrite_check_validate,
+    severity="error",
+    doc_phrases=(
+        "--output=file with existing target and no --overwrite -> startup validation error",
+    ),
+    summary="Block overwrite of existing output file unless --overwrite is set.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Learn-specific flags
+# ---------------------------------------------------------------------------
+
+FLAG_MODE = FlagSpec(
+    name="--mode",
+    type="enum",
+    enum_values=("auto", "repo", "mathlib"),
+    default="auto",
+    enforcement="startup-validated",
+    notes="auto resolves from topic after mode-resolution step",
+)
+
+FLAG_LEVEL = _common.FLAG_LEVEL
+
+FLAG_SCOPE = FlagSpec(
+    name="--scope",
+    type="enum",
+    enum_values=("auto", "file", "changed", "project", "topic"),
+    default="auto",
+    enforcement="startup-validated",
+    notes="Defaults depend on resolved --mode; see scope-defaults-by-mode table",
+)
+
+FLAG_STYLE = FlagSpec(
+    name="--style",
+    type="enum",
+    enum_values=("tour", "socratic", "exercise", "game"),
+    default="tour",
+    enforcement="startup-validated",
+)
+
+FLAG_OUTPUT = _common.FLAG_OUTPUT
+FLAG_OUT = _common.FLAG_OUT
+FLAG_OVERWRITE = _common.FLAG_OVERWRITE
+
+FLAG_INTERACTIVE = FlagSpec(
+    name="--interactive",
+    type="bool",
+    default=False,
+    enforcement="startup-validated",
+    coerce=INTERACTIVE_WITHOUT_SOCRATIC,
+    notes="True Socratic method; valid only with --style=socratic",
+)
+
+FLAG_INTENT = _common.FLAG_INTENT_LEARN
+
+FLAG_PRESENTATION = _common.FLAG_PRESENTATION
+
+FLAG_VERIFY = _common.FLAG_VERIFY
+
+FLAG_TRACK = FlagSpec(
+    name="--track",
+    type="enum",
+    enum_values=("nng-like", "set-theory-like", "analysis-like", "proofs-reintro"),
+    default=None,
+    enforcement="startup-validated",
+    coerce=TRACK_WITHOUT_GAME,
+    notes="Exercise ladder; valid only with --style=game",
+)
+
+FLAG_SOURCE = _common.FLAG_SOURCE
+
+FLAG_ADAPTIVE = FlagSpec(
+    name="--adaptive",
+    type="enum",
+    enum_values=("on", "off"),
+    default="on",
+    enforcement="startup-validated",
+    notes="Controls whether the debate can change style/level mid-session",
+)
+
+
+# ---------------------------------------------------------------------------
+# Spec
+# ---------------------------------------------------------------------------
+
+SPEC = CommandSpec(
+    name="learn",
+    positionals=(
+        PositionalSpec(
+            name="topic",
+            required=False,
+            notes=(
+                "Free-text topic, theorem name, file path, or natural-language claim. "
+                "If omitted, start conversational discovery."
+            ),
+        ),
+    ),
+    flags=(
+        FLAG_MODE,
+        FLAG_LEVEL,
+        FLAG_SCOPE,
+        FLAG_STYLE,
+        FLAG_OUTPUT,
+        FLAG_OUT,
+        FLAG_OVERWRITE,
+        FLAG_INTERACTIVE,
+        FLAG_INTENT,
+        FLAG_PRESENTATION,
+        FLAG_VERIFY,
+        FLAG_TRACK,
+        FLAG_SOURCE,
+        FLAG_ADAPTIVE,
+    ),
+    cross_validations=(
+        SOURCE_OVERRIDES_SCOPE,
+        OUTPUT_FILE_REQUIRES_OUT,
+        OVERWRITE_CHECK,
+    ),
+)

--- a/plugins/lean4/lib/command_args/specs/prove.py
+++ b/plugins/lean4/lib/command_args/specs/prove.py
@@ -1,0 +1,197 @@
+"""Spec for /lean4:prove — guided cycle-by-cycle theorem proving."""
+from __future__ import annotations
+
+from ..types import (
+    CommandSpec,
+    FlagSpec,
+    PositionalSpec,
+)
+
+
+# ---------------------------------------------------------------------------
+# Flag definitions
+# ---------------------------------------------------------------------------
+
+FLAG_REPAIR_ONLY = FlagSpec(
+    name="--repair-only",
+    type="bool",
+    default=False,
+    enforcement="startup-validated",
+    notes="Fix build errors only, skip sorry-filling",
+)
+
+FLAG_PLANNING = FlagSpec(
+    name="--planning",
+    type="enum",
+    enum_values=("ask", "on", "off"),
+    default="ask",
+    enforcement="startup-validated",
+    notes="ask prompts at startup",
+)
+
+FLAG_REVIEW_SOURCE = FlagSpec(
+    name="--review-source",
+    type="enum",
+    enum_values=("internal", "external", "both", "none"),
+    default="internal",
+    enforcement="startup-validated",
+)
+
+FLAG_REVIEW_EVERY = FlagSpec(
+    name="--review-every",
+    type="freeform",
+    default="checkpoint",
+    enforcement="startup-validated",
+    notes="N (sorries), checkpoint, or never",
+)
+
+FLAG_CHECKPOINT = FlagSpec(
+    name="--checkpoint",
+    type="bool",
+    default=True,
+    enforcement="startup-validated",
+)
+
+FLAG_DEEP = FlagSpec(
+    name="--deep",
+    type="enum",
+    enum_values=("never", "ask", "stuck", "always"),
+    default="never",
+    enforcement="startup-validated",
+)
+
+FLAG_DEEP_SORRY_BUDGET = FlagSpec(
+    name="--deep-sorry-budget",
+    type="int",
+    default=1,
+    int_min=1,
+    enforcement="session-enforced",
+)
+
+FLAG_DEEP_TIME_BUDGET = FlagSpec(
+    name="--deep-time-budget",
+    type="duration",
+    default="10m",
+    enforcement="advisory",
+    notes="Scopes deep-mode subagent work. Not tracked or enforced.",
+)
+
+FLAG_MAX_DEEP_PER_CYCLE = FlagSpec(
+    name="--max-deep-per-cycle",
+    type="int",
+    default=1,
+    int_min=0,
+    enforcement="session-enforced",
+)
+
+FLAG_DEEP_SNAPSHOT = FlagSpec(
+    name="--deep-snapshot",
+    type="enum",
+    enum_values=("stash",),
+    default="stash",
+    enforcement="startup-validated",
+    notes="V1: stash only",
+)
+
+FLAG_DEEP_ROLLBACK = FlagSpec(
+    name="--deep-rollback",
+    type="enum",
+    enum_values=("on-regression", "on-no-improvement", "always", "never"),
+    default="on-regression",
+    enforcement="startup-validated",
+)
+
+FLAG_DEEP_SCOPE = FlagSpec(
+    name="--deep-scope",
+    type="enum",
+    enum_values=("target", "cross-file"),
+    default="target",
+    enforcement="startup-validated",
+)
+
+FLAG_DEEP_MAX_FILES = FlagSpec(
+    name="--deep-max-files",
+    type="int",
+    default=1,
+    int_min=1,
+    enforcement="session-enforced",
+)
+
+FLAG_DEEP_MAX_LINES = FlagSpec(
+    name="--deep-max-lines",
+    type="int",
+    default=120,
+    int_min=1,
+    enforcement="session-enforced",
+)
+
+FLAG_DEEP_REGRESSION_GATE = FlagSpec(
+    name="--deep-regression-gate",
+    type="enum",
+    enum_values=("strict", "off"),
+    default="strict",
+    enforcement="startup-validated",
+    notes="strict auto-aborts on regression",
+)
+
+FLAG_BATCH_SIZE = FlagSpec(
+    name="--batch-size",
+    type="int",
+    default=1,
+    int_min=1,
+    enforcement="advisory",
+)
+
+FLAG_COMMIT = FlagSpec(
+    name="--commit",
+    type="enum",
+    enum_values=("ask", "auto", "never"),
+    default="ask",
+    enforcement="startup-validated",
+    notes="ask prompts before each commit",
+)
+
+FLAG_GOLF = FlagSpec(
+    name="--golf",
+    type="enum",
+    enum_values=("prompt", "auto", "never"),
+    default="prompt",
+    enforcement="startup-validated",
+)
+
+
+# ---------------------------------------------------------------------------
+# Spec
+# ---------------------------------------------------------------------------
+
+SPEC = CommandSpec(
+    name="prove",
+    positionals=(
+        PositionalSpec(
+            name="scope",
+            required=False,
+            notes="Specific file or theorem to focus on; defaults to all",
+        ),
+    ),
+    flags=(
+        FLAG_REPAIR_ONLY,
+        FLAG_PLANNING,
+        FLAG_REVIEW_SOURCE,
+        FLAG_REVIEW_EVERY,
+        FLAG_CHECKPOINT,
+        FLAG_DEEP,
+        FLAG_DEEP_SORRY_BUDGET,
+        FLAG_DEEP_TIME_BUDGET,
+        FLAG_MAX_DEEP_PER_CYCLE,
+        FLAG_DEEP_SNAPSHOT,
+        FLAG_DEEP_ROLLBACK,
+        FLAG_DEEP_SCOPE,
+        FLAG_DEEP_MAX_FILES,
+        FLAG_DEEP_MAX_LINES,
+        FLAG_DEEP_REGRESSION_GATE,
+        FLAG_BATCH_SIZE,
+        FLAG_COMMIT,
+        FLAG_GOLF,
+    ),
+    cross_validations=(),
+)

--- a/plugins/lean4/lib/command_args/tokenizer.py
+++ b/plugins/lean4/lib/command_args/tokenizer.py
@@ -1,0 +1,32 @@
+"""shlex-based POSIX tokenizer for slash-command raw tails."""
+from __future__ import annotations
+
+import shlex
+
+
+def tokenize(raw_tail: str) -> list[str]:
+    """Split a raw tail into tokens using POSIX shell quoting rules.
+
+    Handles --flag=value, --flag value, "quoted strings", and backslash escapes.
+    Returns an empty list for empty/whitespace-only input.
+    """
+    stripped = raw_tail.strip()
+    if not stripped:
+        return []
+    try:
+        return shlex.split(stripped)
+    except ValueError as e:
+        raise ValueError(f"Failed to tokenize input: {e}") from e
+
+
+def normalize_flags(tokens: list[str]) -> list[str]:
+    """Expand --flag=value into [--flag, value] and pass other tokens through."""
+    result: list[str] = []
+    for token in tokens:
+        if token.startswith("--") and "=" in token:
+            flag, _, value = token.partition("=")
+            result.append(flag)
+            result.append(value)
+        else:
+            result.append(token)
+    return result

--- a/plugins/lean4/lib/command_args/types.py
+++ b/plugins/lean4/lib/command_args/types.py
@@ -1,0 +1,138 @@
+"""Core data types for the lean4 slash-command parser."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Literal, Mapping
+
+EnforcementClass = Literal[
+    "startup-validated",
+    "session-enforced",
+    "best-effort",
+    "advisory",
+]
+
+FlagType = Literal["bool", "enum", "int", "duration", "path", "freeform"]
+
+Source = Literal["explicit", "default", "coerced"]
+
+Severity = Literal["error", "warning"]
+
+
+@dataclass(frozen=True)
+class ParseContext:
+    """Carries the user's workspace cwd through coercion/validation callables."""
+
+    cwd: str  # absolute path to the user's workspace
+
+
+# Bare callable signatures — wrapped in Coercion / CrossValidation records.
+CoerceFn = Callable[[object, Mapping[str, object], ParseContext], tuple[object, str | None]]
+ValidateFn = Callable[[Mapping[str, object], ParseContext], list[str]]
+
+
+@dataclass(frozen=True)
+class Coercion:
+    """A per-flag value-changing coercion rule with doc-sync metadata."""
+
+    rule_id: str
+    fn: CoerceFn
+    doc_phrases: tuple[str, ...] = ()
+    summary: str = ""
+    # A Coercion ALWAYS changes the value and sets source="coerced".
+    # "warn + ignore" is a coercion to spec.default.
+    # For warning-only rules where value is UNCHANGED, use CrossValidation(severity="warning").
+
+
+@dataclass(frozen=True)
+class CrossValidation:
+    """A multi-flag or warning-only validation rule with doc-sync metadata."""
+
+    rule_id: str
+    fn: ValidateFn
+    severity: Severity = "error"
+    doc_phrases: tuple[str, ...] = ()
+    summary: str = ""
+    # severity="error" → returned strings go to ParseResult.errors
+    # severity="warning" → returned strings go to ParseResult.warnings
+    # One CrossValidation is either entirely error-producing or entirely
+    # warning-producing. Split into two records if a rule needs both.
+
+
+@dataclass(frozen=True)
+class FlagSpec:
+    """Specification for a single command flag."""
+
+    name: str
+    aliases: tuple[str, ...] = ()
+    type: FlagType = "freeform"
+    enum_values: tuple[str, ...] = ()
+    default: object = None
+    enforcement: EnforcementClass = "startup-validated"
+    requires: tuple[str, ...] = ()  # unconditional companion flags
+    forbidden_with: tuple[str, ...] = ()
+    coerce: Coercion | None = None
+    int_min: int | None = None
+    int_max: int | None = None
+    notes: str = ""
+
+
+@dataclass(frozen=True)
+class PositionalSpec:
+    """Specification for a positional argument."""
+
+    name: str
+    required: bool = False
+    notes: str = ""
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    """Full specification for a slash command's parser-decidable inputs."""
+
+    name: str
+    positionals: tuple[PositionalSpec, ...] = ()
+    flags: tuple[FlagSpec, ...] = ()
+    cross_validations: tuple[CrossValidation, ...] = ()
+
+
+@dataclass(frozen=True)
+class ResolvedFlag:
+    """A single flag's resolved value with provenance metadata."""
+
+    value: object
+    source: Source
+    enforcement: EnforcementClass
+    coerced_from: object = None  # only set when source == "coerced"
+
+
+@dataclass
+class ParseResult:
+    """The output of parse_invocation — a lossless representation of parsed inputs."""
+
+    command: str
+    raw_tail: str
+    positionals: dict[str, str] = field(default_factory=dict)
+    options: dict[str, ResolvedFlag] = field(default_factory=dict)
+    coercions: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Serialize to a plain dict for JSON output / artifact writing."""
+        return {
+            "command": self.command,
+            "raw_tail": self.raw_tail,
+            "positionals": dict(self.positionals),
+            "options": {
+                name: {
+                    "value": rf.value,
+                    "source": rf.source,
+                    "enforcement": rf.enforcement,
+                    **({"coerced_from": rf.coerced_from} if rf.coerced_from is not None else {}),
+                }
+                for name, rf in self.options.items()
+            },
+            "coercions": list(self.coercions),
+            "warnings": list(self.warnings),
+            "errors": list(self.errors),
+        }

--- a/plugins/lean4/lib/scripts/cycle_tracker.sh
+++ b/plugins/lean4/lib/scripts/cycle_tracker.sh
@@ -269,10 +269,15 @@ cmd_init() {
   # Clean stale sessions (>24h, owned by current user)
   find /tmp -maxdepth 1 -name 'lean4-session-*.json' -user "$(id -u)" -mmin +1440 -delete 2>/dev/null || true
 
-  # Create state file via mktemp (no race)
+  # Create state file via mktemp (no race).
+  # BSD mktemp (macOS) requires the template to END with X's — a .json
+  # suffix after the X's is treated as a literal path, not a template.
+  # So we create without .json, then rename.
   _detect_backend
-  local state_file
-  state_file=$(mktemp /tmp/lean4-session-XXXXXX.json)
+  local state_file tmp_file
+  tmp_file=$(mktemp /tmp/lean4-session-XXXXXX)
+  state_file="${tmp_file}.json"
+  mv "$tmp_file" "$state_file"
   local session_id
   session_id=$(basename "$state_file" .json)
 

--- a/plugins/lean4/lib/scripts/cycle_tracker.sh
+++ b/plugins/lean4/lib/scripts/cycle_tracker.sh
@@ -225,7 +225,7 @@ _parse_duration() {
   fi
   local num="${val%%[mshMSH]}"
   local suffix="${val##*[0-9]}"
-  suffix="${suffix,,}"  # lowercase
+  suffix="$(printf '%s' "$suffix" | tr '[:upper:]' '[:lower:]')"  # portable lowercase
   case "$suffix" in
     s) echo "$num" ;;
     h) echo $(( num * 3600 )) ;;

--- a/plugins/lean4/lib/scripts/parse_command_args.py
+++ b/plugins/lean4/lib/scripts/parse_command_args.py
@@ -28,16 +28,27 @@ def main() -> int:
         print(__doc__, file=sys.stderr)
         return 1
 
-    # Parse CLI: <command> [--cwd PATH] -- <raw tail>
+    # Parse CLI: <command> [--cwd PATH] -- <single raw tail string>
+    # The raw tail is passed as exactly ONE shell argument after "--" so that
+    # quoting boundaries are preserved. Using multiple args after "--" would
+    # lose the original quoting (e.g. -- "Theorem 1" becomes two words).
     command_name = args[0]
     cwd = os.getcwd()
-    raw_tail_parts: list[str] = []
+    raw_tail: str | None = None
     past_separator = False
 
     i = 1
     while i < len(args):
         if past_separator:
-            raw_tail_parts.append(args[i])
+            if raw_tail is not None:
+                print(
+                    "Error: expected exactly one argument after '--' (the raw tail "
+                    "as a single string). Got multiple arguments. Wrap the tail in "
+                    "quotes: -- '\"Theorem 1\" --mode=attempt'",
+                    file=sys.stderr,
+                )
+                return 1
+            raw_tail = args[i]
         elif args[i] == "--":
             past_separator = True
         elif args[i] == "--cwd" and i + 1 < len(args):
@@ -52,7 +63,8 @@ def main() -> int:
         print("Error: missing '--' separator before raw tail", file=sys.stderr)
         return 1
 
-    raw_tail = " ".join(raw_tail_parts)
+    if raw_tail is None:
+        raw_tail = ""
 
     # Look up spec
     spec = COMMAND_SPECS.get(command_name)

--- a/plugins/lean4/lib/scripts/parse_command_args.py
+++ b/plugins/lean4/lib/scripts/parse_command_args.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Standalone CLI for the lean4 slash-command parser.
+
+Usage:
+    python3 parse_command_args.py <command> [--cwd PATH] -- <raw tail>
+
+Exit codes:
+    0 — success (prints ParseResult JSON to stdout)
+    1 — usage error (bad CLI arguments)
+    2 — validation error (prints error JSON to stdout)
+"""
+import json
+import os
+import sys
+
+# lib/scripts/parse_command_args.py -> dirname = lib/scripts -> parent = lib
+_LIB_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _LIB_ROOT not in sys.path:
+    sys.path.insert(0, _LIB_ROOT)
+
+from command_args import COMMAND_SPECS, format_validated_block, parse_invocation  # noqa: E402
+
+
+def main() -> int:
+    args = sys.argv[1:]
+
+    if not args or args[0] in ("-h", "--help"):
+        print(__doc__, file=sys.stderr)
+        return 1
+
+    # Parse CLI: <command> [--cwd PATH] -- <raw tail>
+    command_name = args[0]
+    cwd = os.getcwd()
+    raw_tail_parts: list[str] = []
+    past_separator = False
+
+    i = 1
+    while i < len(args):
+        if past_separator:
+            raw_tail_parts.append(args[i])
+        elif args[i] == "--":
+            past_separator = True
+        elif args[i] == "--cwd" and i + 1 < len(args):
+            cwd = args[i + 1]
+            i += 1
+        else:
+            print(f"Error: unexpected argument {args[i]!r} before '--'", file=sys.stderr)
+            return 1
+        i += 1
+
+    if not past_separator:
+        print("Error: missing '--' separator before raw tail", file=sys.stderr)
+        return 1
+
+    raw_tail = " ".join(raw_tail_parts)
+
+    # Look up spec
+    spec = COMMAND_SPECS.get(command_name)
+    if spec is None:
+        available = ", ".join(sorted(COMMAND_SPECS.keys()))
+        print(f"Error: unknown command {command_name!r}; available: {available}", file=sys.stderr)
+        return 1
+
+    # Normalize cwd and parse
+    cwd = os.path.abspath(cwd)
+    result = parse_invocation(spec, raw_tail, cwd=cwd)
+
+    if result.errors:
+        json.dump({"errors": result.errors, "command": command_name}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return 2
+
+    # Success — print full result as JSON
+    json.dump(result.to_dict(), sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/lean4/skills/lean4/SKILL.md
+++ b/plugins/lean4/skills/lean4/SKILL.md
@@ -35,10 +35,23 @@ Use this skill whenever you're editing Lean 4 proofs, debugging Lean builds, for
 | `/lean4:learn` | Interactive teaching and mathlib exploration |
 | `/lean4:doctor` | Diagnostics, cleanup, and migration help |
 
-Slash-command inputs are raw text interpreted by the model, not host-parsed
-CLI flags. Commands with flags must parse and announce resolved inputs before
-acting; `--max-total-runtime` is a best-effort wall-clock budget, not a
-host-enforced timeout. See [command-invocation.md](references/command-invocation.md).
+This plugin ships a host-agnostic parser (`lib/command_args/`) that covers the
+parser-decidable startup rules of the six parameter-heavy commands (`draft`,
+`learn`, `formalize`, `autoformalize`, `prove`, `autoprove`). A small set of
+documented startup rules in these commands depend on runtime context (repo-
+level search, interactive prompting) and are applied by the command after
+reading the parser's output. The other commands (`checkpoint`, `review`,
+`refactor`, `golf`, `doctor`) remain model-parsed.
+When a host adapter installs the `UserPromptSubmit` hook, the parser runs
+before the model sees a `/lean4:*` prompt matching one of the six covered
+commands, injects a `validated-invocation` block into context, and rejects
+invalid invocations at the hook level; invocations of the other commands pass
+through unchanged. Hosts without the hook fall back to model-parsed startup
+via the shared [command-invocation.md](references/command-invocation.md)
+contract.
+Commands always announce resolved inputs, reject invalid startup configs before
+doing work, and treat wall-clock budgets like `--max-total-runtime` as
+best-effort.
 
 ### Which Command?
 

--- a/plugins/lean4/skills/lean4/references/command-invocation.md
+++ b/plugins/lean4/skills/lean4/references/command-invocation.md
@@ -1,9 +1,32 @@
 # Command Invocation Contract
 
-Slash-command inputs in this plugin are **model-parsed, not host-parsed**. The
-host passes the raw text after `/lean4:<command>` to the agent; it does **not**
-apply a schema, validate enums, coerce values, or enforce timeouts on the
-plugin's behalf.
+This plugin ships a host-agnostic parser (`lib/command_args/`) that covers the
+**parser-decidable** startup rules of the six parameter-heavy commands —
+`draft`, `learn`, `formalize`, `autoformalize`, `prove`, and `autoprove`.
+Parser-decidable rules are those whose outcome can be fully determined from
+flags, positionals, and `os.path.exists` checks alone, without repo-level
+search or interactive user prompting. A small set of documented startup rules
+in these commands depend on runtime context the parser cannot evaluate (e.g.
+local-declaration resolution in learn); those are listed in the forward-
+exclusions and are applied by the command at runtime after reading the parser's
+output. Other commands in this plugin (`checkpoint`, `review`, `refactor`,
+`golf`, `doctor`) are not parameter-heavy and are not covered by
+`lib/command_args/`; they remain model-parsed on every host.
+
+For the six covered commands, whether the parser actually runs before the
+model sees a slash-command invocation depends on the host adapter:
+
+- The **Claude Code adapter** invokes the parser from a `UserPromptSubmit`
+  hook before the model sees the prompt and rejects invalid invocations with
+  a hook-level block.
+- **Other host adapters** MAY invoke the same parser via
+  `lib/scripts/parse_command_args.py`. Hosts that do not integrate the parser
+  fall back to the model-parsed **Required Startup Behavior** below — on
+  those hosts, slash-command inputs remain model-parsed.
+
+Regardless of host or command, the plugin does **not** enforce wall-clock
+budgets on the plugin's behalf — those remain best-effort and are re-checked
+at safe boundaries by the command itself.
 
 ## Required Startup Behavior
 
@@ -21,6 +44,44 @@ substantive work:
 4. Maintain promised session counters explicitly (`cycles_run`,
    `stuck_cycles`, `deep_invocations`, and similar state) rather than relying on
    the model to remember them informally.
+
+## Validated Invocation Block (host-provided)
+
+A host adapter MAY pre-parse a slash-command invocation and inject the result
+into the model's context as a fenced `validated-invocation` block. The block is
+a lossless serialization of the host parser's `ParseResult`.
+
+When such a block appears in context for the current `/lean4:<command>`
+invocation, the command **MUST** treat it as the authoritative interpretation
+of **parser-decidable** inputs and **MUST NOT** re-parse the raw invocation
+text for those inputs.
+
+Commands that have **repo-dependent startup rules** — rules whose outcome
+depends on runtime context the host parser cannot evaluate — MAY apply
+those rules after reading the block, refining specific fields with runtime
+context. The command's emitted Resolved Inputs summary may differ from the
+block for forward-excluded fields only; for all parser-decided fields, the
+Resolved Inputs MUST match the block exactly.
+
+When no `validated-invocation` block appears (non-Claude hosts, or hosts that
+have not installed the parser hook), the command falls back to the
+**Required Startup Behavior** above and parses the raw text itself.
+
+A `validated-invocation` block carrying any startup-validation error never
+reaches the model: the host adapter rejects the prompt before invocation. A
+block carrying only warnings reaches the model and the command surfaces those
+warnings in its Resolved Inputs summary.
+
+## Adapter Implementations
+
+- **Default (model-parsed):** non-Claude hosts pass the raw tail to the model;
+  the command parses it per the Required Startup Behavior above.
+- **Claude plugin (hook-validated):** the `UserPromptSubmit` hook
+  `hooks/validate_user_prompt.py` parses `/lean4:*` prompts via
+  `lib/command_args/` before the model sees them. Hard errors are returned to
+  the user as a hook rejection; successful parses are injected as a
+  `validated-invocation` block. Other hosts can call the same parser via
+  `lib/scripts/parse_command_args.py`.
 
 ## Enforcement Classes
 

--- a/plugins/lean4/tests/command_args/_doc_sync_allowlist.py
+++ b/plugins/lean4/tests/command_args/_doc_sync_allowlist.py
@@ -1,0 +1,18 @@
+"""Reverse-direction allow-list for the doc-sync test (Layer 3).
+
+Each entry is either:
+  - A rule_id string (for Coercion / CrossValidation records)
+  - A (command, "requires"|"forbidden_with", flag, other) tuple
+
+Used for spec-side constraints that intentionally have no documented prose.
+The forward-direction step (5) cannot use this list — it has its own
+exclusions mechanism at _doc_sync_forward_exclusions.py.
+
+This list must stay under ~10 entries.
+"""
+
+ALLOWLIST: list[str | tuple[str, str, str, str]] = [
+    # Currently empty — all spec-encoded rules have corresponding doc prose.
+    # If a rule is added to COMMAND_SPECS without a doc update, add it here
+    # temporarily with a justification comment naming the issue or commit.
+]

--- a/plugins/lean4/tests/command_args/_doc_sync_forward_exclusions.py
+++ b/plugins/lean4/tests/command_args/_doc_sync_forward_exclusions.py
@@ -1,0 +1,34 @@
+"""Forward-direction exclusions for the doc-sync test (Layer 3).
+
+Each entry is a (command_name, distinctive_substring) pair for a documented
+rule that is intentionally NOT encoded in COMMAND_SPECS because encoding it
+would require I/O beyond os.path.exists, interactive user prompting, or
+repo-level search.
+
+The doc-sync test's forward pass (step 5) checks extracted doc fragments
+against this list BEFORE asserting they are encoded in specs. If a fragment
+matches an exclusion, it is skipped.
+
+This list must stay under ~10 entries. If it grows much larger, reconsider
+either the parser's I/O budget or the doc format.
+"""
+
+EXCLUSIONS: list[tuple[str, str]] = [
+    # --- Class (a): file-content I/O beyond os.path.exists ---
+    # .gitignore hints — requires reading .gitignore
+    ("draft", "not in `.gitignore`"),
+    ("learn", "not in `.gitignore`"),
+    ("formalize", "not in `.gitignore`"),
+    # --source unreadable/unsupported format — requires content sniffing
+    ("draft", "unreadable format"),
+    ("formalize", "unreadable format"),
+    ("learn", "Unsupported source type"),
+
+    # --- Class (b): interactive user prompting ---
+    # learn track picker — model-side interactive flow
+    ("learn", "prompt track picker"),
+
+    # --- Class (c): repo-level search ---
+    # learn scope-coercion exception — requires local-declaration resolution
+    ("learn", "unless topic resolves to a local declaration"),
+]

--- a/plugins/lean4/tests/command_args/test_formatter.py
+++ b/plugins/lean4/tests/command_args/test_formatter.py
@@ -1,0 +1,142 @@
+"""Snapshot tests for format_validated_block / parse_validated_block round-trip."""
+import os
+import sys
+import unittest
+
+# Ensure the library package is importable.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "lib"))
+
+from command_args.formatter import format_validated_block, parse_validated_block
+from command_args.types import ParseResult, ResolvedFlag
+
+
+class TestFormatterRoundTrip(unittest.TestCase):
+    """format_validated_block and parse_validated_block are exact inverses."""
+
+    def test_basic_round_trip(self):
+        """Build a ParseResult with known values, format it, parse it back."""
+        original = ParseResult(
+            command="draft",
+            raw_tail='"Theorem 1" --mode=skeleton',
+            positionals={"topic": "Theorem 1"},
+            options={
+                "--mode": ResolvedFlag(
+                    value="skeleton", source="explicit",
+                    enforcement="startup-validated",
+                ),
+                "--level": ResolvedFlag(
+                    value="intermediate", source="default",
+                    enforcement="startup-validated",
+                ),
+            },
+            coercions=[],
+            warnings=[],
+            errors=[],
+        )
+        block = format_validated_block(original)
+        restored = parse_validated_block(block)
+
+        self.assertEqual(restored.command, original.command)
+        self.assertEqual(restored.raw_tail, original.raw_tail)
+        self.assertEqual(restored.positionals, original.positionals)
+        self.assertEqual(restored.errors, original.errors)
+        self.assertEqual(restored.coercions, original.coercions)
+        self.assertEqual(restored.warnings, original.warnings)
+        for name in original.options:
+            self.assertEqual(restored.options[name].value, original.options[name].value)
+            self.assertEqual(restored.options[name].source, original.options[name].source)
+            self.assertEqual(restored.options[name].enforcement, original.options[name].enforcement)
+            self.assertIsNone(restored.options[name].coerced_from)
+
+    def test_round_trip_with_coerced_flag(self):
+        """Coerced flag preserves source='coerced' and coerced_from value."""
+        original = ParseResult(
+            command="draft",
+            raw_tail='"x" --intent=auto',
+            positionals={"topic": "x"},
+            options={
+                "--intent": ResolvedFlag(
+                    value="usage", source="coerced",
+                    enforcement="startup-validated",
+                    coerced_from="auto",
+                ),
+            },
+            coercions=["--intent=auto coerced to usage"],
+            warnings=[],
+            errors=[],
+        )
+        block = format_validated_block(original)
+        restored = parse_validated_block(block)
+
+        self.assertEqual(restored.options["--intent"].value, "usage")
+        self.assertEqual(restored.options["--intent"].source, "coerced")
+        self.assertEqual(restored.options["--intent"].coerced_from, "auto")
+        self.assertEqual(restored.coercions, ["--intent=auto coerced to usage"])
+
+    def test_round_trip_empty_positionals(self):
+        """A result with no positionals round-trips through (none) sentinel."""
+        original = ParseResult(
+            command="autoprove",
+            raw_tail="--planning=on",
+            positionals={},
+            options={
+                "--planning": ResolvedFlag(
+                    value="on", source="explicit",
+                    enforcement="startup-validated",
+                ),
+            },
+        )
+        block = format_validated_block(original)
+        restored = parse_validated_block(block)
+
+        self.assertEqual(restored.positionals, {})
+        self.assertEqual(restored.options["--planning"].value, "on")
+
+    def test_round_trip_with_warnings_and_coercions(self):
+        """Both warnings and coercions lists survive the round-trip."""
+        original = ParseResult(
+            command="learn",
+            raw_tail="topology --track=nng-like",
+            positionals={"topic": "topology"},
+            options={
+                "--track": ResolvedFlag(
+                    value=None, source="coerced",
+                    enforcement="startup-validated",
+                    coerced_from="nng-like",
+                ),
+                "--style": ResolvedFlag(
+                    value="tour", source="default",
+                    enforcement="startup-validated",
+                ),
+            },
+            coercions=["--track ignored: only valid with --style=game"],
+            warnings=["--source overrides --scope for initial discovery"],
+            errors=[],
+        )
+        block = format_validated_block(original)
+        restored = parse_validated_block(block)
+
+        self.assertEqual(restored.coercions, original.coercions)
+        self.assertEqual(restored.warnings, original.warnings)
+
+    def test_block_fencing(self):
+        """Formatted block starts with ```validated-invocation and ends with ```."""
+        result = ParseResult(
+            command="prove",
+            raw_tail="MyFile.lean",
+            positionals={"scope": "MyFile.lean"},
+            options={
+                "--repair-only": ResolvedFlag(
+                    value=False, source="default",
+                    enforcement="startup-validated",
+                ),
+            },
+        )
+        block = format_validated_block(result)
+        lines = block.split("\n")
+        self.assertEqual(lines[0], "```validated-invocation")
+        self.assertEqual(lines[-1], "```")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lean4/tests/command_args/test_formatter.py
+++ b/plugins/lean4/tests/command_args/test_formatter.py
@@ -138,5 +138,64 @@ class TestFormatterRoundTrip(unittest.TestCase):
         self.assertEqual(lines[-1], "```")
 
 
+    def test_round_trip_string_that_looks_like_int(self):
+        """String '123' must not become int 123 after round-trip (lossless)."""
+        result = ParseResult(
+            command="draft",
+            raw_tail='--source=123 "x"',
+            positionals={"topic": "x"},
+            options={
+                "--source": ResolvedFlag(
+                    value="123", source="explicit",
+                    enforcement="startup-validated",
+                ),
+                "--mode": ResolvedFlag(
+                    value="skeleton", source="default",
+                    enforcement="startup-validated",
+                ),
+            },
+        )
+        block = format_validated_block(result)
+        parsed = parse_validated_block(block)
+        self.assertEqual(parsed.options["--source"].value, "123")
+        self.assertIsInstance(parsed.options["--source"].value, str)
+
+    def test_round_trip_string_none_literal(self):
+        """String 'None' (as a value) must not become Python None."""
+        result = ParseResult(
+            command="draft",
+            raw_tail='"x"',
+            positionals={"topic": "x"},
+            options={
+                "--source": ResolvedFlag(
+                    value="None", source="explicit",
+                    enforcement="startup-validated",
+                ),
+            },
+        )
+        block = format_validated_block(result)
+        parsed = parse_validated_block(block)
+        self.assertEqual(parsed.options["--source"].value, "None")
+        self.assertIsInstance(parsed.options["--source"].value, str)
+
+    def test_round_trip_string_true_literal(self):
+        """String 'true' must not become Python True."""
+        result = ParseResult(
+            command="draft",
+            raw_tail='"x"',
+            positionals={"topic": "x"},
+            options={
+                "--source": ResolvedFlag(
+                    value="true", source="explicit",
+                    enforcement="startup-validated",
+                ),
+            },
+        )
+        block = format_validated_block(result)
+        parsed = parse_validated_block(block)
+        self.assertEqual(parsed.options["--source"].value, "true")
+        self.assertIsInstance(parsed.options["--source"].value, str)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/lean4/tests/command_args/test_formatter.py
+++ b/plugins/lean4/tests/command_args/test_formatter.py
@@ -1,9 +1,9 @@
 """Snapshot tests for format_validated_block / parse_validated_block round-trip."""
+import json
 import os
 import sys
 import unittest
 
-# Ensure the library package is importable.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "lib"))
 
 from command_args.formatter import format_validated_block, parse_validated_block
@@ -14,14 +14,13 @@ class TestFormatterRoundTrip(unittest.TestCase):
     """format_validated_block and parse_validated_block are exact inverses."""
 
     def test_basic_round_trip(self):
-        """Build a ParseResult with known values, format it, parse it back."""
-        original = ParseResult(
+        result = ParseResult(
             command="draft",
-            raw_tail='"Theorem 1" --mode=skeleton',
+            raw_tail='"Theorem 1" --mode=attempt',
             positionals={"topic": "Theorem 1"},
             options={
                 "--mode": ResolvedFlag(
-                    value="skeleton", source="explicit",
+                    value="attempt", source="explicit",
                     enforcement="startup-validated",
                 ),
                 "--level": ResolvedFlag(
@@ -29,101 +28,70 @@ class TestFormatterRoundTrip(unittest.TestCase):
                     enforcement="startup-validated",
                 ),
             },
-            coercions=[],
-            warnings=[],
-            errors=[],
         )
-        block = format_validated_block(original)
-        restored = parse_validated_block(block)
-
-        self.assertEqual(restored.command, original.command)
-        self.assertEqual(restored.raw_tail, original.raw_tail)
-        self.assertEqual(restored.positionals, original.positionals)
-        self.assertEqual(restored.errors, original.errors)
-        self.assertEqual(restored.coercions, original.coercions)
-        self.assertEqual(restored.warnings, original.warnings)
-        for name in original.options:
-            self.assertEqual(restored.options[name].value, original.options[name].value)
-            self.assertEqual(restored.options[name].source, original.options[name].source)
-            self.assertEqual(restored.options[name].enforcement, original.options[name].enforcement)
-            self.assertIsNone(restored.options[name].coerced_from)
+        block = format_validated_block(result)
+        parsed = parse_validated_block(block)
+        self.assertEqual(parsed.command, result.command)
+        self.assertEqual(parsed.raw_tail, result.raw_tail)
+        self.assertEqual(parsed.positionals, result.positionals)
+        self.assertEqual(parsed.options["--mode"], result.options["--mode"])
+        self.assertEqual(parsed.options["--level"], result.options["--level"])
 
     def test_round_trip_with_coerced_flag(self):
-        """Coerced flag preserves source='coerced' and coerced_from value."""
-        original = ParseResult(
-            command="draft",
-            raw_tail='"x" --intent=auto',
-            positionals={"topic": "x"},
+        result = ParseResult(
+            command="autoprove",
+            raw_tail="--commit=ask",
             options={
-                "--intent": ResolvedFlag(
-                    value="usage", source="coerced",
+                "--commit": ResolvedFlag(
+                    value="auto", source="coerced",
                     enforcement="startup-validated",
-                    coerced_from="auto",
+                    coerced_from="ask",
                 ),
             },
-            coercions=["--intent=auto coerced to usage"],
-            warnings=[],
-            errors=[],
         )
-        block = format_validated_block(original)
-        restored = parse_validated_block(block)
-
-        self.assertEqual(restored.options["--intent"].value, "usage")
-        self.assertEqual(restored.options["--intent"].source, "coerced")
-        self.assertEqual(restored.options["--intent"].coerced_from, "auto")
-        self.assertEqual(restored.coercions, ["--intent=auto coerced to usage"])
+        block = format_validated_block(result)
+        parsed = parse_validated_block(block)
+        self.assertEqual(parsed.options["--commit"].value, "auto")
+        self.assertEqual(parsed.options["--commit"].source, "coerced")
+        self.assertEqual(parsed.options["--commit"].coerced_from, "ask")
 
     def test_round_trip_empty_positionals(self):
-        """A result with no positionals round-trips through (none) sentinel."""
-        original = ParseResult(
-            command="autoprove",
-            raw_tail="--planning=on",
+        result = ParseResult(
+            command="prove", raw_tail="",
             positionals={},
             options={
-                "--planning": ResolvedFlag(
-                    value="on", source="explicit",
+                "--repair-only": ResolvedFlag(
+                    value=False, source="default",
                     enforcement="startup-validated",
                 ),
             },
         )
-        block = format_validated_block(original)
-        restored = parse_validated_block(block)
-
-        self.assertEqual(restored.positionals, {})
-        self.assertEqual(restored.options["--planning"].value, "on")
+        block = format_validated_block(result)
+        parsed = parse_validated_block(block)
+        self.assertEqual(parsed.positionals, {})
 
     def test_round_trip_with_warnings_and_coercions(self):
-        """Both warnings and coercions lists survive the round-trip."""
-        original = ParseResult(
+        result = ParseResult(
             command="learn",
-            raw_tail="topology --track=nng-like",
-            positionals={"topic": "topology"},
+            raw_tail='"groups" --source=notes.md --scope=file',
+            positionals={"topic": "groups"},
             options={
-                "--track": ResolvedFlag(
-                    value=None, source="coerced",
-                    enforcement="startup-validated",
-                    coerced_from="nng-like",
-                ),
-                "--style": ResolvedFlag(
-                    value="tour", source="default",
+                "--scope": ResolvedFlag(
+                    value="file", source="explicit",
                     enforcement="startup-validated",
                 ),
             },
-            coercions=["--track ignored: only valid with --style=game"],
-            warnings=["--source overrides --scope for initial discovery"],
-            errors=[],
+            coercions=["--scope stayed file (no coercion)"],
+            warnings=["source overrides scope for initial discovery"],
         )
-        block = format_validated_block(original)
-        restored = parse_validated_block(block)
-
-        self.assertEqual(restored.coercions, original.coercions)
-        self.assertEqual(restored.warnings, original.warnings)
+        block = format_validated_block(result)
+        parsed = parse_validated_block(block)
+        self.assertEqual(parsed.coercions, result.coercions)
+        self.assertEqual(parsed.warnings, result.warnings)
 
     def test_block_fencing(self):
-        """Formatted block starts with ```validated-invocation and ends with ```."""
         result = ParseResult(
-            command="prove",
-            raw_tail="MyFile.lean",
+            command="prove", raw_tail="MyFile.lean",
             positionals={"scope": "MyFile.lean"},
             options={
                 "--repair-only": ResolvedFlag(
@@ -137,6 +105,22 @@ class TestFormatterRoundTrip(unittest.TestCase):
         self.assertEqual(lines[0], "```validated-invocation")
         self.assertEqual(lines[-1], "```")
 
+    def test_block_body_is_valid_json(self):
+        result = ParseResult(
+            command="draft", raw_tail='"x"',
+            positionals={"topic": "x"},
+            options={
+                "--mode": ResolvedFlag(
+                    value="skeleton", source="default",
+                    enforcement="startup-validated",
+                ),
+            },
+        )
+        block = format_validated_block(result)
+        # Extract body between fences and parse as JSON
+        body = "\n".join(block.split("\n")[1:-1])
+        data = json.loads(body)
+        self.assertEqual(data["command"], "draft")
 
     def test_round_trip_string_that_looks_like_int(self):
         """String '123' must not become int 123 after round-trip (lossless)."""
@@ -149,10 +133,6 @@ class TestFormatterRoundTrip(unittest.TestCase):
                     value="123", source="explicit",
                     enforcement="startup-validated",
                 ),
-                "--mode": ResolvedFlag(
-                    value="skeleton", source="default",
-                    enforcement="startup-validated",
-                ),
             },
         )
         block = format_validated_block(result)
@@ -161,10 +141,9 @@ class TestFormatterRoundTrip(unittest.TestCase):
         self.assertIsInstance(parsed.options["--source"].value, str)
 
     def test_round_trip_string_none_literal(self):
-        """String 'None' (as a value) must not become Python None."""
+        """String 'None' as a value must not become Python None."""
         result = ParseResult(
-            command="draft",
-            raw_tail='"x"',
+            command="draft", raw_tail='"x"',
             positionals={"topic": "x"},
             options={
                 "--source": ResolvedFlag(
@@ -178,23 +157,30 @@ class TestFormatterRoundTrip(unittest.TestCase):
         self.assertEqual(parsed.options["--source"].value, "None")
         self.assertIsInstance(parsed.options["--source"].value, str)
 
-    def test_round_trip_string_true_literal(self):
-        """String 'true' must not become Python True."""
+    def test_round_trip_multiline_raw_tail(self):
+        """Multiline raw_tail must survive round-trip (JSON handles this)."""
         result = ParseResult(
             command="draft",
-            raw_tail='"x"',
-            positionals={"topic": "x"},
-            options={
-                "--source": ResolvedFlag(
-                    value="true", source="explicit",
-                    enforcement="startup-validated",
-                ),
-            },
+            raw_tail='"line one\nline two" --mode=skeleton',
+            positionals={"topic": "line one\nline two"},
+            options={},
         )
         block = format_validated_block(result)
         parsed = parse_validated_block(block)
-        self.assertEqual(parsed.options["--source"].value, "true")
-        self.assertIsInstance(parsed.options["--source"].value, str)
+        self.assertEqual(parsed.raw_tail, result.raw_tail)
+        self.assertEqual(parsed.positionals["topic"], "line one\nline two")
+
+    def test_round_trip_embedded_backticks(self):
+        """Backticks in values must not corrupt the fence."""
+        result = ParseResult(
+            command="draft",
+            raw_tail='"has ``` backticks"',
+            positionals={"topic": "has ``` backticks"},
+            options={},
+        )
+        block = format_validated_block(result)
+        parsed = parse_validated_block(block)
+        self.assertEqual(parsed.positionals["topic"], "has ``` backticks")
 
 
 if __name__ == "__main__":

--- a/plugins/lean4/tests/command_args/test_hook_block_roundtrip.py
+++ b/plugins/lean4/tests/command_args/test_hook_block_roundtrip.py
@@ -1,0 +1,453 @@
+"""Layer 4 hook -> block round-trip integration tests.
+
+For each of the 6 covered commands, verify that:
+1. The hook subprocess produces valid JSON with the expected structure.
+2. The validated-invocation block in additionalContext round-trips through
+   parse_validated_block / format_validated_block.
+3. A direct parse_invocation call produces the same ParseResult as the hook.
+4. Blocked payloads yield decision=block with expected error phrases.
+
+Also tests the two fail-open paths:
+- Import-broken (no lib/command_args on sys.path).
+- Parser-exception (shim that raises from parse_invocation).
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Module-scope constants
+# ---------------------------------------------------------------------------
+
+_PLUGIN_ROOT = Path(__file__).resolve().parents[2]
+HOOK = str((_PLUGIN_ROOT / "hooks" / "validate_user_prompt.py").resolve(strict=True))
+
+# Ensure lib is importable for direct parse_invocation calls.
+_LIB = str(_PLUGIN_ROOT / "lib")
+if _LIB not in sys.path:
+    sys.path.insert(0, _LIB)
+
+from command_args import COMMAND_SPECS, parse_invocation
+from command_args.formatter import format_validated_block, parse_validated_block
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run_hook(prompt: str, cwd: str, session_id: str = "test-roundtrip") -> dict:
+    """Invoke the hook subprocess and return parsed JSON stdout."""
+    payload = json.dumps({
+        "session_id": session_id,
+        "cwd": cwd,
+        "prompt": prompt,
+    })
+    result = subprocess.run(
+        [HOOK],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={**os.environ, "CLAUDE_PLUGIN_ROOT": str(_PLUGIN_ROOT)},
+    )
+    assert result.returncode == 0, (
+        f"Hook exited {result.returncode}\nstderr: {result.stderr}"
+    )
+    return json.loads(result.stdout)
+
+
+def _extract_block(hook_output: dict) -> str:
+    """Pull the additionalContext string from a success hook response."""
+    return hook_output["hookSpecificOutput"]["additionalContext"]
+
+
+def _assert_parse_results_equal(test: unittest.TestCase, a, b, msg_prefix: str = ""):
+    """Assert two ParseResult objects have equivalent data."""
+    prefix = f"{msg_prefix}: " if msg_prefix else ""
+    test.assertEqual(a.command, b.command, f"{prefix}command mismatch")
+    test.assertEqual(a.raw_tail, b.raw_tail, f"{prefix}raw_tail mismatch")
+    test.assertEqual(a.positionals, b.positionals, f"{prefix}positionals mismatch")
+    test.assertEqual(a.errors, b.errors, f"{prefix}errors mismatch")
+    test.assertEqual(a.coercions, b.coercions, f"{prefix}coercions mismatch")
+    test.assertEqual(a.warnings, b.warnings, f"{prefix}warnings mismatch")
+    test.assertEqual(set(a.options.keys()), set(b.options.keys()),
+                     f"{prefix}option keys mismatch")
+    for name in a.options:
+        ra, rb = a.options[name], b.options[name]
+        test.assertEqual(ra.value, rb.value, f"{prefix}option {name} value")
+        test.assertEqual(ra.source, rb.source, f"{prefix}option {name} source")
+        test.assertEqual(ra.enforcement, rb.enforcement,
+                         f"{prefix}option {name} enforcement")
+        test.assertEqual(ra.coerced_from, rb.coerced_from,
+                         f"{prefix}option {name} coerced_from")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# /lean4:draft
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestDraftRoundTrip(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="hook_draft_")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_draft_topic_defaults(self):
+        tail = '"Theorem 1"'
+        out = _run_hook(f"/lean4:draft {tail}", self.tmpdir)
+        block = _extract_block(out)
+        from_hook = parse_validated_block(block)
+        direct = parse_invocation(COMMAND_SPECS["draft"], tail, cwd=self.tmpdir)
+
+        self.assertEqual(from_hook.command, "draft")
+        self.assertEqual(from_hook.positionals["topic"], "Theorem 1")
+        _assert_parse_results_equal(self, from_hook, direct, "draft defaults")
+
+        # Format round-trip
+        re_block = format_validated_block(direct)
+        self.assertEqual(parse_validated_block(re_block).command, "draft")
+
+    def test_draft_with_source_and_mode(self):
+        tail = "--source=paper.pdf --mode=attempt"
+        out = _run_hook(f"/lean4:draft {tail}", self.tmpdir)
+        block = _extract_block(out)
+        from_hook = parse_validated_block(block)
+        direct = parse_invocation(COMMAND_SPECS["draft"], tail, cwd=self.tmpdir)
+
+        self.assertEqual(from_hook.options["--mode"].value, "attempt")
+        self.assertEqual(from_hook.options["--source"].value, "paper.pdf")
+        _assert_parse_results_equal(self, from_hook, direct, "draft source+mode")
+
+    def test_draft_blocked_no_topic_no_source(self):
+        out = _run_hook("/lean4:draft --mode=skeleton", self.tmpdir)
+        self.assertEqual(out["decision"], "block")
+        self.assertIn("topic", out["reason"].lower())
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# /lean4:learn
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestLearnRoundTrip(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="hook_learn_")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_learn_topic_defaults(self):
+        tail = "topology"
+        out = _run_hook(f"/lean4:learn {tail}", self.tmpdir)
+        block = _extract_block(out)
+        from_hook = parse_validated_block(block)
+        direct = parse_invocation(COMMAND_SPECS["learn"], tail, cwd=self.tmpdir)
+
+        self.assertEqual(from_hook.positionals["topic"], "topology")
+        _assert_parse_results_equal(self, from_hook, direct, "learn defaults")
+
+    def test_learn_with_style_and_level(self):
+        tail = "groups --style=socratic --level=beginner"
+        out = _run_hook(f"/lean4:learn {tail}", self.tmpdir)
+        block = _extract_block(out)
+        from_hook = parse_validated_block(block)
+        direct = parse_invocation(COMMAND_SPECS["learn"], tail, cwd=self.tmpdir)
+
+        self.assertEqual(from_hook.options["--style"].value, "socratic")
+        self.assertEqual(from_hook.options["--level"].value, "beginner")
+        _assert_parse_results_equal(self, from_hook, direct, "learn style+level")
+
+    def test_learn_blocked_bad_style(self):
+        out = _run_hook("/lean4:learn topology --style=invalid", self.tmpdir)
+        self.assertEqual(out["decision"], "block")
+        self.assertIn("invalid", out["reason"])
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# /lean4:formalize
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestFormalizeRoundTrip(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="hook_formalize_")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_formalize_topic_defaults(self):
+        tail = '"every prime > 2 is odd"'
+        out = _run_hook(f"/lean4:formalize {tail}", self.tmpdir)
+        block = _extract_block(out)
+        from_hook = parse_validated_block(block)
+        direct = parse_invocation(COMMAND_SPECS["formalize"], tail, cwd=self.tmpdir)
+
+        self.assertEqual(from_hook.positionals["topic"], "every prime > 2 is odd")
+        _assert_parse_results_equal(self, from_hook, direct, "formalize defaults")
+
+    def test_formalize_with_rigor_and_source(self):
+        tail = "--source=paper.pdf --rigor=sketch"
+        out = _run_hook(f"/lean4:formalize {tail}", self.tmpdir)
+        block = _extract_block(out)
+        from_hook = parse_validated_block(block)
+        direct = parse_invocation(COMMAND_SPECS["formalize"], tail, cwd=self.tmpdir)
+
+        self.assertEqual(from_hook.options["--rigor"].value, "sketch")
+        _assert_parse_results_equal(self, from_hook, direct, "formalize rigor+source")
+
+    def test_formalize_blocked_no_topic_no_source(self):
+        out = _run_hook("/lean4:formalize --rigor=checked", self.tmpdir)
+        self.assertEqual(out["decision"], "block")
+        self.assertIn("topic", out["reason"].lower())
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# /lean4:autoformalize
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestAutoformalizeRoundTrip(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="hook_autoformalize_")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_autoformalize_valid(self):
+        tail = "--source=paper.pdf --claim-select=first --out=output.lean"
+        out = _run_hook(f"/lean4:autoformalize {tail}", self.tmpdir)
+        block = _extract_block(out)
+        from_hook = parse_validated_block(block)
+        direct = parse_invocation(COMMAND_SPECS["autoformalize"], tail, cwd=self.tmpdir)
+
+        self.assertEqual(from_hook.options["--source"].value, "paper.pdf")
+        self.assertEqual(from_hook.options["--claim-select"].value, "first")
+        self.assertEqual(from_hook.options["--out"].value, "output.lean")
+        _assert_parse_results_equal(self, from_hook, direct, "autoformalize valid")
+
+    def test_autoformalize_with_extras(self):
+        tail = "--source=notes.pdf --claim-select=first --out=out.lean --rigor=checked --deep=always"
+        out = _run_hook(f"/lean4:autoformalize {tail}", self.tmpdir)
+        block = _extract_block(out)
+        from_hook = parse_validated_block(block)
+        direct = parse_invocation(COMMAND_SPECS["autoformalize"], tail, cwd=self.tmpdir)
+
+        self.assertEqual(from_hook.options["--rigor"].value, "checked")
+        self.assertEqual(from_hook.options["--deep"].value, "always")
+        _assert_parse_results_equal(self, from_hook, direct, "autoformalize extras")
+
+    def test_autoformalize_blocked_missing_source(self):
+        out = _run_hook("/lean4:autoformalize --claim-select=first --out=o.lean", self.tmpdir)
+        self.assertEqual(out["decision"], "block")
+        self.assertIn("source", out["reason"].lower())
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# /lean4:prove
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestProveRoundTrip(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="hook_prove_")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_prove_scope_defaults(self):
+        tail = "MyFile.lean"
+        out = _run_hook(f"/lean4:prove {tail}", self.tmpdir)
+        block = _extract_block(out)
+        from_hook = parse_validated_block(block)
+        direct = parse_invocation(COMMAND_SPECS["prove"], tail, cwd=self.tmpdir)
+
+        self.assertEqual(from_hook.positionals["scope"], "MyFile.lean")
+        _assert_parse_results_equal(self, from_hook, direct, "prove defaults")
+
+    def test_prove_with_flags(self):
+        tail = "Thm.lean --repair-only --planning=on --deep=stuck"
+        out = _run_hook(f"/lean4:prove {tail}", self.tmpdir)
+        block = _extract_block(out)
+        from_hook = parse_validated_block(block)
+        direct = parse_invocation(COMMAND_SPECS["prove"], tail, cwd=self.tmpdir)
+
+        self.assertEqual(from_hook.options["--repair-only"].value, True)
+        self.assertEqual(from_hook.options["--planning"].value, "on")
+        self.assertEqual(from_hook.options["--deep"].value, "stuck")
+        _assert_parse_results_equal(self, from_hook, direct, "prove flags")
+
+    def test_prove_blocked_bad_flag(self):
+        out = _run_hook("/lean4:prove --planning=banana", self.tmpdir)
+        self.assertEqual(out["decision"], "block")
+        self.assertIn("banana", out["reason"])
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# /lean4:autoprove
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestAutoproveRoundTrip(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="hook_autoprove_")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_autoprove_scope_defaults(self):
+        tail = "MyThm.lean"
+        out = _run_hook(f"/lean4:autoprove {tail}", self.tmpdir)
+        block = _extract_block(out)
+        from_hook = parse_validated_block(block)
+        direct = parse_invocation(COMMAND_SPECS["autoprove"], tail, cwd=self.tmpdir)
+
+        self.assertEqual(from_hook.positionals["scope"], "MyThm.lean")
+        _assert_parse_results_equal(self, from_hook, direct, "autoprove defaults")
+
+    def test_autoprove_with_deep_and_commit(self):
+        tail = "--deep=always --commit=never --max-cycles=5"
+        out = _run_hook(f"/lean4:autoprove {tail}", self.tmpdir)
+        block = _extract_block(out)
+        from_hook = parse_validated_block(block)
+        direct = parse_invocation(COMMAND_SPECS["autoprove"], tail, cwd=self.tmpdir)
+
+        self.assertEqual(from_hook.options["--deep"].value, "always")
+        self.assertEqual(from_hook.options["--commit"].value, "never")
+        self.assertEqual(from_hook.options["--max-cycles"].value, 5)
+        _assert_parse_results_equal(self, from_hook, direct, "autoprove deep+commit")
+
+    def test_autoprove_blocked_bad_deep(self):
+        out = _run_hook("/lean4:autoprove --deep=turbo", self.tmpdir)
+        self.assertEqual(out["decision"], "block")
+        self.assertIn("turbo", out["reason"])
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Fail-open tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestFailOpen(unittest.TestCase):
+
+    def test_import_broken_fail_open(self):
+        """Hook with no lib/command_args on path emits fail-open warning."""
+        tmpdir = tempfile.mkdtemp(prefix="hook_failopen_import_")
+        try:
+            # Copy hook to isolated directory with no lib/command_args
+            isolated_hook = os.path.join(tmpdir, "validate_user_prompt.py")
+            shutil.copy2(HOOK, isolated_hook)
+            os.chmod(isolated_hook, 0o755)
+
+            payload = json.dumps({
+                "session_id": "test-failopen",
+                "cwd": tmpdir,
+                "prompt": "/lean4:draft \"hello\"",
+            })
+
+            # Build a hermetic env: scrub PYTHONPATH, CLAUDE_PLUGIN_ROOT,
+            # set PYTHONNOUSERSITE=1 so no user-site packages sneak in.
+            env = {}
+            for k, v in os.environ.items():
+                if k in ("PYTHONPATH", "CLAUDE_PLUGIN_ROOT"):
+                    continue
+                env[k] = v
+            env["PYTHONNOUSERSITE"] = "1"
+            # Point CLAUDE_PLUGIN_ROOT at tmpdir (which has no lib/)
+            env["CLAUDE_PLUGIN_ROOT"] = tmpdir
+
+            result = subprocess.run(
+                [isolated_hook],
+                input=payload,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                env=env,
+            )
+            self.assertEqual(result.returncode, 0, f"stderr: {result.stderr}")
+
+            out = json.loads(result.stdout)
+            ctx = out["hookSpecificOutput"]["additionalContext"]
+            self.assertIn("lean4 parser unavailable", ctx)
+            self.assertIn("fell back to model parsing", ctx)
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_parser_exception_fail_open(self):
+        """Hook with a shim that raises from parse_invocation emits crash warning."""
+        tmpdir = tempfile.mkdtemp(prefix="hook_failopen_crash_")
+        try:
+            # Copy hook
+            isolated_hook = os.path.join(tmpdir, "validate_user_prompt.py")
+            shutil.copy2(HOOK, isolated_hook)
+            os.chmod(isolated_hook, 0o755)
+
+            # Create a shim command_args package that raises
+            lib_dir = os.path.join(tmpdir, "lib")
+            pkg_dir = os.path.join(lib_dir, "command_args")
+            os.makedirs(pkg_dir)
+
+            # Copy the real specs and types so the import succeeds but
+            # parse_invocation raises.
+            real_pkg = os.path.join(str(_PLUGIN_ROOT), "lib", "command_args")
+            for fname in ("types.py", "tokenizer.py", "formatter.py", "coercions.py"):
+                src = os.path.join(real_pkg, fname)
+                if os.path.exists(src):
+                    shutil.copy2(src, os.path.join(pkg_dir, fname))
+
+            # Copy the specs sub-package wholesale
+            real_specs = os.path.join(real_pkg, "specs")
+            shutil.copytree(real_specs, os.path.join(pkg_dir, "specs"))
+
+            # Write __init__.py that re-exports everything but overrides parse_invocation
+            init_content = (
+                "from .formatter import format_validated_block, parse_validated_block\n"
+                "from .specs import COMMAND_SPECS\n"
+                "\n"
+                "def parse_invocation(spec, raw_tail, *, cwd):\n"
+                "    raise RuntimeError('Intentional shim explosion for testing')\n"
+            )
+            with open(os.path.join(pkg_dir, "__init__.py"), "w") as f:
+                f.write(init_content)
+
+            payload = json.dumps({
+                "session_id": "test-crash",
+                "cwd": tmpdir,
+                "prompt": "/lean4:draft \"hello\"",
+            })
+
+            env = {}
+            for k, v in os.environ.items():
+                if k in ("PYTHONPATH", "CLAUDE_PLUGIN_ROOT"):
+                    continue
+                env[k] = v
+            env["PYTHONNOUSERSITE"] = "1"
+            env["CLAUDE_PLUGIN_ROOT"] = tmpdir
+
+            result = subprocess.run(
+                [isolated_hook],
+                input=payload,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                env=env,
+            )
+            self.assertEqual(result.returncode, 0, f"stderr: {result.stderr}")
+
+            out = json.loads(result.stdout)
+            ctx = out["hookSpecificOutput"]["additionalContext"]
+            self.assertTrue(
+                ctx.startswith("[lean4 parser crashed"),
+                f"Expected crash prefix, got: {ctx!r}",
+            )
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lean4/tests/command_args/test_parse_command_args_cli.py
+++ b/plugins/lean4/tests/command_args/test_parse_command_args_cli.py
@@ -84,6 +84,18 @@ class TestStandaloneCLI(unittest.TestCase):
                 msg=f"Expected overwrite error, got: {data['errors']}"
             )
 
+    def test_multi_arg_after_separator_rejected(self):
+        """Multiple args after -- are rejected (quoting boundaries would be lost)."""
+        r = self._run(["draft", "--", '"Theorem 1"', "--mode=attempt"])
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("exactly one argument", r.stderr.lower())
+
+    def test_unquoted_multi_word_rejected(self):
+        """Common mistake: draft -- Theorem 1 (two args, not one quoted string)."""
+        r = self._run(["draft", "--", "Theorem", "1"])
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("exactly one argument", r.stderr.lower())
+
     def test_json_output_is_valid(self):
         r = self._run(["prove", "--", "Foo.lean"])
         self.assertEqual(r.returncode, 0, msg=r.stderr)

--- a/plugins/lean4/tests/command_args/test_parse_command_args_cli.py
+++ b/plugins/lean4/tests/command_args/test_parse_command_args_cli.py
@@ -1,0 +1,108 @@
+"""Layer 1 supplement: subprocess tests for the standalone CLI.
+
+Exercises the lib/scripts/parse_command_args.py sys.path bootstrap
+from a clean cwd with no PYTHONPATH.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_PLUGIN_ROOT = Path(__file__).resolve().parents[2]
+CLI = str((_PLUGIN_ROOT / "lib" / "scripts" / "parse_command_args.py").resolve(strict=True))
+
+
+class TestStandaloneCLI(unittest.TestCase):
+    """Test parse_command_args.py from a controlled subprocess."""
+
+    def _run(self, args: list[str], *, cwd: str | None = None,
+             env_override: dict | None = None) -> subprocess.CompletedProcess:
+        env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+        env["PYTHONNOUSERSITE"] = "1"
+        if env_override:
+            env.update(env_override)
+        return subprocess.run(
+            [sys.executable, CLI] + args,
+            capture_output=True,
+            text=True,
+            cwd=cwd or tempfile.gettempdir(),
+            env=env,
+        )
+
+    def test_happy_path_draft(self):
+        r = self._run(["draft", "--", '"Theorem 1"'])
+        self.assertEqual(r.returncode, 0, msg=r.stderr)
+        data = json.loads(r.stdout)
+        self.assertEqual(data["command"], "draft")
+        self.assertIn("topic", data["positionals"])
+
+    def test_validation_error_exit_2(self):
+        r = self._run(["draft", "--", '--output=file "x"'])
+        self.assertEqual(r.returncode, 2, msg=r.stderr)
+        data = json.loads(r.stdout)
+        self.assertIn("errors", data)
+        self.assertTrue(len(data["errors"]) > 0)
+
+    def test_unknown_command_exit_1(self):
+        r = self._run(["nonexistent", "--", "foo"])
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("unknown command", r.stderr.lower())
+
+    def test_missing_separator_exit_1(self):
+        r = self._run(["draft", "foo"])
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("--", r.stderr)
+
+    def test_coercion_autoprove(self):
+        r = self._run(["autoprove", "--", "--commit=ask --max-cycles=10"])
+        self.assertEqual(r.returncode, 0, msg=r.stderr)
+        data = json.loads(r.stdout)
+        commit = data["options"]["--commit"]
+        self.assertEqual(commit["value"], "auto")
+        self.assertEqual(commit["source"], "coerced")
+        self.assertEqual(commit["coerced_from"], "ask")
+
+    def test_cwd_flag(self):
+        """--cwd is passed through to the parser for path-sensitive checks."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a file so overwrite check fires
+            target = os.path.join(tmpdir, "existing.lean")
+            with open(target, "w") as f:
+                f.write("")
+            r = self._run([
+                "draft", "--cwd", tmpdir, "--",
+                f'--output=file --out=existing.lean "x"'
+            ])
+            self.assertEqual(r.returncode, 2, msg=r.stderr)
+            data = json.loads(r.stdout)
+            self.assertTrue(
+                any("overwrite" in e.lower() or "existing" in e.lower()
+                    for e in data["errors"]),
+                msg=f"Expected overwrite error, got: {data['errors']}"
+            )
+
+    def test_json_output_is_valid(self):
+        r = self._run(["prove", "--", "Foo.lean"])
+        self.assertEqual(r.returncode, 0, msg=r.stderr)
+        data = json.loads(r.stdout)
+        self.assertIn("command", data)
+        self.assertIn("options", data)
+        self.assertIn("positionals", data)
+
+    def test_direct_exec(self):
+        """CLI is executable directly (shebang + chmod)."""
+        r = subprocess.run(
+            [CLI, "draft", "--", '"x"'],
+            capture_output=True,
+            text=True,
+            cwd=tempfile.gettempdir(),
+            env={k: v for k, v in os.environ.items() if k != "PYTHONPATH"},
+        )
+        self.assertEqual(r.returncode, 0, msg=r.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lean4/tests/command_args/test_parser_autoformalize.py
+++ b/plugins/lean4/tests/command_args/test_parser_autoformalize.py
@@ -1,0 +1,131 @@
+"""Layer 1 parser golden tests for /lean4:autoformalize."""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "lib"))
+
+from command_args import COMMAND_SPECS, parse_invocation
+
+SPEC = COMMAND_SPECS["autoformalize"]
+CWD = "/tmp"
+
+
+class TestAutoformalizeHappyPath(unittest.TestCase):
+    """Happy-path tests."""
+
+    def test_all_required_flags(self):
+        result = parse_invocation(
+            SPEC,
+            "--source=paper.pdf --claim-select=first --out=Out.lean",
+            cwd=CWD,
+        )
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--source"].value, "paper.pdf")
+        self.assertEqual(result.options["--source"].source, "explicit")
+        self.assertEqual(result.options["--claim-select"].value, "first")
+        self.assertEqual(result.options["--out"].value, "Out.lean")
+
+    def test_all_required_with_extras(self):
+        result = parse_invocation(
+            SPEC,
+            "--source=paper.pdf --claim-select=first --out=Out.lean --rigor=checked",
+            cwd=CWD,
+        )
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--rigor"].value, "checked")
+        self.assertEqual(result.options["--rigor"].source, "explicit")
+
+
+class TestAutoformalizeMissingRequired(unittest.TestCase):
+    """Missing required flags produce errors."""
+
+    def test_missing_source(self):
+        result = parse_invocation(
+            SPEC,
+            "--claim-select=first --out=Out.lean",
+            cwd=CWD,
+        )
+        self.assertTrue(len(result.errors) > 0)
+        matching = [e for e in result.errors if "source" in e.lower()]
+        self.assertTrue(len(matching) > 0, f"Expected source error, got: {result.errors}")
+
+    def test_missing_claim_select(self):
+        result = parse_invocation(
+            SPEC,
+            "--source=paper.pdf --out=Out.lean",
+            cwd=CWD,
+        )
+        self.assertTrue(len(result.errors) > 0)
+        matching = [e for e in result.errors if "claim-select" in e.lower()]
+        self.assertTrue(len(matching) > 0, f"Expected claim-select error, got: {result.errors}")
+
+    def test_missing_out(self):
+        result = parse_invocation(
+            SPEC,
+            "--source=paper.pdf --claim-select=first",
+            cwd=CWD,
+        )
+        self.assertTrue(len(result.errors) > 0)
+        matching = [e for e in result.errors if "out" in e.lower()]
+        self.assertTrue(len(matching) > 0, f"Expected out error, got: {result.errors}")
+
+    def test_empty_input_all_missing(self):
+        result = parse_invocation(SPEC, "", cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+        # Should have at least source, claim-select, and out errors
+        self.assertTrue(len(result.errors) >= 3, f"Expected >=3 errors, got: {result.errors}")
+
+
+class TestAutoformalizeReviewSourceCoercion(unittest.TestCase):
+    """--review-source=external -> coerced to internal."""
+
+    def test_review_source_external_coerced(self):
+        result = parse_invocation(
+            SPEC,
+            "--source=paper.pdf --claim-select=first --out=Out.lean --review-source=external",
+            cwd=CWD,
+        )
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--review-source"].value, "internal")
+        self.assertEqual(result.options["--review-source"].source, "coerced")
+        self.assertEqual(result.options["--review-source"].coerced_from, "external")
+
+    def test_review_source_both_coerced(self):
+        result = parse_invocation(
+            SPEC,
+            "--source=paper.pdf --claim-select=first --out=Out.lean --review-source=both",
+            cwd=CWD,
+        )
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--review-source"].value, "internal")
+        self.assertEqual(result.options["--review-source"].source, "coerced")
+        self.assertEqual(result.options["--review-source"].coerced_from, "both")
+
+    def test_review_source_internal_not_coerced(self):
+        result = parse_invocation(
+            SPEC,
+            "--source=paper.pdf --claim-select=first --out=Out.lean --review-source=internal",
+            cwd=CWD,
+        )
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--review-source"].value, "internal")
+        self.assertEqual(result.options["--review-source"].source, "explicit")
+
+
+class TestAutoformalizeNoPositionals(unittest.TestCase):
+    """autoformalize has no positionals, so any positional is rejected."""
+
+    def test_positional_rejected(self):
+        result = parse_invocation(
+            SPEC,
+            'unexpected --source=paper.pdf --claim-select=first --out=Out.lean',
+            cwd=CWD,
+        )
+        self.assertTrue(len(result.errors) > 0)
+        matching = [e for e in result.errors if "positional" in e.lower()]
+        self.assertTrue(len(matching) > 0, f"Expected positional error, got: {result.errors}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lean4/tests/command_args/test_parser_autoprove.py
+++ b/plugins/lean4/tests/command_args/test_parser_autoprove.py
@@ -121,23 +121,29 @@ class TestAutoproveTypeErrors(unittest.TestCase):
     def test_valid_duration_minutes(self):
         result = parse_invocation(SPEC, "--max-total-runtime=15m", cwd=CWD)
         self.assertEqual(result.errors, [])
-        self.assertEqual(result.options["--max-total-runtime"].value, 900)  # 15m = 900s
+        self.assertEqual(result.options["--max-total-runtime"].value, "15m")
 
     def test_valid_duration_seconds(self):
         result = parse_invocation(SPEC, "--max-total-runtime=30s", cwd=CWD)
         self.assertEqual(result.errors, [])
-        self.assertEqual(result.options["--max-total-runtime"].value, 30)  # 30s preserved
+        self.assertEqual(result.options["--max-total-runtime"].value, "30s")
 
     def test_valid_duration_90s(self):
-        """Sub-minute budgets must survive — tracker accepts and enforces seconds."""
+        """Sub-minute budgets survive with explicit suffix — tracker reads '90s' as 90 seconds."""
         result = parse_invocation(SPEC, "--max-total-runtime=90s", cwd=CWD)
         self.assertEqual(result.errors, [])
-        self.assertEqual(result.options["--max-total-runtime"].value, 90)  # 90s preserved
+        self.assertEqual(result.options["--max-total-runtime"].value, "90s")
 
     def test_valid_duration_hours(self):
         result = parse_invocation(SPEC, "--max-total-runtime=2h", cwd=CWD)
         self.assertEqual(result.errors, [])
-        self.assertEqual(result.options["--max-total-runtime"].value, 7200)  # 2h = 7200s
+        self.assertEqual(result.options["--max-total-runtime"].value, "2h")
+
+    def test_bare_numeric_normalized_to_minutes(self):
+        """Bare number (no suffix) is interpreted as minutes, normalized to '<N>m'."""
+        result = parse_invocation(SPEC, "--max-total-runtime=120", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--max-total-runtime"].value, "120m")
 
 
 class TestAutoproveUnknownFlag(unittest.TestCase):

--- a/plugins/lean4/tests/command_args/test_parser_autoprove.py
+++ b/plugins/lean4/tests/command_args/test_parser_autoprove.py
@@ -1,0 +1,138 @@
+"""Layer 1 parser golden tests for /lean4:autoprove."""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "lib"))
+
+from command_args import COMMAND_SPECS, parse_invocation
+
+SPEC = COMMAND_SPECS["autoprove"]
+CWD = "/tmp"
+
+
+class TestAutoproveHappyPath(unittest.TestCase):
+    """Happy-path tests."""
+
+    def test_scope_and_max_cycles(self):
+        result = parse_invocation(SPEC, "Foo.lean --max-cycles=10", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.positionals["scope"], "Foo.lean")
+        self.assertEqual(result.options["--max-cycles"].value, 10)
+        self.assertEqual(result.options["--max-cycles"].source, "explicit")
+
+    def test_defaults_applied(self):
+        result = parse_invocation(SPEC, "Foo.lean", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--deep"].value, "stuck")
+        self.assertEqual(result.options["--deep"].source, "default")
+        self.assertEqual(result.options["--commit"].value, "auto")
+        self.assertEqual(result.options["--commit"].source, "default")
+
+    def test_no_positional_ok(self):
+        """Scope is optional for autoprove."""
+        result = parse_invocation(SPEC, "", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertNotIn("scope", result.positionals)
+
+
+class TestAutoproveCommitCoercion(unittest.TestCase):
+    """--commit=ask -> coerced to auto."""
+
+    def test_commit_ask_coerced_to_auto(self):
+        result = parse_invocation(SPEC, "--commit=ask", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--commit"].value, "auto")
+        self.assertEqual(result.options["--commit"].source, "coerced")
+        self.assertEqual(result.options["--commit"].coerced_from, "ask")
+        self.assertTrue(len(result.coercions) > 0, "Expected a coercion note")
+
+
+class TestAutoproveReviewSourceCoercion(unittest.TestCase):
+    """--review-source=external|both -> coerced to internal."""
+
+    def test_review_source_external_coerced(self):
+        result = parse_invocation(SPEC, "--review-source=external", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--review-source"].value, "internal")
+        self.assertEqual(result.options["--review-source"].source, "coerced")
+        self.assertEqual(result.options["--review-source"].coerced_from, "external")
+
+    def test_review_source_both_coerced(self):
+        result = parse_invocation(SPEC, "--review-source=both", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--review-source"].value, "internal")
+        self.assertEqual(result.options["--review-source"].source, "coerced")
+        self.assertEqual(result.options["--review-source"].coerced_from, "both")
+
+    def test_review_source_internal_not_coerced(self):
+        result = parse_invocation(SPEC, "--review-source=internal", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--review-source"].value, "internal")
+        self.assertEqual(result.options["--review-source"].source, "explicit")
+
+
+class TestAutoproveDeepCoercion(unittest.TestCase):
+    """--deep=ask -> coerced to stuck."""
+
+    def test_deep_ask_coerced_to_stuck(self):
+        result = parse_invocation(SPEC, "--deep=ask", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--deep"].value, "stuck")
+        self.assertEqual(result.options["--deep"].source, "coerced")
+        self.assertEqual(result.options["--deep"].coerced_from, "ask")
+
+
+class TestAutoproveDeepRollbackCoercion(unittest.TestCase):
+    """--deep-rollback=never -> coerced to on-regression."""
+
+    def test_deep_rollback_never_coerced(self):
+        result = parse_invocation(SPEC, "--deep-rollback=never", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--deep-rollback"].value, "on-regression")
+        self.assertEqual(result.options["--deep-rollback"].source, "coerced")
+        self.assertEqual(result.options["--deep-rollback"].coerced_from, "never")
+
+
+class TestAutoproveDeepRegressionGateCoercion(unittest.TestCase):
+    """--deep-regression-gate=off -> coerced to strict."""
+
+    def test_deep_regression_gate_off_coerced(self):
+        result = parse_invocation(SPEC, "--deep-regression-gate=off", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--deep-regression-gate"].value, "strict")
+        self.assertEqual(result.options["--deep-regression-gate"].source, "coerced")
+        self.assertEqual(result.options["--deep-regression-gate"].coerced_from, "off")
+
+
+class TestAutoproveTypeErrors(unittest.TestCase):
+    """Type validation errors."""
+
+    def test_bad_int_max_cycles(self):
+        result = parse_invocation(SPEC, "--max-cycles=cat", cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+        self.assertIn("cat", result.errors[0])
+
+    def test_bad_duration(self):
+        result = parse_invocation(SPEC, "--max-total-runtime=10banana", cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+        self.assertIn("10banana", result.errors[0])
+
+    def test_valid_duration_minutes(self):
+        result = parse_invocation(SPEC, "--max-total-runtime=15m", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--max-total-runtime"].value, 15)
+
+
+class TestAutoproveUnknownFlag(unittest.TestCase):
+    """Unknown flags produce errors."""
+
+    def test_unknown_flag(self):
+        result = parse_invocation(SPEC, "--nonexistent=foo", cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+        self.assertIn("Unknown flag", result.errors[0])
+        self.assertIn("--nonexistent", result.errors[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lean4/tests/command_args/test_parser_autoprove.py
+++ b/plugins/lean4/tests/command_args/test_parser_autoprove.py
@@ -121,7 +121,23 @@ class TestAutoproveTypeErrors(unittest.TestCase):
     def test_valid_duration_minutes(self):
         result = parse_invocation(SPEC, "--max-total-runtime=15m", cwd=CWD)
         self.assertEqual(result.errors, [])
-        self.assertEqual(result.options["--max-total-runtime"].value, 15)
+        self.assertEqual(result.options["--max-total-runtime"].value, 900)  # 15m = 900s
+
+    def test_valid_duration_seconds(self):
+        result = parse_invocation(SPEC, "--max-total-runtime=30s", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--max-total-runtime"].value, 30)  # 30s preserved
+
+    def test_valid_duration_90s(self):
+        """Sub-minute budgets must survive — tracker accepts and enforces seconds."""
+        result = parse_invocation(SPEC, "--max-total-runtime=90s", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--max-total-runtime"].value, 90)  # 90s preserved
+
+    def test_valid_duration_hours(self):
+        result = parse_invocation(SPEC, "--max-total-runtime=2h", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--max-total-runtime"].value, 7200)  # 2h = 7200s
 
 
 class TestAutoproveUnknownFlag(unittest.TestCase):

--- a/plugins/lean4/tests/command_args/test_parser_autoprove.py
+++ b/plugins/lean4/tests/command_args/test_parser_autoprove.py
@@ -145,6 +145,21 @@ class TestAutoproveTypeErrors(unittest.TestCase):
         self.assertEqual(result.errors, [])
         self.assertEqual(result.options["--max-total-runtime"].value, "120m")
 
+    def test_fractional_hours_rejected(self):
+        """1.5h is rejected — tracker only accepts integer prefixes."""
+        result = parse_invocation(SPEC, "--max-total-runtime=1.5h", cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+        self.assertIn("fractional", result.errors[0].lower())
+
+    def test_fractional_minutes_rejected(self):
+        result = parse_invocation(SPEC, "--max-total-runtime=0.5m", cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+        self.assertIn("fractional", result.errors[0].lower())
+
+    def test_dot_prefix_rejected(self):
+        result = parse_invocation(SPEC, "--max-total-runtime=.5h", cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+
 
 class TestAutoproveUnknownFlag(unittest.TestCase):
     """Unknown flags produce errors."""

--- a/plugins/lean4/tests/command_args/test_parser_common.py
+++ b/plugins/lean4/tests/command_args/test_parser_common.py
@@ -1,0 +1,124 @@
+"""Layer 1 parser golden tests for cross-command / structural behaviour."""
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "lib"))
+
+from command_args import COMMAND_SPECS, parse_invocation
+
+CWD = "/tmp"
+
+
+class TestMultiPositionalRejection(unittest.TestCase):
+    """Commands that allow at most 1 positional reject extras."""
+
+    def test_draft_rejects_two_positionals(self):
+        spec = COMMAND_SPECS["draft"]
+        result = parse_invocation(spec, '"first" "second"', cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+        matching = [e for e in result.errors if "positional" in e.lower()]
+        self.assertTrue(len(matching) > 0, f"Expected positional error, got: {result.errors}")
+
+    def test_prove_rejects_two_positionals(self):
+        spec = COMMAND_SPECS["prove"]
+        result = parse_invocation(spec, "Foo.lean Bar.lean", cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+        matching = [e for e in result.errors if "positional" in e.lower()]
+        self.assertTrue(len(matching) > 0, f"Expected positional error, got: {result.errors}")
+
+
+class TestWhitespaceHandling(unittest.TestCase):
+    """Leading/trailing whitespace and internal whitespace."""
+
+    def test_leading_trailing_whitespace(self):
+        spec = COMMAND_SPECS["prove"]
+        result = parse_invocation(spec, "   Foo.lean   ", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.positionals["scope"], "Foo.lean")
+
+    def test_multiple_internal_spaces(self):
+        spec = COMMAND_SPECS["prove"]
+        result = parse_invocation(spec, "Foo.lean    --planning=on", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.positionals["scope"], "Foo.lean")
+        self.assertEqual(result.options["--planning"].value, "on")
+
+
+class TestFlagEqualsVsSpace(unittest.TestCase):
+    """--flag=value and --flag value produce identical results."""
+
+    def test_equals_form(self):
+        spec = COMMAND_SPECS["autoprove"]
+        r1 = parse_invocation(spec, "--max-cycles=5", cwd=CWD)
+        self.assertEqual(r1.errors, [])
+        self.assertEqual(r1.options["--max-cycles"].value, 5)
+
+    def test_space_form(self):
+        spec = COMMAND_SPECS["autoprove"]
+        r2 = parse_invocation(spec, "--max-cycles 5", cwd=CWD)
+        self.assertEqual(r2.errors, [])
+        self.assertEqual(r2.options["--max-cycles"].value, 5)
+
+    def test_equals_and_space_identical(self):
+        spec = COMMAND_SPECS["autoprove"]
+        r1 = parse_invocation(spec, "--max-cycles=5", cwd=CWD)
+        r2 = parse_invocation(spec, "--max-cycles 5", cwd=CWD)
+        self.assertEqual(r1.options["--max-cycles"].value, r2.options["--max-cycles"].value)
+        self.assertEqual(r1.options["--max-cycles"].source, r2.options["--max-cycles"].source)
+
+
+class TestToDict(unittest.TestCase):
+    """ParseResult.to_dict() produces JSON-serializable output."""
+
+    def test_to_dict_json_serializable(self):
+        spec = COMMAND_SPECS["draft"]
+        result = parse_invocation(spec, '"hello"', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        d = result.to_dict()
+        # Must not raise
+        serialized = json.dumps(d)
+        self.assertIsInstance(serialized, str)
+        # Round-trip check
+        loaded = json.loads(serialized)
+        self.assertEqual(loaded["command"], "draft")
+        self.assertEqual(loaded["positionals"]["topic"], "hello")
+
+    def test_to_dict_with_coercion(self):
+        spec = COMMAND_SPECS["draft"]
+        result = parse_invocation(spec, '"hello" --intent=auto', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        d = result.to_dict()
+        serialized = json.dumps(d)
+        loaded = json.loads(serialized)
+        self.assertEqual(loaded["options"]["--intent"]["value"], "usage")
+        self.assertEqual(loaded["options"]["--intent"]["source"], "coerced")
+        self.assertEqual(loaded["options"]["--intent"]["coerced_from"], "auto")
+
+
+class TestEmptyRawTail(unittest.TestCase):
+    """Empty raw_tail for commands with no required positionals."""
+
+    def test_prove_empty_ok(self):
+        spec = COMMAND_SPECS["prove"]
+        result = parse_invocation(spec, "", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertNotIn("scope", result.positionals)
+
+    def test_autoprove_empty_ok(self):
+        spec = COMMAND_SPECS["autoprove"]
+        result = parse_invocation(spec, "", cwd=CWD)
+        self.assertEqual(result.errors, [])
+
+
+class TestUnknownCommandSpec(unittest.TestCase):
+    """Unknown command name raises KeyError on COMMAND_SPECS lookup."""
+
+    def test_unknown_command_keyerror(self):
+        with self.assertRaises(KeyError):
+            _ = COMMAND_SPECS["nonexistent"]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lean4/tests/command_args/test_parser_draft.py
+++ b/plugins/lean4/tests/command_args/test_parser_draft.py
@@ -1,0 +1,123 @@
+"""Layer 1 parser golden tests for /lean4:draft."""
+import json
+import os
+import sys
+import unittest
+
+# Ensure the library package is importable.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "lib"))
+
+from command_args import COMMAND_SPECS, parse_invocation
+
+SPEC = COMMAND_SPECS["draft"]
+CWD = "/tmp"
+
+
+class TestDraftHappyPath(unittest.TestCase):
+    """Happy-path tests for the draft command parser."""
+
+    def test_topic_only_all_defaults(self):
+        result = parse_invocation(SPEC, '"Theorem 1"', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.positionals["topic"], "Theorem 1")
+        self.assertEqual(result.options["--mode"].value, "skeleton")
+        self.assertEqual(result.options["--mode"].source, "default")
+
+    def test_topic_with_explicit_mode(self):
+        result = parse_invocation(SPEC, '"x" --mode=attempt', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--mode"].value, "attempt")
+        self.assertEqual(result.options["--mode"].source, "explicit")
+
+    def test_topic_with_spaces(self):
+        result = parse_invocation(SPEC, '"every even number > 2 is the sum of two primes"', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(
+            result.positionals["topic"],
+            "every even number > 2 is the sum of two primes",
+        )
+
+    def test_source_only_no_topic(self):
+        result = parse_invocation(SPEC, "--source=paper.pdf", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertNotIn("topic", result.positionals)
+        self.assertEqual(result.options["--source"].value, "paper.pdf")
+
+    def test_topic_and_source_both_present(self):
+        result = parse_invocation(SPEC, '"Zorn" --source=notes.pdf', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.positionals["topic"], "Zorn")
+        self.assertEqual(result.options["--source"].value, "notes.pdf")
+
+
+class TestDraftBadEnum(unittest.TestCase):
+    """Enum validation errors."""
+
+    def test_bad_mode_value(self):
+        result = parse_invocation(SPEC, '"x" --mode=banana', cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+        self.assertIn("banana", result.errors[0])
+        self.assertIn("skeleton", result.errors[0])
+        self.assertIn("attempt", result.errors[0])
+
+
+class TestDraftMissingRequired(unittest.TestCase):
+    """Cross-validation: topic-or-source required."""
+
+    def test_no_topic_no_source(self):
+        result = parse_invocation(SPEC, "--mode=skeleton", cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+        matching = [e for e in result.errors if "topic" in e.lower() or "source" in e.lower()]
+        self.assertTrue(len(matching) > 0, f"Expected topic/source error, got: {result.errors}")
+
+    def test_empty_input(self):
+        result = parse_invocation(SPEC, "", cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+        matching = [e for e in result.errors if "topic" in e.lower() or "source" in e.lower()]
+        self.assertTrue(len(matching) > 0, f"Expected topic/source error, got: {result.errors}")
+
+
+class TestDraftClaimSelect(unittest.TestCase):
+    """--claim-select requires --source."""
+
+    def test_claim_select_without_source_errors(self):
+        result = parse_invocation(SPEC, '"x" --claim-select=first', cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+        matching = [e for e in result.errors if "claim-select" in e and "source" in e.lower()]
+        self.assertTrue(len(matching) > 0, f"Expected claim-select/source error, got: {result.errors}")
+
+    def test_claim_select_with_source_ok(self):
+        result = parse_invocation(SPEC, '--source=paper.pdf --claim-select=first', cwd=CWD)
+        self.assertEqual(result.errors, [])
+
+
+class TestDraftOutputFileRequiresOut(unittest.TestCase):
+    """--output=file without --out."""
+
+    def test_output_file_without_out_errors(self):
+        result = parse_invocation(SPEC, '"x" --output=file', cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+        matching = [e for e in result.errors if "output" in e.lower() and "out" in e.lower()]
+        self.assertTrue(len(matching) > 0, f"Expected output/out error, got: {result.errors}")
+
+
+class TestDraftIntentCoercion(unittest.TestCase):
+    """Intent auto-collapse coercion."""
+
+    def test_intent_auto_coerced_to_usage(self):
+        result = parse_invocation(SPEC, '"x" --intent=auto', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--intent"].value, "usage")
+        self.assertEqual(result.options["--intent"].source, "coerced")
+        self.assertEqual(result.options["--intent"].coerced_from, "auto")
+
+    def test_intent_math_not_coerced(self):
+        result = parse_invocation(SPEC, '"x" --intent=math', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--intent"].value, "math")
+        self.assertEqual(result.options["--intent"].source, "explicit")
+        self.assertIsNone(result.options["--intent"].coerced_from)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lean4/tests/command_args/test_parser_formalize.py
+++ b/plugins/lean4/tests/command_args/test_parser_formalize.py
@@ -1,0 +1,99 @@
+"""Layer 1 parser golden tests for /lean4:formalize."""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "lib"))
+
+from command_args import COMMAND_SPECS, parse_invocation
+
+SPEC = COMMAND_SPECS["formalize"]
+CWD = "/tmp"
+
+
+class TestFormalizeHappyPath(unittest.TestCase):
+    """Happy-path tests."""
+
+    def test_topic_with_rigor(self):
+        result = parse_invocation(SPEC, '"Zorn" --rigor=axiomatic', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.positionals["topic"], "Zorn")
+        self.assertEqual(result.options["--rigor"].value, "axiomatic")
+        self.assertEqual(result.options["--rigor"].source, "explicit")
+
+    def test_topic_only_defaults(self):
+        result = parse_invocation(SPEC, '"Zorn"', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--rigor"].value, "checked")
+        self.assertEqual(result.options["--rigor"].source, "default")
+
+    def test_source_only(self):
+        result = parse_invocation(SPEC, '--source=paper.pdf', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertNotIn("topic", result.positionals)
+        self.assertEqual(result.options["--source"].value, "paper.pdf")
+
+
+class TestFormalizeMissingTopicAndSource(unittest.TestCase):
+    """topic OR source: missing both -> error."""
+
+    def test_neither_topic_nor_source(self):
+        result = parse_invocation(SPEC, '--rigor=checked', cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+        matching = [e for e in result.errors if "topic" in e.lower() or "source" in e.lower()]
+        self.assertTrue(len(matching) > 0, f"Expected topic/source error, got: {result.errors}")
+
+    def test_empty_input(self):
+        result = parse_invocation(SPEC, '', cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+
+
+class TestFormalizeClaimSelectRequiresSource(unittest.TestCase):
+    """--claim-select requires --source."""
+
+    def test_claim_select_without_source_errors(self):
+        result = parse_invocation(SPEC, '"Zorn" --claim-select=first', cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+        matching = [e for e in result.errors if "claim-select" in e and "source" in e.lower()]
+        self.assertTrue(len(matching) > 0, f"Expected claim-select/source error, got: {result.errors}")
+
+    def test_claim_select_with_source_ok(self):
+        result = parse_invocation(SPEC, '--source=paper.pdf --claim-select=first', cwd=CWD)
+        self.assertEqual(result.errors, [])
+
+
+class TestFormalizeIntentCoercion(unittest.TestCase):
+    """--intent=auto is coerced to usage (formalize intent_auto_collapse)."""
+
+    def test_intent_auto_coerced(self):
+        result = parse_invocation(SPEC, '"Zorn" --intent=auto', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--intent"].value, "usage")
+        self.assertEqual(result.options["--intent"].source, "coerced")
+        self.assertEqual(result.options["--intent"].coerced_from, "auto")
+
+    def test_intent_math_not_coerced(self):
+        result = parse_invocation(SPEC, '"Zorn" --intent=math', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--intent"].value, "math")
+        self.assertEqual(result.options["--intent"].source, "explicit")
+
+    def test_intent_usage_not_coerced(self):
+        result = parse_invocation(SPEC, '"Zorn" --intent=usage', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--intent"].value, "usage")
+        self.assertEqual(result.options["--intent"].source, "explicit")
+
+
+class TestFormalizeOutputFileRequiresOut(unittest.TestCase):
+    """--output=file without --out errors."""
+
+    def test_output_file_without_out_errors(self):
+        result = parse_invocation(SPEC, '"Zorn" --output=file', cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+        matching = [e for e in result.errors if "output" in e.lower() and "out" in e.lower()]
+        self.assertTrue(len(matching) > 0, f"Expected output/out error, got: {result.errors}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lean4/tests/command_args/test_parser_learn.py
+++ b/plugins/lean4/tests/command_args/test_parser_learn.py
@@ -1,0 +1,102 @@
+"""Layer 1 parser golden tests for /lean4:learn."""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "lib"))
+
+from command_args import COMMAND_SPECS, parse_invocation
+
+SPEC = COMMAND_SPECS["learn"]
+CWD = "/tmp"
+
+
+class TestLearnHappyPath(unittest.TestCase):
+    """Happy-path tests."""
+
+    def test_topic_only(self):
+        result = parse_invocation(SPEC, '"continuity"', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.positionals["topic"], "continuity")
+        self.assertEqual(result.options["--mode"].value, "auto")
+        self.assertEqual(result.options["--mode"].source, "default")
+
+    def test_empty_input_ok(self):
+        """learn allows no positional (conversational discovery)."""
+        result = parse_invocation(SPEC, "", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertNotIn("topic", result.positionals)
+
+    def test_topic_with_style(self):
+        result = parse_invocation(SPEC, '"groups" --style=socratic', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--style"].value, "socratic")
+        self.assertEqual(result.options["--style"].source, "explicit")
+
+
+class TestLearnTrackWithoutGame(unittest.TestCase):
+    """--track without --style=game is coerced to None (warn+ignore)."""
+
+    def test_track_without_game_coerced(self):
+        result = parse_invocation(SPEC, '"x" --track=nng-like --style=tour', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--track"].value, None)
+        self.assertEqual(result.options["--track"].source, "coerced")
+        self.assertEqual(result.options["--track"].coerced_from, "nng-like")
+
+    def test_track_with_game_ok(self):
+        result = parse_invocation(SPEC, '"x" --track=nng-like --style=game', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--track"].value, "nng-like")
+        self.assertEqual(result.options["--track"].source, "explicit")
+        self.assertIsNone(result.options["--track"].coerced_from)
+
+
+class TestLearnSourceOverridesScope(unittest.TestCase):
+    """--source + --scope=file|changed|project -> warning."""
+
+    def test_source_plus_scope_file_warns(self):
+        result = parse_invocation(SPEC, '--source=notes.pdf --scope=file', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        matching = [w for w in result.warnings if "source" in w.lower() and "scope" in w.lower()]
+        self.assertTrue(len(matching) > 0, f"Expected source/scope warning, got: {result.warnings}")
+
+    def test_source_plus_scope_auto_no_warning(self):
+        result = parse_invocation(SPEC, '--source=notes.pdf --scope=auto', cwd=CWD)
+        self.assertEqual(result.errors, [])
+        matching = [w for w in result.warnings if "source" in w.lower() and "scope" in w.lower()]
+        self.assertEqual(len(matching), 0, f"Unexpected warning: {result.warnings}")
+
+
+class TestLearnEnumValues(unittest.TestCase):
+    """Valid enum values for --mode, --style, --level, --adaptive."""
+
+    def test_mode_valid_values(self):
+        for val in ("auto", "repo", "mathlib"):
+            result = parse_invocation(SPEC, f'"x" --mode={val}', cwd=CWD)
+            self.assertEqual(result.errors, [], f"Unexpected error for --mode={val}: {result.errors}")
+
+    def test_style_valid_values(self):
+        for val in ("tour", "socratic", "exercise", "game"):
+            result = parse_invocation(SPEC, f'"x" --style={val}', cwd=CWD)
+            self.assertEqual(result.errors, [], f"Unexpected error for --style={val}: {result.errors}")
+
+    def test_level_valid_values(self):
+        for val in ("beginner", "intermediate", "expert"):
+            result = parse_invocation(SPEC, f'"x" --level={val}', cwd=CWD)
+            self.assertEqual(result.errors, [], f"Unexpected error for --level={val}: {result.errors}")
+
+
+class TestLearnBadAdaptive(unittest.TestCase):
+    """Bad enum for --adaptive."""
+
+    def test_bad_adaptive_value(self):
+        result = parse_invocation(SPEC, '"x" --adaptive=banana', cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+        self.assertIn("banana", result.errors[0])
+        self.assertIn("on", result.errors[0])
+        self.assertIn("off", result.errors[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lean4/tests/command_args/test_parser_prove.py
+++ b/plugins/lean4/tests/command_args/test_parser_prove.py
@@ -100,5 +100,31 @@ class TestProveNoCrossValidations(unittest.TestCase):
         self.assertEqual(result.options["--deep"].value, "stuck")
 
 
+class TestProveBooleanFlags(unittest.TestCase):
+    """Boolean flags support explicit =false negation."""
+
+    def test_repair_only_false(self):
+        """--repair-only=false must not produce a stray positional error."""
+        result = parse_invocation(SPEC, "Foo.lean --repair-only=false", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertFalse(result.options["--repair-only"].value)
+
+    def test_repair_only_true(self):
+        result = parse_invocation(SPEC, "Foo.lean --repair-only=true", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertTrue(result.options["--repair-only"].value)
+
+    def test_repair_only_presence(self):
+        """Bare --repair-only (no value) means true."""
+        result = parse_invocation(SPEC, "Foo.lean --repair-only", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertTrue(result.options["--repair-only"].value)
+
+    def test_checkpoint_false(self):
+        result = parse_invocation(SPEC, "--checkpoint=false", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertFalse(result.options["--checkpoint"].value)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/lean4/tests/command_args/test_parser_prove.py
+++ b/plugins/lean4/tests/command_args/test_parser_prove.py
@@ -1,0 +1,104 @@
+"""Layer 1 parser golden tests for /lean4:prove."""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "lib"))
+
+from command_args import COMMAND_SPECS, parse_invocation
+
+SPEC = COMMAND_SPECS["prove"]
+CWD = "/tmp"
+
+
+class TestProveHappyPath(unittest.TestCase):
+    """Happy-path tests."""
+
+    def test_scope_positional(self):
+        result = parse_invocation(SPEC, "Foo.lean", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.positionals["scope"], "Foo.lean")
+
+    def test_empty_scope_ok(self):
+        result = parse_invocation(SPEC, "", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertNotIn("scope", result.positionals)
+
+    def test_all_defaults_no_coercions(self):
+        result = parse_invocation(SPEC, "Foo.lean", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.coercions, [])
+        self.assertEqual(result.warnings, [])
+        # Verify key defaults
+        self.assertEqual(result.options["--planning"].value, "ask")
+        self.assertEqual(result.options["--planning"].source, "default")
+        self.assertEqual(result.options["--commit"].value, "ask")
+        self.assertEqual(result.options["--commit"].source, "default")
+        self.assertEqual(result.options["--deep"].value, "never")
+        self.assertEqual(result.options["--deep"].source, "default")
+
+
+class TestProvePlanningAskIsValid(unittest.TestCase):
+    """--planning=ask is valid for prove (interactive, NOT coerced)."""
+
+    def test_planning_ask_not_coerced(self):
+        result = parse_invocation(SPEC, "Foo.lean --planning=ask", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--planning"].value, "ask")
+        self.assertEqual(result.options["--planning"].source, "explicit")
+        self.assertIsNone(result.options["--planning"].coerced_from)
+
+
+class TestProveCommitAskIsValid(unittest.TestCase):
+    """--commit=ask is valid for prove (interactive, NOT coerced)."""
+
+    def test_commit_ask_not_coerced(self):
+        result = parse_invocation(SPEC, "--commit=ask", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.options["--commit"].value, "ask")
+        self.assertEqual(result.options["--commit"].source, "explicit")
+        self.assertIsNone(result.options["--commit"].coerced_from)
+
+
+class TestProveBadEnum(unittest.TestCase):
+    """Bad enum values produce errors."""
+
+    def test_bad_deep_value(self):
+        result = parse_invocation(SPEC, "--deep=banana", cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+        self.assertIn("banana", result.errors[0])
+        # Should list valid values
+        self.assertIn("never", result.errors[0])
+        self.assertIn("ask", result.errors[0])
+        self.assertIn("stuck", result.errors[0])
+        self.assertIn("always", result.errors[0])
+
+    def test_bad_planning_value(self):
+        result = parse_invocation(SPEC, "--planning=banana", cwd=CWD)
+        self.assertTrue(len(result.errors) > 0)
+        self.assertIn("banana", result.errors[0])
+
+
+class TestProveNoCrossValidations(unittest.TestCase):
+    """prove has no cross-validations, so no warning/error from them."""
+
+    def test_no_cross_validation_errors(self):
+        result = parse_invocation(SPEC, "Foo.lean", cwd=CWD)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.warnings, [])
+
+    def test_no_cross_validation_with_explicit_flags(self):
+        result = parse_invocation(
+            SPEC,
+            "Foo.lean --commit=auto --planning=on --deep=stuck",
+            cwd=CWD,
+        )
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.warnings, [])
+        self.assertEqual(result.options["--commit"].value, "auto")
+        self.assertEqual(result.options["--planning"].value, "on")
+        self.assertEqual(result.options["--deep"].value, "stuck")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lean4/tests/test_cycle_tracker.sh
+++ b/plugins/lean4/tests/test_cycle_tracker.sh
@@ -277,6 +277,19 @@ run init --max-cycles=5 --max-stuck=2 --max-runtime=foo
 assert_exit "--max-runtime=foo rejected" 2
 assert_contains "error: duration format" "duration format"
 
+# Uppercase suffix (Bash 3.2 portability — ${suffix,,} was Bash 4+ only)
+init_session --max-cycles=5 --max-stuck=2 --max-runtime=60M
+FILE=$(state_file)
+RUNTIME=$(read_field "$FILE" "max_runtime_seconds")
+if [[ "$RUNTIME" == "3600" ]]; then
+  echo "  PASS: --max-runtime=60M → 3600 seconds (uppercase suffix)"
+  (( ++PASS ))
+else
+  echo "  FAIL: --max-runtime=60M → $RUNTIME, expected 3600"
+  (( ++FAIL ))
+fi
+cleanup_session
+
 # Valid optional omission
 init_session --max-cycles=5 --max-stuck=2
 FILE=$(state_file)

--- a/plugins/lean4/tests/test_validate_user_prompt.sh
+++ b/plugins/lean4/tests/test_validate_user_prompt.sh
@@ -1,0 +1,354 @@
+#!/bin/bash
+set -euo pipefail
+
+# Layer 2 integration tests for validate_user_prompt.py
+# Pipes JSON to the hook and asserts on exit codes and stdout JSON fields.
+#
+# NOTE: We invoke "$HOOK" directly (no `bash` or `python3` prefix) so that
+# the shebang line and executable bit are exercised end-to-end.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$(cd "$SCRIPT_DIR/.." && pwd)/hooks/validate_user_prompt.py"
+
+PASS=0
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# run_test: pipe $input to the hook, assert exit code.
+#   $1=description  $2=stdin input  $3=expected exit code
+run_test() {
+  local desc="$1" input="$2" expected_exit="$3"
+  local actual_exit=0
+  echo "$input" | "$HOOK" >/dev/null 2>&1 || actual_exit=$?
+  if [[ "$actual_exit" -eq "$expected_exit" ]]; then
+    echo "  PASS: $desc"
+    (( ++PASS ))
+  else
+    echo "  FAIL: $desc (expected exit $expected_exit, got $actual_exit)"
+    (( ++FAIL ))
+  fi
+}
+
+# run_test_empty: pipe $input to the hook, assert exit 0 AND empty stdout.
+#   $1=description  $2=stdin input
+run_test_empty() {
+  local desc="$1" input="$2"
+  local actual_exit=0 output
+  output=$(echo "$input" | "$HOOK" 2>/dev/null) || actual_exit=$?
+  if [[ "$actual_exit" -ne 0 ]]; then
+    echo "  FAIL: $desc (expected exit 0, got $actual_exit)"
+    (( ++FAIL ))
+    return
+  fi
+  if [[ -z "$output" ]]; then
+    echo "  PASS: $desc"
+    (( ++PASS ))
+  else
+    echo "  FAIL: $desc (expected empty stdout, got '$output')"
+    (( ++FAIL ))
+  fi
+}
+
+# run_test_empty_stdin: send no stdin to the hook, assert exit 0 AND empty stdout.
+#   $1=description
+run_test_empty_stdin() {
+  local desc="$1"
+  local actual_exit=0 output
+  output=$("$HOOK" </dev/null 2>/dev/null) || actual_exit=$?
+  if [[ "$actual_exit" -ne 0 ]]; then
+    echo "  FAIL: $desc (expected exit 0, got $actual_exit)"
+    (( ++FAIL ))
+    return
+  fi
+  if [[ -z "$output" ]]; then
+    echo "  PASS: $desc"
+    (( ++PASS ))
+  else
+    echo "  FAIL: $desc (expected empty stdout, got '$output')"
+    (( ++FAIL ))
+  fi
+}
+
+# run_test_json: pipe $input to the hook, extract a jq expression, compare to expected.
+#   $1=description  $2=stdin input  $3=jq expression  $4=expected value
+run_test_json() {
+  local desc="$1" input="$2" jq_expr="$3" expected="$4"
+  local output actual
+  output=$(echo "$input" | "$HOOK" 2>/dev/null)
+  # Use jq if available, else python3 fallback
+  if command -v jq &>/dev/null; then
+    actual=$(echo "$output" | jq -r "$jq_expr" 2>/dev/null)
+  else
+    actual=$(echo "$output" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+# Walk the jq-like path: .a.b.c -> d['a']['b']['c']
+path = sys.argv[1].lstrip('.').split('.')
+cur = d
+for p in path:
+    cur = cur[p]
+print(cur)
+" "$jq_expr" 2>/dev/null)
+  fi
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  PASS: $desc"
+    (( ++PASS ))
+  else
+    echo "  FAIL: $desc (expected '$expected', got '$actual')"
+    (( ++FAIL ))
+  fi
+}
+
+# run_test_json_contains: pipe $input, extract jq field, check substring match.
+#   $1=description  $2=stdin input  $3=jq expression  $4=substring
+run_test_json_contains() {
+  local desc="$1" input="$2" jq_expr="$3" substring="$4"
+  local output actual
+  output=$(echo "$input" | "$HOOK" 2>/dev/null)
+  if command -v jq &>/dev/null; then
+    actual=$(echo "$output" | jq -r "$jq_expr" 2>/dev/null)
+  else
+    actual=$(echo "$output" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+path = sys.argv[1].lstrip('.').split('.')
+cur = d
+for p in path:
+    cur = cur[p]
+print(cur)
+" "$jq_expr" 2>/dev/null)
+  fi
+  if [[ "$actual" == *"$substring"* ]]; then
+    echo "  PASS: $desc"
+    (( ++PASS ))
+  else
+    echo "  FAIL: $desc (expected '$substring' in '$actual')"
+    (( ++FAIL ))
+  fi
+}
+
+echo "=== validate_user_prompt.py integration tests ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# Passthrough cases (no output, exit 0)
+# ---------------------------------------------------------------------------
+
+echo "-- Passthrough cases (exit 0, empty stdout) --"
+
+run_test_empty \
+  "1. Empty prompt" \
+  '{"prompt":""}'
+
+run_test_empty \
+  "2. Non-/lean4: prompt" \
+  '{"prompt":"hello world"}'
+
+run_test_empty \
+  "3. /codex: prefix (not /lean4:)" \
+  '{"prompt":"/codex:foo bar"}'
+
+run_test_empty \
+  "4. Whitespace-only prompt" \
+  '{"prompt":"   "}'
+
+run_test_empty \
+  "5. Malformed JSON on stdin" \
+  "not json at all"
+
+run_test_empty_stdin \
+  "6. Empty stdin"
+
+run_test_empty \
+  "7. Unknown /lean4: command" \
+  '{"prompt":"/lean4:nonexistent foo"}'
+
+run_test_empty \
+  "8. /lean4: with no command name" \
+  '{"prompt":"/lean4: foo"}'
+
+run_test_empty \
+  "9. Uncovered command (doctor)" \
+  '{"prompt":"/lean4:doctor"}'
+
+run_test_empty \
+  "10. Uncovered command (checkpoint)" \
+  '{"prompt":"/lean4:checkpoint"}'
+
+# ---------------------------------------------------------------------------
+# Blocked cases (exit 0, stdout has decision:block)
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "-- Blocked cases (exit 0, decision=block) --"
+
+run_test \
+  "11. Missing topic+source for draft (exit 0)" \
+  '{"prompt":"/lean4:draft --mode=skeleton","cwd":"/tmp"}' \
+  0
+
+run_test_json \
+  "11b. Missing topic+source for draft (decision=block)" \
+  '{"prompt":"/lean4:draft --mode=skeleton","cwd":"/tmp"}' \
+  ".decision" \
+  "block"
+
+run_test \
+  "12. Bad enum for draft --mode (exit 0)" \
+  '{"prompt":"/lean4:draft --mode=banana \"x\"","cwd":"/tmp"}' \
+  0
+
+run_test_json \
+  "12b. Bad enum for draft --mode (decision=block)" \
+  '{"prompt":"/lean4:draft --mode=banana \"x\"","cwd":"/tmp"}' \
+  ".decision" \
+  "block"
+
+run_test \
+  "13. Missing required flags for autoformalize (exit 0)" \
+  '{"prompt":"/lean4:autoformalize","cwd":"/tmp"}' \
+  0
+
+run_test_json \
+  "13b. Missing required flags for autoformalize (decision=block)" \
+  '{"prompt":"/lean4:autoformalize","cwd":"/tmp"}' \
+  ".decision" \
+  "block"
+
+run_test \
+  "14. Bad int for autoprove --max-cycles (exit 0)" \
+  '{"prompt":"/lean4:autoprove --max-cycles=cat","cwd":"/tmp"}' \
+  0
+
+run_test_json \
+  "14b. Bad int for autoprove --max-cycles (decision=block)" \
+  '{"prompt":"/lean4:autoprove --max-cycles=cat","cwd":"/tmp"}' \
+  ".decision" \
+  "block"
+
+# ---------------------------------------------------------------------------
+# Success cases (exit 0, stdout has hookSpecificOutput.additionalContext)
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "-- Success cases (exit 0, hookEventName=UserPromptSubmit) --"
+
+run_test \
+  "15. Valid draft (exit 0)" \
+  '{"prompt":"/lean4:draft \"Theorem 1\"","cwd":"/tmp"}' \
+  0
+
+run_test_json \
+  "15b. Valid draft (hookEventName)" \
+  '{"prompt":"/lean4:draft \"Theorem 1\"","cwd":"/tmp"}' \
+  ".hookSpecificOutput.hookEventName" \
+  "UserPromptSubmit"
+
+run_test \
+  "16. Valid autoprove with coercion (exit 0)" \
+  '{"prompt":"/lean4:autoprove --commit=ask --max-cycles=5","cwd":"/tmp"}' \
+  0
+
+run_test_json \
+  "16b. Valid autoprove with coercion (hookEventName)" \
+  '{"prompt":"/lean4:autoprove --commit=ask --max-cycles=5","cwd":"/tmp"}' \
+  ".hookSpecificOutput.hookEventName" \
+  "UserPromptSubmit"
+
+run_test \
+  "17. Valid prove (exit 0)" \
+  '{"prompt":"/lean4:prove Foo.lean","cwd":"/tmp"}' \
+  0
+
+run_test_json \
+  "17b. Valid prove (hookEventName)" \
+  '{"prompt":"/lean4:prove Foo.lean","cwd":"/tmp"}' \
+  ".hookSpecificOutput.hookEventName" \
+  "UserPromptSubmit"
+
+run_test \
+  "18. Valid learn (exit 0)" \
+  '{"prompt":"/lean4:learn \"groups\"","cwd":"/tmp"}' \
+  0
+
+run_test_json \
+  "18b. Valid learn (hookEventName)" \
+  '{"prompt":"/lean4:learn \"groups\"","cwd":"/tmp"}' \
+  ".hookSpecificOutput.hookEventName" \
+  "UserPromptSubmit"
+
+run_test \
+  "19. Valid formalize (exit 0)" \
+  '{"prompt":"/lean4:formalize \"Zorn\"","cwd":"/tmp"}' \
+  0
+
+run_test_json \
+  "19b. Valid formalize (hookEventName)" \
+  '{"prompt":"/lean4:formalize \"Zorn\"","cwd":"/tmp"}' \
+  ".hookSpecificOutput.hookEventName" \
+  "UserPromptSubmit"
+
+# ---------------------------------------------------------------------------
+# Artifact cases
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "-- Artifact cases --"
+
+# 20. With session_id + CLAUDE_SESSION_DIR: verify artifact file is written
+ARTIFACT_DIR=$(mktemp -d)
+
+# Run the hook with CLAUDE_SESSION_DIR so the artifact lands in our temp dir.
+# env sets the variable for the entire pipeline (the hook is the reader).
+echo '{"prompt":"/lean4:draft \"Theorem 1\"","cwd":"/tmp","session_id":"test123"}' \
+  | env CLAUDE_SESSION_DIR="$ARTIFACT_DIR" "$HOOK" >/dev/null 2>&1 || true
+
+if [[ -f "$ARTIFACT_DIR/lean4_invocation_test123.json" ]]; then
+  echo "  PASS: 20. Artifact file written to CLAUDE_SESSION_DIR"
+  (( ++PASS ))
+else
+  echo "  FAIL: 20. Artifact file not found at $ARTIFACT_DIR/lean4_invocation_test123.json"
+  (( ++FAIL ))
+fi
+rm -rf "$ARTIFACT_DIR"
+
+# 21. Without session_id: verify no artifact file
+NO_ARTIFACT_DIR=$(mktemp -d)
+
+echo '{"prompt":"/lean4:draft \"Theorem 1\"","cwd":"/tmp"}' \
+  | env CLAUDE_SESSION_DIR="$NO_ARTIFACT_DIR" "$HOOK" >/dev/null 2>&1 || true
+
+# Count files -- there should be none starting with lean4_invocation_
+ARTIFACT_COUNT=$(find "$NO_ARTIFACT_DIR" -name 'lean4_invocation_*' 2>/dev/null | wc -l)
+if [[ "$ARTIFACT_COUNT" -eq 0 ]]; then
+  echo "  PASS: 21. No artifact file without session_id"
+  (( ++PASS ))
+else
+  echo "  FAIL: 21. Unexpected artifact files found in $NO_ARTIFACT_DIR"
+  (( ++FAIL ))
+fi
+rm -rf "$NO_ARTIFACT_DIR"
+
+# ---------------------------------------------------------------------------
+# Coercion visibility
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "-- Coercion visibility --"
+
+run_test_json_contains \
+  "22. Autoprove --commit=ask: additionalContext contains 'coerced'" \
+  '{"prompt":"/lean4:autoprove --commit=ask --max-cycles=5","cwd":"/tmp"}' \
+  ".hookSpecificOutput.additionalContext" \
+  "coerced"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/plugins/lean4/tests/test_validate_user_prompt.sh
+++ b/plugins/lean4/tests/test_validate_user_prompt.sh
@@ -346,6 +346,27 @@ run_test_json_contains \
   "coerced"
 
 # ---------------------------------------------------------------------------
+# Whitespace separator regressions
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "-- Whitespace separator regressions --"
+
+# Tab separator between command and tail
+run_test_json \
+  "23. Tab separator: /lean4:draft<TAB>\"x\"" \
+  "{\"prompt\":\"/lean4:draft\t\\\"x\\\"\",\"cwd\":\"/tmp\"}" \
+  ".hookSpecificOutput.hookEventName" \
+  "UserPromptSubmit"
+
+# Newline separator between command and tail
+run_test_json \
+  "24. Newline separator: /lean4:draft<NL>\"x\"" \
+  "{\"prompt\":\"/lean4:draft\n\\\"x\\\"\",\"cwd\":\"/tmp\"}" \
+  ".hookSpecificOutput.hookEventName" \
+  "UserPromptSubmit"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/plugins/lean4/tools/lint_docs.sh
+++ b/plugins/lean4/tools/lint_docs.sh
@@ -1543,8 +1543,11 @@ check_command_invocation_contract() {
         return
     fi
 
-    if ! grep -qi 'model-parsed, not host-parsed' "$ref" 2>/dev/null; then
-        warn "command-invocation.md: Missing model-parsed vs host-parsed clarification"
+    if ! grep -q '^## Validated Invocation Block' "$ref" 2>/dev/null; then
+        warn "command-invocation.md: Missing 'Validated Invocation Block' section"
+    fi
+    if ! grep -q '^## Adapter Implementations' "$ref" 2>/dev/null; then
+        warn "command-invocation.md: Missing 'Adapter Implementations' section"
     fi
 
     for cmd in draft formalize autoformalize prove autoprove learn; do
@@ -1556,6 +1559,12 @@ check_command_invocation_contract() {
         fi
         if ! grep -q '^## Invocation Contract' "$file" 2>/dev/null; then
             warn "$base: Missing Invocation Contract section"
+        fi
+        if ! grep -q '\*\*Primary path (hook-validated):\*\*' "$file" 2>/dev/null; then
+            warn "$base: Missing 'Primary path (hook-validated):' marker — Invocation Contract rewrite skipped?"
+        fi
+        if grep -q '^Slash-command inputs are raw text' "$file" 2>/dev/null; then
+            warn "$base: Still contains legacy 'Slash-command inputs are raw text' intro — Invocation Contract rewrite incomplete"
         fi
     done
 


### PR DESCRIPTION
## Summary

Phase 3 of #103. Adds a host-agnostic Python parser and a Claude `UserPromptSubmit` hook that pre-validates the six parser-covered `/lean4:` commands (`draft`, `learn`, `formalize`, `autoformalize`, `prove`, `autoprove`) before the model sees them. The other five commands (`checkpoint`, `review`, `refactor`, `golf`, `doctor`) pass through the hook untouched.

- **Parser package** (`lib/command_args/`): encodes every parser-decidable flag, default, alias, coercion, and cross-flag rule for the six parameter-heavy commands (`draft`, `learn`, `formalize`, `autoformalize`, `prove`, `autoprove`). A small set of documented rules that depend on runtime context (repo-level search, interactive prompting, file-content inspection) are intentionally left model-side and tracked in a forward-exclusions list.
- **`UserPromptSubmit` hook** (`hooks/validate_user_prompt.py`): blocks hard parse errors before the model turn; injects a `validated-invocation` block via `additionalContext` on success. Fails open on any internal error (import failure, parser crash) — a Python bug never blocks a user from running a command.
- **Standalone CLI** (`lib/scripts/parse_command_args.py`): for non-Claude hosts to invoke the same parser. Requires exactly one argument after `--` (the raw tail as a single string) so shell quoting boundaries are preserved. Exit 0 on success, 2 on validation errors, 1 on usage errors.
- **Doc updates**: `command-invocation.md` gains "Validated Invocation Block" and "Adapter Implementations" sections; all six commands get rewritten Invocation Contract intros (primary hook-validated path / fallback model-parsed path) and `argument-hint` frontmatter; `SKILL.md`, both READMEs, and `lint_docs.sh` updated.
- **Version bump** to 4.4.9 (`plugin.json`, `marketplace.json`, `CHANGELOG.md`). Changelog covers #105 (Phase 1–2), #104 (OOM warning), this PR (#106, Phase 3), and the Bash 3.2 portability fix.
- **Bash 3.2 fix**: `cycle_tracker.sh` `${suffix,,}` replaced with portable `tr` lowercase — unblocks macOS stock bash.
- **164 automated checks** across three layers. Layer 1: parser golden tests per command. Layer 2: 33 bash hook integration assertions (including tab/newline whitespace regressions). Layer 4: hook-to-block subprocess round-trip, fail-open simulations, formatter snapshots (JSON-based), and standalone CLI subprocess tests (including multi-arg rejection regressions). (131 Python tests total across Layers 1 + 4; 33 bash assertions in Layer 2.) Layer 3 (bidirectional doc-sync) is scaffolded (exclusion/allow-list files shipped) but the executable `test_doc_sync.py` is deferred. Existing suites (guardrails 75, cycle_tracker 174, contracts 27) pass with zero regressions.

With #105 already merged on `main`, this PR completes the remaining parser/hook work for command invocation and closes #103.

## Design decisions

- **Per-command spec modules are the source of truth** for flag definitions (`lib/command_args/specs/{draft,learn,formalize,autoformalize,prove,autoprove}.py`, aggregated by `specs/__init__.py`). A bidirectional doc-sync test (Layer 3) is scaffolded in this PR — the forward-exclusions and reverse-allow-list files are shipped — but the executable `test_doc_sync.py` is not yet wired and is deferred to a follow-up.
- **Block is authoritative for parser-decidable inputs only.** Commands with repo-dependent startup rules (e.g. learn's `--mode=mathlib` scope coercion) may refine forward-excluded fields after reading the block.
- **Durations are suffixed strings** (`"15m"`, `"30s"`, `"2h"`), not bare integers, so the tracker's `_parse_duration` always receives an unambiguous unit.
- **Coercion vs CrossValidation distinction**: `Coercion` always changes the value (including "warn + ignore" which coerces to default); `CrossValidation` is for multi-flag logic and warning-only rules where the value is unchanged.
- **Five commands untouched by the parser** (`checkpoint`, `review`, `refactor`, `golf`, `doctor`) remain model-parsed and pass through the hook without importing the parser.

## Test plan

- [x] `python3 -m unittest discover plugins/lean4/tests/command_args -v` (131 tests)
- [x] `bash plugins/lean4/tests/test_validate_user_prompt.sh` (33 assertions)
- [x] Existing suites: `test_guardrails.sh` (75/75), `test_cycle_tracker.sh` (175/175, +1 uppercase suffix), `test_contracts.sh` (27/27)
- [x] `lint_docs.sh` exits 1 with 3 pre-existing line-count warnings only (no new warnings from Phase 3; the exit code is nonzero because `lint_docs.sh` treats all warnings as issues)
- [x] Manual hook smoke: `echo '{"prompt":"/lean4:draft \"Theorem 1\""}' | plugins/lean4/hooks/validate_user_prompt.py` emits validated block
- [x] Manual hook block: `echo '{"prompt":"/lean4:draft --mode=banana"}' | plugins/lean4/hooks/validate_user_prompt.py` emits `decision: "block"`
- [x] Passthrough: non-`/lean4:` prompts and uncovered commands (`/lean4:doctor`) produce no output
- [x] E2E inside Claude Code after `/plugin install` from local checkout