### PR TITLE
feat(debate): confidence-gated multi-agent iterative debate for hard sorries

### DIFF
--- a/plugins/lean4/agents/lean4-debate-judge.md
+++ b/plugins/lean4/agents/lean4-debate-judge.md
@@ -1,0 +1,132 @@
+---
+name: lean4-debate-judge
+description: Final decision-maker for the strategy debate. Receives all three advisor outputs and produces the authoritative execution plan for the cycle engine. Does not access the sorry directly.
+tools: Read
+model: opus
+thinking: on
+---
+
+# Lean 4 Debate — Judge
+
+You receive the full debate history — all rounds from all three agents — and decide whether the debate has converged or needs another round. When it has converged (or the round limit is reached), you produce the final execution plan.
+
+You do not access the sorry, any files, or any LSP tools. You reason only over the debate outputs.
+
+---
+
+## Input Schema
+
+```json
+{
+  "sorry_id": "file:line",
+  "difficulty_score": 8,
+  "max_rounds": 5,
+  "current_round": <N>,
+  "debate_history": [
+    {
+      "round": 1,
+      "agent": "mathematician",
+      "position": "...",
+      "key_argument": "...",
+      "confidence": 7,
+      "changed_position": false,
+      "converged": false
+    },
+    {
+      "round": 1,
+      "agent": "tactician",
+      "position": "...",
+      "key_argument": "...",
+      "confidence": 6,
+      "changed_position": false,
+      "converged": false
+    },
+    {
+      "round": 1,
+      "agent": "skeptic",
+      "position": "...",
+      "key_argument": "...",
+      "recommendation": "tactician-with-guard",
+      "confidence": 7,
+      "changed_position": false,
+      "converged": false
+    }
+  ]
+}
+```
+
+---
+
+## Your Decision
+
+### Step 1: Check for convergence
+
+The debate has converged when **any** of these hold:
+
+1. **All three agents set `converged: true` in the latest round** — genuine agreement reached
+2. **Two agents set `converged: true` and the third's `confidence` is ≤ 3** — weak dissent, majority rules
+3. **All agents are proposing the same core strategy** (even if worded differently) — read the substance, not the labels
+4. **`current_round == max_rounds`** — hard stop regardless of convergence
+
+If not converged and `current_round < max_rounds`: output `"verdict": "continue"` with the next round's prompt.
+
+If converged or at max rounds: output `"verdict": "resolved"` with the final execution plan.
+
+### Step 2: If continuing — build the next round prompt
+
+Identify the single most important unresolved disagreement from the latest round. Formulate it as a sharp question that forces the agents to address the crux directly.
+
+### Step 3: If resolved — produce the execution plan
+
+Read the full debate arc. Identify what the agents ultimately agreed on, including any guards or amendments added during debate. Synthesize this into a concrete execution plan.
+
+---
+
+## Output Schema — Continue
+
+```json
+{
+  "sorry_id": "file:line",
+  "verdict": "continue",
+  "next_round": <N+1>,
+  "crux": "<the single unresolved disagreement — one sentence>",
+  "next_round_prompt": "<sharp question or challenge to put to all three agents in round N+1>",
+  "current_best": "<the strongest strategy so far, even if not yet agreed upon>",
+  "current_confidence": <1-10>
+}
+```
+
+## Output Schema — Resolved
+
+```json
+{
+  "sorry_id": "file:line",
+  "verdict": "resolved",
+  "rounds_taken": <N>,
+  "winner": "<mathematician | tactician | synthesized | escalate-to-deep>",
+  "execution_plan": "<2-4 sentences: what the cycle engine should do — concrete enough to generate proof candidates directly>",
+  "tactic_hints": ["<specific tactic or lemma to try first>", "..."],
+  "guards": ["<guard identified during debate>", "..."],
+  "preflight_falsification": <true|false>,
+  "confidence": <1-10>,
+  "stuck_threshold": <1|2|3>,
+  "debate_summary": "<1 sentence for display to user — e.g., 'Converged in 2 rounds: induction on n with Finset.sum_range_succ, Skeptic guard for empty base case (confidence 8/10)'>",
+  "escalate_reason": "<if winner=escalate-to-deep: why, else null>"
+}
+```
+
+**`stuck_threshold`:** confidence 8–10 → 3, confidence 5–7 → 2, confidence 1–4 → 1.
+
+**`execution_plan`** must be concrete: not "try induction" but "induct on n; base case: `simp [Finset.sum_empty]`; inductive step: `rw [Finset.sum_range_succ]; ring`."
+
+**`debate_summary`** is the only thing shown to the user — 1 sentence, include round count and confidence.
+
+---
+
+## Constraints
+
+- Do NOT access sorry files, LSP tools, or any external resources.
+- `verdict: "continue"` is only valid when `current_round < max_rounds` AND the debate has not converged.
+- Do not manufacture convergence — if agents are still genuinely disagreeing, continue the debate.
+- Do not extend the debate past `max_rounds` — force resolution at the hard stop.
+- The `execution_plan` in a resolved output must be synthesized from what agents actually argued, not invented independently.

--- a/plugins/lean4/agents/lean4-debate-mathematician.md
+++ b/plugins/lean4/agents/lean4-debate-mathematician.md
@@ -1,0 +1,99 @@
+---
+name: lean4-debate-mathematician
+description: Mathematical strategy advisor for high-difficulty sorries. Proposes proof structure based on mathematical content — decomposition, induction principles, key lemmas. Runs independently before any proof attempt.
+tools: lean_goal, lean_local_search, lean_leanfinder, lean_leansearch, lean_loogle
+model: opus
+thinking: on
+---
+
+# Lean 4 Debate — Mathematician
+
+You reason about the **mathematical content** of Lean 4 proof goals. You think in terms of mathematical structures, decompositions, and theorems — not Lean syntax.
+
+You participate in two modes depending on what input you receive:
+
+---
+
+## Mode A: Initial Proposal
+
+Input contains `"round": 1` and no `"debate_history"`.
+
+Reason from first principles about the goal. Commit to one strategy — the mathematically strongest approach. Do not hedge.
+
+---
+
+## Mode B: Debate Round
+
+Input contains `"round": N` (N ≥ 2) and `"debate_history"` with prior arguments from all agents.
+
+**Read every prior argument carefully.** You are open to being wrong. If another agent has made a logically sound point that changes your view, update your position and say so explicitly. Only hold your ground if you have a specific logical rebuttal — not just preference.
+
+Ask yourself:
+- Has the Tactician identified a concrete Lean elaboration failure that invalidates my approach?
+- Has the Skeptic found an edge case I missed?
+- Is there a synthesis of my approach and theirs that is stronger than either alone?
+
+If you are updating your position, state clearly what changed your mind. If you are holding your position, give the specific logical reason why the counterargument fails.
+
+---
+
+## Input Schema
+
+```json
+{
+  "sorry_id": "file:line",
+  "goal": "<lean_goal output>",
+  "local_hypotheses": ["h1 : T1", "h2 : T2"],
+  "lsp_search_results": {
+    "leanfinder": ["lemma : type"],
+    "leansearch": ["..."],
+    "loogle": ["..."]
+  },
+  "prior_failures": ["attempt: error"],
+  "difficulty_score": 8,
+  "round": 1,
+  "debate_history": [
+    {
+      "round": 1,
+      "agent": "mathematician | tactician | skeptic",
+      "position": "...",
+      "confidence": 7,
+      "key_argument": "..."
+    }
+  ]
+}
+```
+
+`debate_history` is empty or absent on round 1. On round N, it contains all outputs from rounds 1 through N-1.
+
+---
+
+## Output Schema
+
+```json
+{
+  "agent": "mathematician",
+  "sorry_id": "file:line",
+  "round": <N>,
+  "position": "<your current proof strategy — mathematical language, not Lean syntax>",
+  "key_argument": "<the single strongest reason this approach is correct>",
+  "confidence": <1-10>,
+  "changed_position": <true|false>,
+  "change_reason": "<if changed_position=true: what argument convinced you, else null>",
+  "concedes_to": "<'tactician' | 'skeptic' | null — if you fully accept another agent's position>",
+  "rebuttal": "<if holding position: specific logical rebuttal to the strongest counterargument, else null>",
+  "converged": <true|false>
+}
+```
+
+**`converged: true`** means you now agree with another agent's position (or all agents agree with yours). The debate can end. Set this only when genuine logical agreement exists — not just to end the debate.
+
+---
+
+## Constraints
+
+- No Lean tactic syntax. Mathematical reasoning only.
+- Do NOT fill the sorry or edit any file.
+- At most 2 LSP tool calls total across all rounds (not per round).
+- `confidence` must be honest. If another agent's argument has weakened your position, lower it.
+- `changed_position` must be true whenever you materially update your strategy, even partially.

--- a/plugins/lean4/agents/lean4-debate-skeptic.md
+++ b/plugins/lean4/agents/lean4-debate-skeptic.md
@@ -1,0 +1,114 @@
+---
+name: lean4-debate-skeptic
+description: Adversarial failure-mode advisor for high-difficulty sorries. Critiques proposed strategies, identifies edge cases and statement risks, and either proposes guards or recommends escalation. Runs after Mathematician and Tactician, sees both their outputs.
+tools: lean_goal, lean_local_search, lean_leanfinder, lean_loogle
+model: opus
+thinking: on
+---
+
+# Lean 4 Debate — Skeptic
+
+You find failure modes. You are not contrarian — you follow logic wherever it leads. If the Mathematician and Tactician have converged on a genuinely sound strategy, say so and end the debate. If there are real holes, name them precisely.
+
+You always run after Mathematician and Tactician in each round. You see all prior arguments.
+
+---
+
+## Mode A: First Round Critique (round 1)
+
+Read both initial proposals. For each, ask:
+
+**Mathematician's proposal:**
+- Are there unhandled edge cases (base cases, `n = 0`, empty types, vacuous hypotheses)?
+- Does the key lemma actually match the goal's type, or just look similar?
+- Could the statement itself be false? Give a specific counterexample if so.
+
+**Tactician's proposal:**
+- Will these tactics terminate on this goal size? (Large Finsets, deep induction → timeout risk)
+- Are the simp lemmas actually `@[simp]`-tagged in current mathlib?
+- Are there coercions, universe issues, or implicit argument mismatches?
+
+If a proposal has a fixable flaw, propose the specific guard. If it has an unfixable flaw, say why.
+
+---
+
+## Mode B: Later Rounds (round ≥ 2)
+
+Read all prior arguments carefully. Things may have evolved — do not critique stale positions.
+
+Ask yourself:
+- Have the other agents already addressed my prior critiques? If so, concede them.
+- Has a synthesis emerged that is stronger than either original proposal?
+- Is there a remaining unresolved issue, or has the debate reached a sound conclusion?
+
+If the other agents have genuinely resolved your objections with logical arguments, set `converged: true` and endorse the current best position. Do not manufacture new objections to keep the debate going.
+
+If a real unresolved issue remains, state it precisely — not "might fail" but "specifically, `Finset.sum_comm` is not `@[simp]`-tagged in mathlib4, so `simp [Finset.sum_comm]` will silently fail with no error."
+
+---
+
+## Input Schema
+
+```json
+{
+  "sorry_id": "file:line",
+  "goal": "<lean_goal output>",
+  "local_hypotheses": ["h1 : T1"],
+  "lsp_search_results": { "leanfinder": [], "leansearch": [], "loogle": [] },
+  "prior_failures": [],
+  "difficulty_score": 8,
+  "round": 1,
+  "debate_history": [
+    {
+      "round": 1,
+      "agent": "mathematician | tactician | skeptic",
+      "position": "...",
+      "confidence": 7,
+      "key_argument": "..."
+    }
+  ]
+}
+```
+
+---
+
+## Output Schema
+
+```json
+{
+  "agent": "skeptic",
+  "sorry_id": "file:line",
+  "round": <N>,
+  "position": "<your current assessment of which strategy is best, or that none are viable>",
+  "key_argument": "<the single most important unresolved issue, or 'no unresolved issues' if converged>",
+  "mathematician_verdict": "<valid | valid-with-guard | invalid | conceded>",
+  "mathematician_critique": "<specific failure mode, or 'resolved' if prior critique was addressed>",
+  "mathematician_guard": "<specific fix, or null>",
+  "tactician_verdict": "<valid | valid-with-guard | invalid | conceded>",
+  "tactician_critique": "<specific failure mode, or 'resolved' if prior critique was addressed>",
+  "tactician_guard": "<specific fix, or null>",
+  "statement_risk": <true|false>,
+  "statement_risk_reason": "<specific counterexample or null>",
+  "recommendation": "<mathematician | tactician | mathematician-with-guard | tactician-with-guard | synthesized | escalate-to-deep>",
+  "confidence": <1-10>,
+  "changed_position": <true|false>,
+  "change_reason": "<what argument convinced you to update, else null>",
+  "converged": <true|false>
+}
+```
+
+**`converged: true`** means the debate has reached a sound conclusion — all real objections are resolved and a clear winning strategy exists. Set this when true, regardless of round number.
+
+**`recommendation: "synthesized"`** when the best path is a combination of both proposals that neither originally stated.
+
+**`escalate-to-deep`** only when both proposals are genuinely unworkable with no viable amendment.
+
+---
+
+## Constraints
+
+- Be specific. "Might fail" is not a valid critique. Name the exact failure mode with evidence.
+- Do NOT fill the sorry or edit any file.
+- At most 1 LSP tool call total across all rounds.
+- If you concede a prior critique, say so explicitly — do not silently drop it.
+- `statement_risk: true` requires a specific counterexample or concrete structural argument. Difficulty alone does not justify it.

--- a/plugins/lean4/agents/lean4-debate-tactician.md
+++ b/plugins/lean4/agents/lean4-debate-tactician.md
@@ -1,0 +1,101 @@
+---
+name: lean4-debate-tactician
+description: Lean 4 tactic strategy advisor for high-difficulty sorries. Proposes concrete tactic sequences based on goal shape and Lean mechanics. Runs independently before any proof attempt.
+tools: lean_goal, lean_local_search, lean_leanfinder, lean_loogle, lean_multi_attempt
+model: sonnet
+thinking: off
+---
+
+# Lean 4 Debate — Tactician
+
+You reason about **Lean 4 mechanics**: what tactic sequences will actually typecheck given this goal shape. You think about elaboration, simp sets, instance synthesis, timeout risk — the concrete realities of making Lean accept a proof.
+
+You participate in two modes depending on what input you receive:
+
+---
+
+## Mode A: Initial Proposal
+
+Input contains `"round": 1` and no `"debate_history"`.
+
+Look at the goal shape and commit to the most mechanically sound tactic approach. Be concrete — name specific tactics and lemmas. Do not hedge.
+
+---
+
+## Mode B: Debate Round
+
+Input contains `"round": N` (N ≥ 2) and `"debate_history"` with prior arguments from all agents.
+
+**Read every prior argument carefully.** You are open to being wrong. If the Mathematician has identified a proof structure that makes the tactic path clearer or simpler, incorporate it. If the Skeptic has found a real elaboration failure in your proposal, acknowledge it and revise.
+
+Ask yourself:
+- Does the Mathematician's decomposition suggest a better tactic entry point than I proposed?
+- Is the Skeptic's elaboration critique technically correct, or can I show why it won't actually occur?
+- Can I propose a tactic sequence that incorporates the best mathematical insight from the Mathematician?
+
+If you are updating your position, state clearly what changed your mind. If you are holding your position, give the specific mechanical reason why the counterargument fails.
+
+---
+
+## Input Schema
+
+```json
+{
+  "sorry_id": "file:line",
+  "goal": "<lean_goal output>",
+  "local_hypotheses": ["h1 : T1", "h2 : T2"],
+  "lsp_search_results": {
+    "leanfinder": ["lemma : type"],
+    "leansearch": ["..."],
+    "loogle": ["..."]
+  },
+  "prior_failures": ["attempt: error"],
+  "difficulty_score": 8,
+  "round": 1,
+  "debate_history": [
+    {
+      "round": 1,
+      "agent": "mathematician | tactician | skeptic",
+      "position": "...",
+      "confidence": 7,
+      "key_argument": "..."
+    }
+  ]
+}
+```
+
+`debate_history` is empty or absent on round 1. On round N, it contains all outputs from rounds 1 through N-1.
+
+---
+
+## Output Schema
+
+```json
+{
+  "agent": "tactician",
+  "sorry_id": "file:line",
+  "round": <N>,
+  "position": "<your current tactic approach — name specific Lean 4 tactics and lemmas>",
+  "tactic_sequence": ["<tactic1>", "<tactic2>", "..."],
+  "key_argument": "<the single strongest mechanical reason this tactic sequence will typecheck>",
+  "confidence": <1-10>,
+  "changed_position": <true|false>,
+  "change_reason": "<if changed_position=true: what argument convinced you, else null>",
+  "concedes_to": "<'mathematician' | 'skeptic' | null — if you fully accept another agent's position>",
+  "rebuttal": "<if holding position: specific mechanical rebuttal to the strongest counterargument, else null>",
+  "converged": <true|false>
+}
+```
+
+**`converged: true`** means you now agree with another agent's position (or all agents agree with yours). The debate can end. Set this only when genuine logical agreement exists.
+
+---
+
+## Constraints
+
+- Be concrete — name real Lean 4 tactics and lemmas, not vague descriptions.
+- Do NOT fill the sorry or edit any file.
+- `lean_multi_attempt` is for feasibility probing only — 1 call max, ≤2 snippets, no edits committed.
+- At most 2 LSP/tool calls total across all rounds.
+- `confidence` must be honest. If the Skeptic's critique is valid, lower your confidence.
+- `changed_position` must be true whenever you materially update your tactic sequence.

--- a/plugins/lean4/commands/autoprove.md
+++ b/plugins/lean4/commands/autoprove.md
@@ -41,6 +41,8 @@ Autonomous multi-cycle theorem proving. Runs cycles automatically with hard stop
 | --batch-size | No | 2 | Sorries to attempt per cycle |
 | --commit | No | auto | `auto` or `never` (`ask` coerced to `auto` — see note below) |
 | --golf | No | never | `prompt`, `auto`, or `never` |
+| --debate | No | auto | `auto` (run silently, log result) or `off` (disable). Note: `ask` coerced to `auto` — no interactive prompting in autoprove. |
+| --debate-threshold | No | 7 | Minimum difficulty score (1–10) to trigger debate |
 | --max-cycles | No | 20 | Hard stop: max total cycles |
 | --max-total-runtime | No | 120m | Hard stop: max total runtime |
 | --max-stuck-cycles | No | 3 | Hard stop: max consecutive stuck cycles |
@@ -76,7 +78,7 @@ Each cycle has 6 phases — see [cycle-engine.md](../skills/lean4/references/cyc
 
 ### Phase 1: Plan
 
-See [cycle-engine: LSP-First Protocol](../skills/lean4/references/cycle-engine.md#lsp-first-protocol). Discover sorries via LSP, search with up to 3 tools (~30s), identify sorries, set order.
+See [cycle-engine: LSP-First Protocol](../skills/lean4/references/cycle-engine.md#lsp-first-protocol). Discover sorries via LSP, search with up to 3 tools (~30s), rate each sorry's difficulty (1–10), set order. For sorries rated ≥ `--debate-threshold`, a strategy debate runs automatically before execution and is logged (see [debate-patterns.md](../skills/lean4/references/debate-patterns.md)).
 
 ### Phase 2: Work (Per Sorry)
 
@@ -161,6 +163,7 @@ Statement changes are logged but auto-skipped. Use `/lean4:prove` for interactiv
 **Deep safety coercions** (validated and applied at startup with warnings):
 - `--deep-rollback=never` → coerced to `on-regression`
 - `--deep-regression-gate=off` → coerced to `strict`
+- `--debate=ask` → coerced to `auto` (no interactive prompting in autoprove)
 
 See [cycle-engine.md](../skills/lean4/references/cycle-engine.md#deep-mode) for full semantics, definitions, and prove/autoprove comparison.
 
@@ -195,4 +198,5 @@ Guardrailed git commands are blocked. See [cycle-engine.md](../skills/lean4/refe
 - `/lean4:review` - Quality check (read-only)
 - `/lean4:golf` - Optimize proofs
 - [Cycle Engine](../skills/lean4/references/cycle-engine.md) - Shared prove/autoprove mechanics
+- [Debate Patterns](../skills/lean4/references/debate-patterns.md) - Difficulty scoring and three-advisor debate
 - [Examples](../skills/lean4/references/command-examples.md#autoprove)

--- a/plugins/lean4/commands/learn.md
+++ b/plugins/lean4/commands/learn.md
@@ -114,9 +114,36 @@ Offer the depth-check menu:
 - **formalize a specific result** → suggest `/lean4:formalize`
 - **save to scratch** / **write to file** (mid-session output actions — `--output` is part of the loop, not just startup config)
 
+### 4.5. Pedagogical Self-Debate
+
+After receiving the user's response (answer attempt, question, menu choice, or freeform message) and before formulating a reply, reason from three advisor perspectives to choose the best response strategy:
+
+- **Pace Advisor**: "Is the learner ready to advance, or do they need consolidation? What does their response reveal about their current understanding level?"
+- **Method Advisor**: "Is the current style still right, or should we switch? Would a different framing (intuitive vs. formal vs. example-driven) serve them better here?"
+- **Depth Advisor**: "Should I go deeper on this subtlety, surface a related concept, or redirect? Am I risking overloading them?"
+
+Pick the best strategy based on the learner's current profile (`{intent, level, style, track}`) and what their response revealed. **Tiebreak:** prioritize the learner's momentum (keep them engaged) over completeness.
+
+Then announce the chosen strategy in a brief note before the actual reply:
+
+> *Pedagogy: [one sentence — e.g., "Hinting rather than revealing since you're close" or "Switching to a worked example since you've been stuck on the same concept twice."]*
+
+**When to run:**
+- **Mandatory** in `--style=game` and `--style=socratic` modes.
+- **Optional** (skip for trivial menu navigation) in `--style=tour` and `--style=exercise` modes.
+
+**Key constraints:**
+- Do NOT trigger new Lean verification here — reason about teaching strategy only, using already-discovered information.
+- In `--style=game`: if the user has failed the same exercise 2+ times, the Pace Advisor must flag this and the strategy must include hint escalation (hint 1 → hint 2 → hint 3 → show answer with explanation) or offer to regress to an easier level.
+- If the user's last 2 responses reveal the same misunderstanding, the debate MUST flag this and the chosen strategy MUST switch approach.
+- The debate may update `style` or `level` in the Learning Profile mid-session if there is clear evidence it should change. Announce any profile update.
+- The summary note is always shown; never hidden. Keep it to 1 sentence.
+
+See [Pedagogical Self-Debate](../skills/lean4/references/learn-pathways.md#pedagogical-self-debate) for the full reference.
+
 ### 5. Iterate
 
-Return to step 2 with refined scope based on user's choice. Continue until the user is satisfied or switches mode.
+After step 4.5, respond using the chosen strategy. Return to step 4 (Depth Check) for the next turn. On mode switch or topic change, return to step 2 (Discovery). Continue until the user is satisfied or switches mode.
 
 ## Output
 

--- a/plugins/lean4/commands/prove.md
+++ b/plugins/lean4/commands/prove.md
@@ -40,6 +40,8 @@ Guided, cycle-by-cycle theorem proving. Asks before each cycle, supports deep es
 | --batch-size | No | 1 | Sorries to attempt per cycle |
 | --commit | No | ask | `ask` (prompt before each commit), `auto`, or `never` |
 | --golf | No | prompt | `prompt`, `auto`, or `never` |
+| --debate | No | ask | `ask` (show debate, user may override winner), `auto` (run silently), or `off` (disable) |
+| --debate-threshold | No | 7 | Minimum difficulty score (1–10) to trigger debate |
 
 ## Startup Behavior
 
@@ -65,7 +67,7 @@ Each cycle has 6 phases — see [cycle-engine.md](../skills/lean4/references/cyc
 
 ### Phase 1: Plan
 
-See [cycle-engine: LSP-First Protocol](../skills/lean4/references/cycle-engine.md#lsp-first-protocol). Discover sorries via LSP, search with up to 3 tools (~30s), show plan and get confirmation.
+See [cycle-engine: LSP-First Protocol](../skills/lean4/references/cycle-engine.md#lsp-first-protocol). Discover sorries via LSP, search with up to 3 tools (~30s), rate each sorry's difficulty (1–10), show plan and get confirmation. For sorries rated ≥ `--debate-threshold`, a strategy debate runs before execution (see [debate-patterns.md](../skills/lean4/references/debate-patterns.md)).
 
 ### Phase 2: Work (Per Sorry)
 
@@ -185,4 +187,5 @@ Guardrailed git commands are blocked. See [cycle-engine.md](../skills/lean4/refe
 - `/lean4:review` - Quality check (read-only)
 - `/lean4:golf` - Optimize proofs
 - [Cycle Engine](../skills/lean4/references/cycle-engine.md) - Shared prove/autoprove mechanics
+- [Debate Patterns](../skills/lean4/references/debate-patterns.md) - Difficulty scoring and three-advisor debate
 - [Examples](../skills/lean4/references/command-examples.md#prove)

--- a/plugins/lean4/skills/lean4/references/cycle-engine.md
+++ b/plugins/lean4/skills/lean4/references/cycle-engine.md
@@ -26,13 +26,121 @@ LSP tools are the normative first-pass for all discovery, search, and validation
 2. Up to 3 LSP search tools (time-boxed ~30s total): `lean_local_search`, preferably `lean_leanfinder` for semantic/goal-aware search (`lean_leansearch` for natural-language fallback, `lean_hammer_premise` for premise suggestions), and `lean_loogle` for type-pattern gaps
 3. Record top candidate lemmas and intended next attempts in the plan
 4. **Trivial-goal shortcut:** If the goal is obviously solvable (`rfl`, `simp`, `exact` with a known lemma), skip extended search — proceed directly to work phase
+5. **Difficulty rating:** Score each sorry 1–10 using the rubric in [debate-patterns.md](debate-patterns.md#difficulty-scoring-rubric). If score ≥ 7 and `--debate != off`, run the three-advisor debate and record the winning strategy + confidence score before proceeding to the Work phase. See [debate-patterns.md](debate-patterns.md) for full rubric, advisor roles, and format.
 
 **Work phase (per sorry):**
+
+If this sorry has a debate result (see Debate Gate below), execute `judge.execution_plan` instead of generic candidate generation. If `judge.winner == "escalate-to-deep"`, skip Work and enter Deep Mode immediately.
+
+Standard path (difficulty ≤ 6, `--debate=off`, or confident=true from self-assessment):
 1. Refresh `lean_goal(file, line)` at start
 2. Run up to 2 LSP search tools before any script fallback (skip if trivial goal or prior planning search was conclusive)
 3. Generate 2-3 candidate proof snippets from search results. When `lean_hammer_premise` returns premises, generate `simp only [p1, p2]` and `grind [p1, p2]` candidates.
 4. Test with `lean_multi_attempt(file, line, snippets=[...])`
 5. Prefer shortest passing candidate; only then edit/commit
+
+## Debate Gate
+
+Run this procedure for every sorry in the Plan phase, after `lean_goal` and LSP search complete. This is not optional when `--debate != off` and the sorry scores ≥ 7.
+
+### Step 1: Score difficulty
+
+Score the sorry 1–10 using the rubric in [debate-patterns.md](debate-patterns.md#difficulty-scoring-rubric). If score ≤ 6, skip the rest of this section and proceed to Work with standard candidate generation.
+
+Trivial shortcut: if the goal is obviously `rfl`/`simp`/`exact`, score = 1, skip.
+Thin-data skip: if LSP returned < 2 results total, skip debate, go to standard Work (or Deep Mode if available).
+
+### Step 2: Self-assess confidence
+
+Ask yourself: **"Am I 100% confident in a single proof strategy right now — no doubt, no alternatives I'm uncertain between?"**
+
+- If **yes**: proceed directly to Work with that strategy. Do not spawn any agents.
+- If **no**: continue to Step 3.
+
+The bar is genuinely 100%. Any specific doubt — an edge case, an elaboration risk, two plausible approaches — means no.
+
+### Step 3: Run the debate loop
+
+Execute this loop. Do not skip steps. Do not wait for user input between rounds.
+
+```
+debate_history = []
+round = 1
+max_rounds = (value of --debate-max-rounds, default 5)
+
+LOOP:
+  // Spawn Mathematician and Tactician IN PARALLEL
+  mathematician_output = Agent(
+    subagent_type = "lean4:lean4-debate-mathematician",
+    prompt = {sorry context} + {round, debate_history}
+  )
+  tactician_output = Agent(
+    subagent_type = "lean4:lean4-debate-tactician",
+    prompt = {sorry context} + {round, debate_history}
+  )
+
+  // Append both to history, then spawn Skeptic
+  debate_history.append(mathematician_output, tactician_output)
+  skeptic_output = Agent(
+    subagent_type = "lean4:lean4-debate-skeptic",
+    prompt = {sorry context} + {round, debate_history}
+  )
+
+  // Append Skeptic, then spawn Judge
+  debate_history.append(skeptic_output)
+  judge_output = Agent(
+    subagent_type = "lean4:lean4-debate-judge",
+    prompt = {sorry_id, difficulty_score, max_rounds, current_round=round, debate_history}
+  )
+
+  IF judge_output.verdict == "resolved":
+    BREAK
+
+  IF round == max_rounds:
+    // Judge already forced resolution above — this shouldn't be reached
+    BREAK
+
+  round += 1
+  // Add judge's next_round_prompt to context for next round
+  // (append to debate_history so agents see the Judge's crux question)
+  debate_history.append(judge_output)
+  CONTINUE LOOP
+```
+
+The "sorry context" passed to each agent each round is:
+```json
+{
+  "sorry_id": "file:line",
+  "goal": "<lean_goal output>",
+  "local_hypotheses": ["h : T"],
+  "lsp_search_results": { "leanfinder": [...], "leansearch": [...], "loogle": [...] },
+  "prior_failures": [...],
+  "difficulty_score": N,
+  "round": <current round>,
+  "debate_history": <all prior outputs>
+}
+```
+
+### Step 4: Emit result and proceed
+
+Emit to user (prove mode) or log (autoprove mode):
+```
+*Debate (difficulty N/10, R rounds): [judge_output.debate_summary]*
+```
+
+If `--debate=ask` (prove mode), prompt:
+```
+Proceed with this strategy? [yes / override / skip-debate]
+```
+On `override`: user provides alternate strategy inline, use that instead.
+On `skip-debate`: fall back to standard 2-3 candidate generation.
+On `yes` or autoprove: proceed to Work using `judge_output.execution_plan`.
+
+If `judge_output.winner == "escalate-to-deep"`: skip Work, enter Deep Mode immediately.
+Use `judge_output.stuck_threshold` as the attempt limit for this sorry (overrides default of 3).
+If `judge_output.preflight_falsification == true`: run falsification pass before any proof attempt.
+
+---
 
 **Fallback gate:** Script fallback (`$LEAN4_SCRIPTS/smart_search.sh`, `$LEAN4_SCRIPTS/search_mathlib.sh`) and repair agents are permitted when:
 - LSP search budget is exhausted (at least 2 searches returning empty/inconclusive), OR
@@ -96,6 +204,7 @@ A sorry or repair target is **stuck** when any of these hold:
 - LSP queries attempted (tool name + query text)
 - Top candidate lemmas returned (if any)
 - `lean_multi_attempt` outcomes (snippets tested, pass/fail for each)
+- If a debate was run: full debate block (all three advisor proposals, winner, confidence) and which part of the winning strategy failed
 
 **Important:** Stuck-triggered replan is mandatory even if `--planning=off`. It is a safety mechanism, not optional planning.
 
@@ -287,3 +396,4 @@ Blocked git commands (both prove and autoprove):
 - [sorry-filling.md](sorry-filling.md) — Sorry elimination tactics
 - [compilation-errors.md](compilation-errors.md) — Error-by-error repair guidance
 - [command-examples.md](command-examples.md) — Usage examples
+- [debate-patterns.md](debate-patterns.md) — Difficulty scoring rubric, three-advisor debate format, and budget rules

--- a/plugins/lean4/skills/lean4/references/debate-patterns.md
+++ b/plugins/lean4/skills/lean4/references/debate-patterns.md
@@ -1,0 +1,337 @@
+# Debate Patterns Reference
+
+> Confidence-gated multi-agent debate for high-difficulty sorries. A single agent attempts first and self-reports confidence. If below 100%, independent agents debate iteratively until they converge on a strategy — following logic, not stubbornness.
+
+## Overview
+
+Two-stage process:
+
+**Stage 1 — Confidence Gate:** The main cycle engine agent attempts the sorry and asks itself: "Am I 100% confident in this strategy?" If yes, proceed immediately. If no, escalate to Stage 2.
+
+**Stage 2 — Iterative Debate:** Three independent agents (Mathematician, Tactician, Skeptic) argue in rounds. After each round a Judge checks for convergence. The debate continues until agents agree or a round limit is hit. Agents are genuinely open to each other's arguments — positions change when the logic demands it.
+
+---
+
+## Stage 1: Confidence Gate
+
+Before spawning any debate agents, the cycle engine performs a self-assessment on each sorry that scores ≥ 7 on the difficulty rubric.
+
+### Self-assessment prompt
+
+After completing Plan phase LSP search for a sorry, ask:
+
+> "Given the goal, the LSP search results, and any prior failures: do I have a single proof strategy I am 100% confident will work? If I had to commit right now to one approach, would I bet on it without hesitation?"
+
+Answer with:
+
+```json
+{
+  "sorry_id": "file:line",
+  "confident": <true|false>,
+  "strategy": "<if confident=true: the strategy to execute>",
+  "doubt_reason": "<if confident=false: what specifically is uncertain — not just 'it is hard'>"
+}
+```
+
+- `confident: true` → skip debate entirely, proceed with `strategy` directly into Work phase
+- `confident: false` → escalate to Stage 2
+
+**The bar is genuinely 100%.** "Pretty sure" is not 100%. If there is any specific doubt — an elaboration risk, an edge case, an alternative decomposition that might be better — it is not 100%.
+
+---
+
+## Stage 2: Iterative Debate
+
+### Agents
+
+| Agent | File | Model | Thinking | Role |
+|-------|------|-------|----------|------|
+| Mathematician | [lean4-debate-mathematician.md](../../../agents/lean4-debate-mathematician.md) | opus | on | Mathematical structure and decomposition |
+| Tactician | [lean4-debate-tactician.md](../../../agents/lean4-debate-tactician.md) | sonnet | off | Lean 4 tactic mechanics and elaboration |
+| Skeptic | [lean4-debate-skeptic.md](../../../agents/lean4-debate-skeptic.md) | opus | on | Failure modes, edge cases, statement risk |
+| Judge | [lean4-debate-judge.md](../../../agents/lean4-debate-judge.md) | opus | on | Convergence detection, final execution plan |
+
+### The debate loop
+
+```
+Round 1:
+  Mathematician and Tactician spawn in parallel (no shared context)
+  ↓ both complete
+  Skeptic spawns (sees both outputs)
+  ↓ Skeptic completes
+  Judge spawns (sees all three outputs)
+  ↓
+  Judge outputs verdict: "continue" OR "resolved"
+
+Round N (if continue):
+  Mathematician, Tactician, Skeptic each receive:
+    - original sorry context
+    - full debate_history (all prior rounds from all agents)
+    - Judge's crux question from prior round
+  All three spawn in parallel
+  ↓ all complete
+  Judge spawns (sees full debate_history including round N)
+  ↓
+  Judge outputs verdict: "continue" OR "resolved"
+
+Stop when:
+  - Judge outputs "resolved" (convergence detected), OR
+  - current_round == max_rounds (hard stop, Judge forces resolution)
+```
+
+### Convergence conditions (Judge evaluates after each round)
+
+The debate resolves when **any** of:
+1. All three agents set `converged: true` in the latest round
+2. Two agents set `converged: true` and the third's `confidence` ≤ 3
+3. All agents are substantively proposing the same strategy (even if worded differently)
+4. `current_round == max_rounds` (hard stop)
+
+### Round limit
+
+Default `max_rounds = 5`. Configurable via `--debate-max-rounds`. In practice most debates resolve in 2–3 rounds — if agents are following logic, genuine disagreement rarely survives 3 rounds of direct engagement.
+
+---
+
+## Spawn Protocol
+
+### Step 0: Build shared input context
+
+Assembled once from Plan phase data. Passed to all agents every round, augmented with `round` and `debate_history`.
+
+```json
+{
+  "sorry_id": "file:line",
+  "goal": "<lean_goal output>",
+  "local_hypotheses": ["h : T"],
+  "lsp_search_results": {
+    "leanfinder": ["lemma : type"],
+    "leansearch": [],
+    "loogle": []
+  },
+  "prior_failures": [],
+  "difficulty_score": 8,
+  "round": <current_round>,
+  "debate_history": [ <all prior round outputs> ]
+}
+```
+
+### Step 1: Round 1 — Mathematician and Tactician in parallel
+
+```
+Agent(
+  subagent_type = "lean4:lean4-debate-mathematician",
+  prompt = shared_context with round=1, debate_history=[],
+  isolation = true
+)
+
+Agent(
+  subagent_type = "lean4:lean4-debate-tactician",
+  prompt = shared_context with round=1, debate_history=[],
+  isolation = true
+)
+```
+
+Wait for both. Each returns JSON. Append both to `debate_history`.
+
+### Step 2: Skeptic
+
+```
+Agent(
+  subagent_type = "lean4:lean4-debate-skeptic",
+  prompt = shared_context with round=1, debate_history=[mathematician_r1, tactician_r1],
+  isolation = true
+)
+```
+
+Append to `debate_history`.
+
+### Step 3: Judge
+
+```
+Agent(
+  subagent_type = "lean4:lean4-debate-judge",
+  prompt = {
+    "sorry_id": "file:line",
+    "difficulty_score": N,
+    "max_rounds": 5,
+    "current_round": 1,
+    "debate_history": [mathematician_r1, tactician_r1, skeptic_r1]
+  },
+  isolation = true
+)
+```
+
+### Step 4: If Judge returns `verdict: "continue"`
+
+Increment round. Spawn Mathematician, Tactician, Skeptic again — each receives the full `debate_history` so far plus the Judge's `next_round_prompt` appended to the context. Run in sequence as above (Mathematician + Tactician parallel → Skeptic → Judge).
+
+### Step 5: If Judge returns `verdict: "resolved"`
+
+Use `judge.execution_plan` as the sorry's Work phase strategy. Emit to user:
+
+```
+*Debate (difficulty N/10, R rounds): [judge.debate_summary]*
+```
+
+---
+
+## Difficulty Scoring Rubric
+
+Rate each sorry 1–10 after `lean_goal` + LSP search in Plan phase:
+
+| Signal | Low (0 pts) | Medium (1 pt) | High (2 pts) |
+|--------|-------------|---------------|--------------|
+| Goal complexity | Atomic, no binders | 1–2 quantifiers or type class constraints | Nested ∀/∃, universe polymorphism, dependent types |
+| Mathlib search confidence | ≥ 2 high-confidence hits | 1 hit or low confidence | No hits |
+| Hypothesis depth | ≤ 3 hypotheses | 4–8 hypotheses | > 8 or deep `have`/`let` chains |
+| Type class complexity | None needed | 1 instance | ≥ 2 or synthesis likely to fail |
+| Prior history | No failures | 1 failure | 2+ failures or previously stuck |
+| Cross-file dependencies | Self-contained | 1–2 external defs | Many defs or depends on sorry'd lemmas |
+
+Sum → `score = ceil(sum / 12 * 10)`, floor 1, cap 10.
+
+**Threshold:** score ≥ 7 → confidence gate runs. score ≤ 6 → skip gate, standard Work.
+
+**Trivial shortcut:** Obviously solvable goal (`rfl`, `simp`, `exact` with known lemma) → skip everything, difficulty 1, direct to Work.
+
+**Thin-data skip:** LSP returned < 2 results total → skip debate, go directly to Deep Mode or standard Work.
+
+---
+
+## Integration with Cycle Engine
+
+### Plan phase
+
+```
+For each sorry:
+  1. lean_goal + up to 3 LSP search tools (existing)
+  2. Rate difficulty 1–10
+  3. IF score ≥ 7 AND --debate != off AND LSP results not thin:
+       Self-assess confidence (Stage 1)
+       IF confident: proceed to Work with self-assessed strategy
+       IF not confident: run Stage 2 debate → use judge.execution_plan in Work
+     ELSE:
+       Standard 2-3 candidate generation in Work
+```
+
+### Work phase
+
+When a sorry has a judge output:
+- Generate candidates that implement `judge.execution_plan`
+- Apply `judge.tactic_hints` as first candidates in `lean_multi_attempt`
+- Apply `judge.guards` as pre/post conditions
+- If `judge.preflight_falsification == true`: run falsification pass first (30-60s max)
+- If `judge.winner == "escalate-to-deep"`: skip Work, enter Deep Mode immediately
+- Use `judge.stuck_threshold` as attempt limit before escalating (overrides default 3)
+
+### Stuck handoff evidence
+
+When a debated sorry gets stuck, include:
+- Full judge resolved output (all fields)
+- Which part of `execution_plan` failed and why
+- Whether agents' `potential_blocker` fields materialized
+
+---
+
+## Flag Reference
+
+| Flag | prove default | autoprove default | Description |
+|------|--------------|------------------|-------------|
+| `--debate` | `ask` | `auto` | `ask`: show summary + prompt user before Work; `auto`: run silently; `off`: disable |
+| `--debate-threshold` | `7` | `7` | Minimum difficulty score to trigger confidence gate |
+| `--debate-max-rounds` | `5` | `5` | Hard stop on debate rounds |
+
+**`--debate=ask` prompt (prove only):**
+```
+Debate resolved in R rounds: [judge.debate_summary]
+Proceed with this strategy? [yes / override / skip-debate]
+```
+
+**`--debate=off`:** Difficulty scoring still runs and is logged, but no confidence gate and no agents spawned.
+
+---
+
+## Failure Handling
+
+| Failure | Response |
+|---------|----------|
+| Mathematician or Tactician fails round 1 | Skeptic critiques only the available proposal; Judge notes missing agent |
+| Both parallel agents fail round 1 | Skip debate; standard Work; log `"debate skipped: both advisors failed"` |
+| Skeptic fails | Judge receives raw proposals with no critique; picks based on confidence scores alone |
+| Judge fails | Fall back to: highest-confidence agent's position; tiebreak: Tactician |
+| Any agent returns malformed JSON | Treat as agent failure, apply rules above |
+| Debate hits `max_rounds` without convergence | Judge forces resolution with best available position; notes `"resolved by round limit"` in `debate_summary` |
+
+---
+
+## Relationship to Existing Escalation
+
+```
+Sorry discovered
+  ↓
+Difficulty score
+  ├── ≤ 6  OR  --debate=off  OR  thin LSP data
+  │     → standard Work (stuck threshold = 3)
+  │           ↓ if stuck → Deep Mode
+  │
+  └── ≥ 7  AND  --debate != off  AND  sufficient data
+        → Confidence gate (self-assessment)
+              ├── confident=true → Work with self-assessed strategy
+              │         ↓ if stuck → Deep Mode
+              │
+              └── confident=false → Iterative debate
+                    Round 1: Mathematician ║ Tactician → Skeptic → Judge
+                    Round N: repeat with full history until converged
+                          ↓ resolved
+                    winner=escalate-to-deep → Deep Mode
+                    winner=strategy → Work (confidence-adjusted stuck threshold)
+                          ↓ if stuck → Deep Mode
+```
+
+---
+
+## Testing
+
+### Load the plugin
+
+```bash
+claude --plugin-dir /Users/romirpatel/lean4-skills/plugins/lean4
+```
+
+### Test confidence gate (Stage 1)
+
+On a sorry you are certain about, the self-assessment should return `confident: true` and skip debate entirely. On a sorry with genuine ambiguity, it should return `confident: false` and trigger Stage 2.
+
+### Test individual debate agents
+
+**Round 1 — Mathematician:**
+```
+Use the lean4:lean4-debate-mathematician agent with this input:
+{"sorry_id":"Test.lean:10","goal":"⊢ ∀ (n : ℕ), ∑ i in Finset.range n, (2 * i + 1) = n ^ 2","local_hypotheses":[],"lsp_search_results":{"leanfinder":["Finset.sum_range_succ : ∑ i in Finset.range (n+1), f i = ∑ i in Finset.range n, f i + f n"],"leansearch":[],"loogle":[]},"prior_failures":["simp failed"],"difficulty_score":8,"round":1,"debate_history":[]}
+```
+
+**Round 2 — Mathematician (with history):** Pass the same input but set `"round": 2` and populate `"debate_history"` with round 1 outputs from all three agents. Verify the agent reads prior arguments and either updates its position or provides a specific rebuttal.
+
+**Judge — continue vs resolved:** Pass a debate history where agents clearly disagree → expect `verdict: "continue"`. Pass a history where all three set `converged: true` → expect `verdict: "resolved"`.
+
+### Test full pipeline
+
+```
+/lean4:prove --debate=ask
+```
+
+On a sorry scoring ≥ 7, you should see:
+1. Confidence gate self-assessment (logged)
+2. If not confident: debate rounds running (each round logged)
+3. Final: `*Debate (difficulty 8/10, 2 rounds): [summary]*`
+4. Prompt: `Proceed with this strategy? [yes / override / skip-debate]`
+
+---
+
+## See Also
+
+- [cycle-engine.md](cycle-engine.md) — Where debate integrates
+- [sorry-filling.md](sorry-filling.md) — Standard Work phase
+- [learn-pathways.md](learn-pathways.md) — Pedagogical Self-Debate (single-agent simulation for teaching context)
+- [domain-patterns.md](domain-patterns.md) — Domain patterns advisors draw on

--- a/plugins/lean4/skills/lean4/references/learn-pathways.md
+++ b/plugins/lean4/skills/lean4/references/learn-pathways.md
@@ -166,6 +166,74 @@ Prerequisite: none
 4. Use extracted content as seed for the resolved mode's discovery step.
 5. On failure (unreadable, too large, fetch blocked): ask user for relevant excerpt and proceed with that.
 
+## Pedagogical Self-Debate
+
+After receiving a user response and before formulating a reply, `/lean4:learn` internally reasons from three advisor perspectives to select the best response strategy. This runs inside the iterate loop (step 4.5 in `learn.md`).
+
+### The Three Advisors
+
+| Advisor | Question it asks | Signals it looks for |
+|---------|-----------------|----------------------|
+| **Pace Advisor** | Is the learner ready to advance, or do they need consolidation? | Correct but tentative → consolidate. Confident and correct → advance. Repeated same error → slow down or switch. |
+| **Method Advisor** | Is the current style still right, or should we switch? | Disengaged in socratic → try tour. Bored in tour → try exercise. Struggling in formal → try informal/intuitive framing. |
+| **Depth Advisor** | Should I go deeper, surface a related concept, or redirect? | If they asked a tangential question → surface and redirect. If they're close to a subtlety → go deeper. If they're overwhelmed → redirect to main thread. |
+
+### Picking a Strategy
+
+After each advisor generates a candidate response approach, pick the one best aligned with:
+- The learner's current profile (`{intent, level, style, track}`)
+- What the current response concretely revealed
+
+**Tiebreak:** when advisors conflict, prioritize the learner's momentum — keeping them engaged beats completeness.
+
+### Summary Note Format
+
+Always announce the chosen strategy before the actual reply, in a single sentence:
+
+> *Pedagogy: [chosen strategy — e.g., "Hinting rather than revealing since you're close" or "Switching to a worked example since you've been stuck on the same concept twice."]*
+
+### When to Run
+
+| Style | Debate required? |
+|-------|-----------------|
+| `game` | Always (mandatory) |
+| `socratic` | Always (mandatory) |
+| `exercise` | On substantive user responses; skip for trivial menu picks |
+| `tour` | Skip for trivial navigation; run when user asks a question or expresses confusion |
+
+### Profile Updates Mid-Session
+
+The debate may update `style` or `level` in the Learning Profile if evidence is clear (e.g., user is consistently bored → raise `--level`; user is consistently lost → lower `--level` or switch `--style`). Announce any profile update inline:
+
+> *Pedagogy: Raising level to `expert` since your questions show strong prior familiarity; switching style to `exercise` to keep you engaged.*
+
+Profile updates from the debate follow the same precedence rules: they override inference but can be overridden by explicit user flags on a later turn.
+
+### Stuck Detection
+
+If the user's last 2 responses reveal the **same misunderstanding**, the debate MUST flag this and the chosen strategy MUST switch approach — not repeat the same explanation. Options:
+- Change framing (intuitive → formal, or vice versa)
+- Surface a prerequisite concept
+- Present a minimal counterexample to isolate the misconception
+- In `game` mode: escalate hint level (see below)
+
+### Hint Escalation Protocol (game mode)
+
+When the user fails the same exercise 2+ times, the Pace Advisor flags this. The chosen strategy must follow the escalation ladder:
+
+| Failure count | Response strategy |
+|--------------|------------------|
+| 1st failure | Affirm attempt, give directional hint (no answer) |
+| 2nd failure | More specific hint: name the relevant tactic/lemma/concept |
+| 3rd failure | Show the full answer with step-by-step explanation |
+| After 3rd | Offer: retry a variation, regress to an easier level, or continue to next exercise |
+
+Never skip levels in the escalation ladder within a single exercise session. Reset the counter when the exercise changes.
+
+### No Lean Verification
+
+The self-debate step reasons about teaching strategy only. It must not trigger new Lean tool calls (`lean_goal`, `lean_multi_attempt`, etc.) — those belong to the verification layer (step 3 / game verification). Use already-discovered information.
+
 ## Learning Profile
 
 Persisted within the current conversation only (not across new sessions).


### PR DESCRIPTION
## Summary

- Adds a confidence gate: before attempting a hard sorry, the agent self-assesses whether it is 100% confident. If not, it escalates to a multi-agent debate.
- Introduces 4 independent debate agents (Mathematician, Tactician, Skeptic, Judge) that argue iteratively with full shared history until they converge on a strategy.
- Wires the debate loop as imperative steps in `cycle-engine.md` so it runs automatically during `/lean4:prove` and `/lean4:autoprove` — no manual chaining needed.
- Difficulty rubric (1–10) gates the confidence check at score ≥ 7.
- Adds `--debate` and `--debate-max-rounds` flags to `prove` and `autoprove`.

## Test plan

- [ ] Load plugin with `claude --plugin-dir ./plugins/lean4`
- [ ] Run `/lean4:prove --debate=ask` on a hard sorry (e.g. measure-theoretic goal with `ℝ≥0∞`) and verify debate triggers automatically
- [ ] Verify each agent can be invoked in isolation with synthetic JSON input
- [ ] Verify `--debate=off` disables agent spawning while still logging difficulty score
- [ ] Verify debate resolves in ≤ 5 rounds and Judge produces a concrete `execution_plan`

🤖 Generated with [Claude Code](https://claude.com/claude-code)