### PR TITLE
style: normalize executable-script module docstrings to BLOCK form

### DIFF
--- a/plugins/lean4/hooks/validate_user_prompt.py
+++ b/plugins/lean4/hooks/validate_user_prompt.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Claude UserPromptSubmit hook for /lean4:* slash commands.
+"""
+Claude UserPromptSubmit hook for /lean4:* slash commands.
 
 Validates slash-command inputs before the model sees the prompt.
 Hard parse errors block the prompt; successful parses inject a

--- a/plugins/lean4/lib/scripts/parse_command_args.py
+++ b/plugins/lean4/lib/scripts/parse_command_args.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Standalone CLI for the lean4 slash-command parser.
+"""
+Standalone CLI for the lean4 slash-command parser.
 
 Usage:
     python3 parse_command_args.py <command> [--cwd PATH] -- <raw tail>

--- a/plugins/lean4/lib/scripts/test_apply_exact_chains.py
+++ b/plugins/lean4/lib/scripts/test_apply_exact_chains.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Fixture tests for find_apply_exact_chains() in find_golfable.py.
+"""
+Fixture tests for find_apply_exact_chains() in find_golfable.py.
 
 Run from the repo root:
     python3 plugins/lean4/lib/scripts/test_apply_exact_chains.py

--- a/plugins/lean4/lib/scripts/tests/test_ordering.py
+++ b/plugins/lean4/lib/scripts/tests/test_ordering.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Deterministic test for benefit-based sort order in find_golfable.py.
+"""
+Deterministic test for benefit-based sort order in find_golfable.py.
 
 Validates that analyze_file() returns patterns sorted by policy order:
   directness → performance → structural → conditional


### PR DESCRIPTION
## Summary

Aligns the 4 remaining executable Python scripts with INLINE-form module docstrings (`"""<text>` on the opener line) to the BLOCK form (`"""` on its own line, content on the next) that the other 8 scripts under `hooks/` and `lib/scripts/` already use.

Files reshaped (4 of 12 executable scripts):
- `plugins/lean4/hooks/validate_user_prompt.py`
- `plugins/lean4/lib/scripts/parse_command_args.py`
- `plugins/lean4/lib/scripts/test_apply_exact_chains.py`
- `plugins/lean4/lib/scripts/tests/test_ordering.py`

Pure stylistic / mechanical change — diff is `+8 / -4` (each file gains a line where `"""` and the content split apart). The only user-visible effect is that `parse_command_args.py --help` now prints the module docstring with the same leading blank line style already used by `sorry_analyzer.py` — i.e. consistent with the existing repo convention for scripts that `print(__doc__)`.

If we want pristine `__doc__` output (no leading blank line), that's a separate tiny PR that normalizes the `print(__doc__)` callers via `lstrip()` or `inspect.cleandoc`. Out of scope here.

## Why BLOCK over INLINE

- Extends from a one-line summary to multiple paragraphs without re-flowing the opener.
- Avoids line-length churn when the summary grows.
- Makes the shebang + docstring boundary visually obvious.
- Works cleanly for both short and long script headers.
- The downside is one extra line per file in 4 cases.

After this PR, all 12 executable Python scripts in `plugins/lean4/hooks/` and `plugins/lean4/lib/scripts/` use the same docstring opener convention.

## Test plan

- [x] `parse_command_args.py --help` — runs, output starts with a leading blank line (cosmetic, matches `sorry_analyzer.py`'s existing behavior)
- [x] `python3 -m unittest discover -s plugins/lean4/tests/command_args` — 131/131
- [x] `python3 plugins/lean4/lib/scripts/test_apply_exact_chains.py` — passing
- [x] `python3 plugins/lean4/lib/scripts/tests/test_ordering.py` — 5/5
- [x] `bash3-compat` workflow — green on PR head

## Follow-ups (separate PRs)

- **Regression lint for runtime portability** — extend `lint_bash_compat.sh` with a check that runtime `.py` files use exactly `#!/usr/bin/env python3` and that `plugins/lean4/bin` doesn't reappear as a symlink/path.
- **CI tooling adoption** — add `ruff check --select E,F,W,I` (conservative + import ordering) to CI, plus `shellcheck` on shell scripts.
- **(Optional polish)** — normalize `print(__doc__)` callers with `lstrip()` / `inspect.cleandoc` so `parse_command_args.py --help` and `sorry_analyzer.py` no-args both print without a leading blank line.