### PR TITLE
Harden shebang portability after #118

### DIFF
--- a/.github/workflows/bash3-compat.yml
+++ b/.github/workflows/bash3-compat.yml
@@ -12,7 +12,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Verify /bin/bash is Bash 3.2 (macOS default)
-        run: /bin/bash --version
+        run: |
+          /bin/bash --version
+          /bin/bash -c '[[ "${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}" == "3.2" ]] \
+            || { echo "Expected /bin/bash 3.2, got ${BASH_VERSION}"; exit 1; }'
 
       - name: Static lint — Bash 4+ / BSD-incompat constructs
         run: /bin/bash plugins/lean4/tools/lint_bash_compat.sh

--- a/plugins/lean4/tests/test_lint_bash_compat.sh
+++ b/plugins/lean4/tests/test_lint_bash_compat.sh
@@ -211,30 +211,26 @@ expect_shebang_lint_fail '#!/usr/bin/bash — alt system path'        '#!/usr/bi
 expect_shebang_lint_fail '#!/opt/homebrew/bin/bash — Homebrew path' '#!/opt/homebrew/bin/bash'
 expect_shebang_lint_fail '#!/usr/local/bin/bash — alt prefix'       '#!/usr/local/bin/bash'
 
-# Negative case — env-bash with a clean body must pass cleanly.
-# Re-uses the existing expect_lint_pass helper, which writes
-# #!/usr/bin/env bash as the probe's shebang.
-expect_lint_pass '#!/usr/bin/env bash — accepted by Check 8'         ': # no-op'
+# env-bash with extra arguments must be rejected: on Linux, env treats
+# 'bash -e' as one program name and the kernel exec fails (env -S would
+# split it, but we want a single, mechanical rule). Set flags inside the
+# script body via 'set -...' instead.
+expect_shebang_lint_fail '#!/usr/bin/env bash -e — non-portable env args' '#!/usr/bin/env bash -e'
 
-# Negative case — env-bash with optional trailing args (e.g. `-e`) is also
-# acceptable; the check matches any prefix `#!/usr/bin/env bash...`.
-expect_shebang_lint_accept() {
-  local desc="$1" shebang="$2"
-  local probe="$TMPDIR_ROOT/lib/scripts/probe.sh"
-  printf '%s\n: # no-op\n' "$shebang" > "$probe"
-  local exit_code=0
-  "$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" >/dev/null 2>&1 || exit_code=$?
-  if [[ "$exit_code" -eq 0 ]]; then
-    echo "  PASS: $desc"
-    ((PASS++)) || true
-  else
-    echo "  FAIL: $desc (expected exit 0, got $exit_code)"
-    ((FAIL++)) || true
-  fi
-  rm -f "$probe"
-}
+# Wrong interpreter — env-sh / env-zsh etc. must be rejected; runtime
+# scripts assume bash 3.2+ features (arrays, [[ ]], etc.).
+expect_shebang_lint_fail '#!/usr/bin/env sh — wrong interpreter' '#!/usr/bin/env sh'
 
-expect_shebang_lint_accept '#!/usr/bin/env bash -e — with flag args' '#!/usr/bin/env bash -e'
+# No shebang at all — first line is a regular comment. Runtime scripts
+# must declare their interpreter explicitly; the probe-writing helper
+# uses head -n1 to read the shebang, so a leading non-#! line trips the
+# check.
+expect_shebang_lint_fail 'no shebang — first line is a regular comment' '# just a comment'
+
+# Negative case — exact '#!/usr/bin/env bash' with a clean body must
+# pass cleanly. Re-uses the existing expect_lint_pass helper, which
+# writes '#!/usr/bin/env bash' as the probe's shebang.
+expect_lint_pass '#!/usr/bin/env bash — accepted by Check 8' ': # no-op'
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/plugins/lean4/tests/test_lint_bash_compat.sh
+++ b/plugins/lean4/tests/test_lint_bash_compat.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Self-test for lint_bash_compat.sh — verifies it catches all 7 advertised
+# Self-test for lint_bash_compat.sh — verifies it catches all advertised
 # Bash 4+ / BSD-incompatible constructs and does NOT false-positive on safe
 # parameter-expansion forms that legitimately contain , or ^.
 #
@@ -177,6 +177,64 @@ else
   ((FAIL++)) || true
 fi
 rm "$TMPDIR_ROOT/lib/scripts/bad_all.sh"
+
+# ---------------------------------------------------------------------------
+# Check 8 self-tests — runtime-path shebang regression
+#
+# Writes a probe with the given shebang line and a no-op body, asserts the
+# linter exits non-zero (Check 8 flags the shebang). Kept separate from
+# the "exactly 7 categories" combined probe above, which intentionally
+# stays scoped to Bash-4/BSD construct categories.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- Check 8 self-tests (shebang regression) --"
+
+expect_shebang_lint_fail() {
+  local desc="$1" shebang="$2"
+  local probe="$TMPDIR_ROOT/lib/scripts/probe.sh"
+  printf '%s\n: # no-op\n' "$shebang" > "$probe"
+  local exit_code=0
+  "$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" >/dev/null 2>&1 || exit_code=$?
+  if [[ "$exit_code" -eq 1 ]]; then
+    echo "  PASS: $desc"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: $desc (expected exit 1, got $exit_code)"
+    ((FAIL++)) || true
+  fi
+  rm -f "$probe"
+}
+
+# Positive cases — absolute Bash shebangs must be rejected in runtime path.
+expect_shebang_lint_fail '#!/bin/bash — system path'                '#!/bin/bash'
+expect_shebang_lint_fail '#!/usr/bin/bash — alt system path'        '#!/usr/bin/bash'
+expect_shebang_lint_fail '#!/opt/homebrew/bin/bash — Homebrew path' '#!/opt/homebrew/bin/bash'
+expect_shebang_lint_fail '#!/usr/local/bin/bash — alt prefix'       '#!/usr/local/bin/bash'
+
+# Negative case — env-bash with a clean body must pass cleanly.
+# Re-uses the existing expect_lint_pass helper, which writes
+# #!/usr/bin/env bash as the probe's shebang.
+expect_lint_pass '#!/usr/bin/env bash — accepted by Check 8'         ': # no-op'
+
+# Negative case — env-bash with optional trailing args (e.g. `-e`) is also
+# acceptable; the check matches any prefix `#!/usr/bin/env bash...`.
+expect_shebang_lint_accept() {
+  local desc="$1" shebang="$2"
+  local probe="$TMPDIR_ROOT/lib/scripts/probe.sh"
+  printf '%s\n: # no-op\n' "$shebang" > "$probe"
+  local exit_code=0
+  "$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" >/dev/null 2>&1 || exit_code=$?
+  if [[ "$exit_code" -eq 0 ]]; then
+    echo "  PASS: $desc"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: $desc (expected exit 0, got $exit_code)"
+    ((FAIL++)) || true
+  fi
+  rm -f "$probe"
+}
+
+expect_shebang_lint_accept '#!/usr/bin/env bash -e — with flag args' '#!/usr/bin/env bash -e'
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/plugins/lean4/tests/test_lint_bash_compat.sh
+++ b/plugins/lean4/tests/test_lint_bash_compat.sh
@@ -5,14 +5,23 @@ set -euo pipefail
 # Bash 4+ / BSD-incompatible constructs and does NOT false-positive on safe
 # parameter-expansion forms that legitimately contain , or ^.
 #
-# Helpers invoke the copied lint with /bin/bash explicitly so the self-test
-# is end-to-end under the system default Bash, even when a newer Bash is
-# earlier on PATH. Matches the CI workflow's /bin/bash invocation.
+# Helpers invoke the copied lint with $BASH_FOR_COMPAT (default /bin/bash)
+# so the self-test is end-to-end under the system default Bash, even when a
+# newer Bash is earlier on PATH. CI invokes this with the default to match
+# the macOS Bash-3.2 contract. On hosts without /bin/bash (e.g. NixOS) the
+# test SKIPs gracefully; developers can also point BASH_FOR_COMPAT at
+# /opt/homebrew/bin/bash etc. to exercise other interpreters.
 #
 # Scope note: Check 1 (case modifiers) is a heuristic. It targets common
 # forms — ${var,,}, ${var,}, ${var^^}, ${var^}, patterned variants — and
 # has one known false-negative on arithmetic-subscript case-mod like
 # ${arr[i-1],,}. That form is intentionally out of scope.
+
+BASH_FOR_COMPAT="${BASH_FOR_COMPAT:-/bin/bash}"
+if [[ ! -x "$BASH_FOR_COMPAT" ]]; then
+  echo "SKIP: $BASH_FOR_COMPAT not found — cannot run lint self-test"
+  exit 0
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LINT="$SCRIPT_DIR/../tools/lint_bash_compat.sh"
@@ -31,14 +40,14 @@ cp "$LINT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh"
 # ---------------------------------------------------------------------------
 
 # expect_lint_fail "description" "script body"
-#   Writes script body to a probe file, runs the lint under /bin/bash,
-#   asserts exit 1 (lint caught the issue).
+#   Writes script body to a probe file, runs the lint under
+#   $BASH_FOR_COMPAT, asserts exit 1 (lint caught the issue).
 expect_lint_fail() {
   local desc="$1" body="$2"
   local probe="$TMPDIR_ROOT/lib/scripts/probe.sh"
   printf '#!/usr/bin/env bash\n%s\n' "$body" > "$probe"
   local exit_code=0
-  /bin/bash "$TMPDIR_ROOT/tools/lint_bash_compat.sh" >/dev/null 2>&1 || exit_code=$?
+  "$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" >/dev/null 2>&1 || exit_code=$?
   if [[ "$exit_code" -eq 1 ]]; then
     echo "  PASS: $desc"
     ((PASS++)) || true
@@ -50,14 +59,14 @@ expect_lint_fail() {
 }
 
 # expect_lint_pass "description" "script body"
-#   Writes script body to a probe file, runs the lint under /bin/bash,
-#   asserts exit 0 (lint did not false-positive).
+#   Writes script body to a probe file, runs the lint under
+#   $BASH_FOR_COMPAT, asserts exit 0 (lint did not false-positive).
 expect_lint_pass() {
   local desc="$1" body="$2"
   local probe="$TMPDIR_ROOT/lib/scripts/probe.sh"
   printf '#!/usr/bin/env bash\n%s\n' "$body" > "$probe"
   local exit_code=0
-  /bin/bash "$TMPDIR_ROOT/tools/lint_bash_compat.sh" >/dev/null 2>&1 || exit_code=$?
+  "$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" >/dev/null 2>&1 || exit_code=$?
   if [[ "$exit_code" -eq 0 ]]; then
     echo "  PASS: $desc"
     ((PASS++)) || true
@@ -155,7 +164,7 @@ coproc mycoproc { cat; }
 echo "${myvar@Q}"
 PROBE
 
-combined_output=$(/bin/bash "$TMPDIR_ROOT/tools/lint_bash_compat.sh" 2>&1 || true)
+combined_output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" 2>&1 || true)
 # Count warn lines that report actual matches (filename:line:content),
 # excluding the summary line ("⚠️  N issue(s) found...").
 combined_issue_count=$(echo "$combined_output" | grep -c '^⚠️.*:[0-9]\+:' || true)

--- a/plugins/lean4/tests/test_lint_bash_compat.sh
+++ b/plugins/lean4/tests/test_lint_bash_compat.sh
@@ -217,6 +217,11 @@ expect_shebang_lint_fail '#!/usr/local/bin/bash — alt prefix'       '#!/usr/lo
 # script body via 'set -...' instead.
 expect_shebang_lint_fail '#!/usr/bin/env bash -e — non-portable env args' '#!/usr/bin/env bash -e'
 
+# Token-boundary regression — defends against a future "loosening" of the
+# exact match back to a prefix/substring form. Trivially rejected today
+# (bashfoo != bash), but the probe ensures it stays that way.
+expect_shebang_lint_fail '#!/usr/bin/env bashfoo — not bash token' '#!/usr/bin/env bashfoo'
+
 # Wrong interpreter — env-sh / env-zsh etc. must be rejected; runtime
 # scripts assume bash 3.2+ features (arrays, [[ ]], etc.).
 expect_shebang_lint_fail '#!/usr/bin/env sh — wrong interpreter' '#!/usr/bin/env sh'

--- a/plugins/lean4/tools/lint_bash_compat.sh
+++ b/plugins/lean4/tools/lint_bash_compat.sh
@@ -10,6 +10,12 @@
 # (e.g. #!/opt/homebrew/bin/bash) and NOT be called from the plugin
 # runtime path.
 #
+# Shebang policy (Check 8): every .sh file in hooks/ and lib/scripts/ must
+# use #!/usr/bin/env bash for NixOS / minimal-container portability. Any
+# absolute Bash shebang (#!/bin/bash, #!/opt/homebrew/bin/bash, etc.) in
+# the runtime path is rejected — opt-out Bash-4+ scripts must live outside
+# this scope per the rule above.
+#
 # Run:  bash plugins/lean4/tools/lint_bash_compat.sh
 # ---------------------------------------------------------------------------
 set -euo pipefail
@@ -160,6 +166,32 @@ done
 [[ $found -eq 0 ]] && ok "No mktemp with post-X suffix found"
 
 # ---------------------------------------------------------------------------
+# Check 8: portable shebangs in runtime path
+#
+# Hooks (invoked directly via hooks.json) and lib/scripts/ must use
+# #!/usr/bin/env bash so they work on hosts without /bin/bash (NixOS,
+# minimal containers). Any other shebang form — absolute paths like
+# #!/bin/bash, #!/opt/homebrew/bin/bash, or non-bash interpreters — is
+# rejected in this scope. Files without a shebang at all are skipped
+# (they are not directly executable and rely on the caller's interpreter).
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- Check 8: portable shebangs in runtime path --"
+found=0
+for f in "${SHELL_FILES[@]}"; do
+  first_line=$(head -n1 "$f")
+  case "$first_line" in
+    "#!"*) ;;
+    *) continue ;;
+  esac
+  if [[ "$first_line" != "#!/usr/bin/env bash"* ]]; then
+    warn "$(basename "$f"):1: non-portable shebang '$first_line' — runtime scripts must use '#!/usr/bin/env bash'"
+    found=1
+  fi
+done
+[[ $found -eq 0 ]] && ok "All runtime scripts use #!/usr/bin/env bash"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""
@@ -168,6 +200,6 @@ if [[ $ISSUES -eq 0 ]]; then
   echo "✓ All ${#SHELL_FILES[@]} scripts are Bash 3.2 compatible"
   exit 0
 else
-  echo "⚠️  $ISSUES issue(s) found — these constructs break on macOS /bin/bash 3.2"
+  echo "⚠️  $ISSUES issue(s) found — break on macOS /bin/bash 3.2 (Checks 1–7) or non-portable hosts like NixOS (Check 8)"
   exit 1
 fi

--- a/plugins/lean4/tools/lint_bash_compat.sh
+++ b/plugins/lean4/tools/lint_bash_compat.sh
@@ -11,10 +11,13 @@
 # runtime path.
 #
 # Shebang policy (Check 8): every .sh file in hooks/ and lib/scripts/ must
-# use #!/usr/bin/env bash for NixOS / minimal-container portability. Any
-# absolute Bash shebang (#!/bin/bash, #!/opt/homebrew/bin/bash, etc.) in
-# the runtime path is rejected — opt-out Bash-4+ scripts must live outside
-# this scope per the rule above.
+# start with exactly '#!/usr/bin/env bash' on its first line. Rejected:
+# absolute Bash shebangs (#!/bin/bash, #!/opt/homebrew/bin/bash, ...),
+# env-bash with extra arguments (#!/usr/bin/env bash -e — not portable on
+# Linux without env -S, which interprets 'bash -e' as one program name),
+# and files with no shebang at all. Bash-4+ opt-out scripts must live
+# outside this scope per the policy above. Set flags via 'set -...'
+# inside the script body, not via shebang args.
 #
 # Run:  bash plugins/lean4/tools/lint_bash_compat.sh
 # ---------------------------------------------------------------------------
@@ -168,24 +171,23 @@ done
 # ---------------------------------------------------------------------------
 # Check 8: portable shebangs in runtime path
 #
-# Hooks (invoked directly via hooks.json) and lib/scripts/ must use
-# #!/usr/bin/env bash so they work on hosts without /bin/bash (NixOS,
-# minimal containers). Any other shebang form — absolute paths like
-# #!/bin/bash, #!/opt/homebrew/bin/bash, or non-bash interpreters — is
-# rejected in this scope. Files without a shebang at all are skipped
-# (they are not directly executable and rely on the caller's interpreter).
+# Hooks (invoked directly via hooks.json) and lib/scripts/ must start with
+# exactly '#!/usr/bin/env bash' so they work on hosts without /bin/bash
+# (NixOS, minimal containers). Rejected:
+#   * absolute Bash paths: #!/bin/bash, #!/opt/homebrew/bin/bash, ...
+#   * env-bash with arguments: #!/usr/bin/env bash -e (not portable on
+#     Linux — env interprets 'bash -e' as one program name; needs env -S)
+#   * any non-bash interpreter
+#   * no shebang at all (runtime scripts must declare their interpreter)
+# Set flags via 'set -...' inside the script body, not via shebang args.
 # ---------------------------------------------------------------------------
 echo ""
 echo "-- Check 8: portable shebangs in runtime path --"
 found=0
 for f in "${SHELL_FILES[@]}"; do
   first_line=$(head -n1 "$f")
-  case "$first_line" in
-    "#!"*) ;;
-    *) continue ;;
-  esac
-  if [[ "$first_line" != "#!/usr/bin/env bash"* ]]; then
-    warn "$(basename "$f"):1: non-portable shebang '$first_line' — runtime scripts must use '#!/usr/bin/env bash'"
+  if [[ "$first_line" != "#!/usr/bin/env bash" ]]; then
+    warn "$(basename "$f"):1: non-portable shebang '$first_line' — runtime scripts must use exactly '#!/usr/bin/env bash'"
     found=1
   fi
 done


### PR DESCRIPTION
## Summary

Follow-up hardening for #118 (portable shebangs). PR #118 fixed all current `#!/bin/bash` → `#!/usr/bin/env bash` shebangs by hand; this PR makes the rule mechanical so it stays fixed, and tightens two surrounding gaps the reviews flagged:

- **`test(lint): parameterize via BASH_FOR_COMPAT`** — `tests/test_lint_bash_compat.sh` defaults to `/bin/bash` (matching the macOS Bash-3.2 CI contract) but now SKIPs gracefully when the interpreter is absent, so the test stops hard-failing on NixOS / minimal containers (the exact hosts PR #118 unblocked for runtime). The skip path is locally exercisable: `BASH_FOR_COMPAT=/nonexistent test_lint_bash_compat.sh`.
- **`chore(lint): add Check 8`** — `tools/lint_bash_compat.sh` now enforces the shebang rule for every `.sh` under `plugins/lean4/hooks/` and `plugins/lean4/lib/scripts/`. Self-test probes added in the same commit.
- **`ci(bash3-compat): hard-assert /bin/bash is Bash 3.2`** — the "Verify /bin/bash is Bash 3.2" step previously ran `/bin/bash --version` informationally and would never fail. If GitHub bumps the `macos-latest` image's system bash, the rest of the workflow's 3.2 coverage silently rots. The step now exits 1 with a clear message when `BASH_VERSINFO` isn't `3.2`.
- **`fix(lint): tighten Check 8`** (review fixup) — match `#!/usr/bin/env bash` exactly (not as a prefix): the prefix form silently accepted `#!/usr/bin/env bash -e`, which is non-portable on Linux because `env` treats `bash -e` as one program name (would need `env -S`). Set flags via `set -...` inside the script body instead. Also drops the no-shebang skip, so a runtime `.sh` with no shebang at all is now flagged. Self-test gains probes for `env bash -e`, `env sh`, and "no shebang"; loses the now-incorrect `-e` acceptance.
- **`test(lint): bashfoo token-boundary probe`** (review fixup) — defense in depth against a future "loosening" of the exact match back to prefix/substring. `#!/usr/bin/env bashfoo` is trivially rejected today; the probe ensures it stays that way.

Five small, independent commits so reviewers can step through each concern in isolation.

**Rule after all five commits — every `.sh` under `plugins/lean4/hooks/` and `plugins/lean4/lib/scripts/` must start with exactly `#!/usr/bin/env bash`.** No absolute paths, no env-bash arguments, no other interpreters, no missing shebang.

## Test plan

Verified locally on Linux (`/bin/bash` 5.2.37):

- [x] `tools/lint_bash_compat.sh` — 9/9 scripts pass, Check 8 reports green
- [x] `tests/test_lint_bash_compat.sh` — 44/44 (35 existing + 9 new Check 8 probes)
- [x] `tests/test_bash3_smoke.sh` — 14/14
- [x] Negative tests (revert a runtime shebang, confirm Check 8 fires + lint exits 1, then restore):
  - `#!/bin/bash` → flagged
  - `#!/opt/homebrew/bin/bash` → flagged (broadened rule, not just `/bin/bash`)
  - `#!/usr/bin/env bash -e` → flagged (after the tightening commit; was incorrectly accepted before)
- [x] Skip path: `BASH_FOR_COMPAT=/nonexistent` → "SKIP:" message, exit 0
- [x] CI assertion locally: `bash 5.2.37` correctly fails the new `[[ ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]} == "3.2" ]]` check
- [x] **CI green**: `bash3-compat` workflow on `macos-latest` passed on PR head (real `/bin/bash` 3.2 accepts the version assertion; Check 8 doesn't flag the existing runtime shebangs)

Not done: optional one-line README "requires bash on PATH" note — the README has no install/requirements section to slot it into naturally, and the requirement is implicit in `#!/usr/bin/env bash`. Easy to add later if it comes up.