### PR TITLE
feat(lint): runtime-portability checks (Python shebangs + no bin/ shortcut)

### DIFF
--- a/plugins/lean4/tests/test_lint_bash_compat.sh
+++ b/plugins/lean4/tests/test_lint_bash_compat.sh
@@ -2,8 +2,11 @@
 set -euo pipefail
 
 # Self-test for lint_bash_compat.sh — verifies it catches all advertised
-# Bash 4+ / BSD-incompatible constructs and does NOT false-positive on safe
-# parameter-expansion forms that legitimately contain , or ^.
+# Bash 4+ / BSD-incompatible constructs (Checks 1–7), runtime shebang
+# regressions for both shell and Python (Checks 8–9), and the
+# guardrail-bypassing bin/ shortcut path (Check 10) — and does NOT
+# false-positive on safe parameter-expansion forms that legitimately
+# contain , or ^.
 #
 # Helpers invoke the copied lint with $BASH_FOR_COMPAT (default /bin/bash)
 # so the self-test is end-to-end under the system default Bash, even when a
@@ -236,6 +239,99 @@ expect_shebang_lint_fail 'no shebang — first line is a regular comment' '# jus
 # pass cleanly. Re-uses the existing expect_lint_pass helper, which
 # writes '#!/usr/bin/env bash' as the probe's shebang.
 expect_lint_pass '#!/usr/bin/env bash — accepted by Check 8' ': # no-op'
+
+# ---------------------------------------------------------------------------
+# Check 9 self-tests — runtime-path Python shebang regression
+#
+# Writes a probe .py file with the given shebang and a trivial body,
+# asserts the linter exits 1 (Check 9 flags the shebang). The acceptable
+# form is exactly '#!/usr/bin/env python3'; the no-shebang case is also
+# acceptable (library modules without a shebang are out of scope).
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- Check 9 self-tests (Python shebang regression) --"
+
+expect_py_shebang_lint_fail() {
+  local desc="$1" shebang="$2"
+  local probe="$TMPDIR_ROOT/lib/scripts/probe.py"
+  printf '%s\npass\n' "$shebang" > "$probe"
+  local exit_code=0
+  "$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" >/dev/null 2>&1 || exit_code=$?
+  if [[ "$exit_code" -eq 1 ]]; then
+    echo "  PASS: $desc"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: $desc (expected exit 1, got $exit_code)"
+    ((FAIL++)) || true
+  fi
+  rm -f "$probe"
+}
+
+expect_py_lint_pass() {
+  local desc="$1" content="$2"
+  local probe="$TMPDIR_ROOT/lib/scripts/probe.py"
+  printf '%s\n' "$content" > "$probe"
+  local exit_code=0
+  "$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" >/dev/null 2>&1 || exit_code=$?
+  if [[ "$exit_code" -eq 0 ]]; then
+    echo "  PASS: $desc"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: $desc (expected exit 0, got $exit_code)"
+    ((FAIL++)) || true
+  fi
+  rm -f "$probe"
+}
+
+# Positive cases — must be rejected.
+expect_py_shebang_lint_fail '#!/usr/bin/env sh — polyglot trampoline regression' '#!/usr/bin/env sh'
+expect_py_shebang_lint_fail '#!/usr/bin/env python — missing version suffix'     '#!/usr/bin/env python'
+expect_py_shebang_lint_fail '#!/usr/bin/python3 — absolute system path'          '#!/usr/bin/python3'
+expect_py_shebang_lint_fail '#!/opt/homebrew/bin/python3 — Homebrew path'        '#!/opt/homebrew/bin/python3'
+expect_py_shebang_lint_fail '#!/usr/bin/env python3.10 — pinned minor version'   '#!/usr/bin/env python3.10'
+expect_py_shebang_lint_fail '#!/usr/bin/env pythonfoo — token-boundary'          '#!/usr/bin/env pythonfoo'
+
+# Negative cases — must be accepted.
+expect_py_lint_pass '#!/usr/bin/env python3 — exact, accepted' '#!/usr/bin/env python3
+pass'
+expect_py_lint_pass 'no shebang — library module is out of scope' '"""Library module."""
+def f(): pass'
+
+# ---------------------------------------------------------------------------
+# Check 10 self-tests — no plugins/lean4/bin shortcut path
+#
+# Creates $TMPDIR_ROOT/bin as a symlink, file, or directory and asserts
+# the linter exits 1. Cleans up after each. The no-bin negative case is
+# implicitly verified by every other probe (none of them creates bin/),
+# so all the prior "lint exits 0" expectations also cover Check 10.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- Check 10 self-tests (no bin shortcut) --"
+
+expect_bin_lint_fail() {
+  local desc="$1" kind="$2"  # symlink|file|dir
+  local bin="$TMPDIR_ROOT/bin"
+  case "$kind" in
+    symlink) ln -s lib/scripts "$bin" ;;
+    file) touch "$bin" ;;
+    dir) mkdir "$bin" ;;
+    *) echo "  FAIL: $desc (internal: unknown kind '$kind')"; ((FAIL++)) || true; return ;;
+  esac
+  local exit_code=0
+  "$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" >/dev/null 2>&1 || exit_code=$?
+  if [[ "$exit_code" -eq 1 ]]; then
+    echo "  PASS: $desc"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: $desc (expected exit 1, got $exit_code)"
+    ((FAIL++)) || true
+  fi
+  rm -rf "$bin"
+}
+
+expect_bin_lint_fail 'bin/ as symlink to lib/scripts' symlink
+expect_bin_lint_fail 'bin/ as plain directory'        dir
+expect_bin_lint_fail 'bin/ as plain file'             file
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/plugins/lean4/tests/test_lint_bash_compat.sh
+++ b/plugins/lean4/tests/test_lint_bash_compat.sh
@@ -42,20 +42,26 @@ cp "$LINT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh"
 # Helpers
 # ---------------------------------------------------------------------------
 
+# On FAIL, helpers dump the captured lint output indented under the
+# failure line so the actual diagnostic is visible in CI logs without
+# rerunning anything. Lint stdout+stderr is captured to a local variable
+# (not /dev/null) for exactly this reason.
+
 # expect_lint_fail "description" "script body"
 #   Writes script body to a probe file, runs the lint under
 #   $BASH_FOR_COMPAT, asserts exit 1 (lint caught the issue).
 expect_lint_fail() {
-  local desc="$1" body="$2"
+  local desc="$1" body="$2" output
   local probe="$TMPDIR_ROOT/lib/scripts/probe.sh"
   printf '#!/usr/bin/env bash\n%s\n' "$body" > "$probe"
   local exit_code=0
-  "$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" >/dev/null 2>&1 || exit_code=$?
+  output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" 2>&1) || exit_code=$?
   if [[ "$exit_code" -eq 1 ]]; then
     echo "  PASS: $desc"
     ((PASS++)) || true
   else
     echo "  FAIL: $desc (expected exit 1, got $exit_code)"
+    echo "$output" | sed 's/^/      /'
     ((FAIL++)) || true
   fi
   rm -f "$probe"
@@ -65,16 +71,17 @@ expect_lint_fail() {
 #   Writes script body to a probe file, runs the lint under
 #   $BASH_FOR_COMPAT, asserts exit 0 (lint did not false-positive).
 expect_lint_pass() {
-  local desc="$1" body="$2"
+  local desc="$1" body="$2" output
   local probe="$TMPDIR_ROOT/lib/scripts/probe.sh"
   printf '#!/usr/bin/env bash\n%s\n' "$body" > "$probe"
   local exit_code=0
-  "$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" >/dev/null 2>&1 || exit_code=$?
+  output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" 2>&1) || exit_code=$?
   if [[ "$exit_code" -eq 0 ]]; then
     echo "  PASS: $desc"
     ((PASS++)) || true
   else
     echo "  FAIL: $desc (expected exit 0, got $exit_code)"
+    echo "$output" | sed 's/^/      /'
     ((FAIL++)) || true
   fi
   rm -f "$probe"
@@ -193,16 +200,17 @@ echo ""
 echo "-- Check 8 self-tests (shebang regression) --"
 
 expect_shebang_lint_fail() {
-  local desc="$1" shebang="$2"
+  local desc="$1" shebang="$2" output
   local probe="$TMPDIR_ROOT/lib/scripts/probe.sh"
   printf '%s\n: # no-op\n' "$shebang" > "$probe"
   local exit_code=0
-  "$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" >/dev/null 2>&1 || exit_code=$?
+  output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" 2>&1) || exit_code=$?
   if [[ "$exit_code" -eq 1 ]]; then
     echo "  PASS: $desc"
     ((PASS++)) || true
   else
     echo "  FAIL: $desc (expected exit 1, got $exit_code)"
+    echo "$output" | sed 's/^/      /'
     ((FAIL++)) || true
   fi
   rm -f "$probe"
@@ -252,32 +260,34 @@ echo ""
 echo "-- Check 9 self-tests (Python shebang regression) --"
 
 expect_py_shebang_lint_fail() {
-  local desc="$1" shebang="$2"
+  local desc="$1" shebang="$2" output
   local probe="$TMPDIR_ROOT/lib/scripts/probe.py"
   printf '%s\npass\n' "$shebang" > "$probe"
   local exit_code=0
-  "$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" >/dev/null 2>&1 || exit_code=$?
+  output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" 2>&1) || exit_code=$?
   if [[ "$exit_code" -eq 1 ]]; then
     echo "  PASS: $desc"
     ((PASS++)) || true
   else
     echo "  FAIL: $desc (expected exit 1, got $exit_code)"
+    echo "$output" | sed 's/^/      /'
     ((FAIL++)) || true
   fi
   rm -f "$probe"
 }
 
 expect_py_lint_pass() {
-  local desc="$1" content="$2"
+  local desc="$1" content="$2" output
   local probe="$TMPDIR_ROOT/lib/scripts/probe.py"
   printf '%s\n' "$content" > "$probe"
   local exit_code=0
-  "$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" >/dev/null 2>&1 || exit_code=$?
+  output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" 2>&1) || exit_code=$?
   if [[ "$exit_code" -eq 0 ]]; then
     echo "  PASS: $desc"
     ((PASS++)) || true
   else
     echo "  FAIL: $desc (expected exit 0, got $exit_code)"
+    echo "$output" | sed 's/^/      /'
     ((FAIL++)) || true
   fi
   rm -f "$probe"
@@ -309,7 +319,7 @@ echo ""
 echo "-- Check 10 self-tests (no bin shortcut) --"
 
 expect_bin_lint_fail() {
-  local desc="$1" kind="$2"  # symlink|file|dir
+  local desc="$1" kind="$2" output  # kind: symlink|file|dir
   local bin="$TMPDIR_ROOT/bin"
   case "$kind" in
     symlink) ln -s lib/scripts "$bin" ;;
@@ -318,12 +328,13 @@ expect_bin_lint_fail() {
     *) echo "  FAIL: $desc (internal: unknown kind '$kind')"; ((FAIL++)) || true; return ;;
   esac
   local exit_code=0
-  "$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" >/dev/null 2>&1 || exit_code=$?
+  output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" 2>&1) || exit_code=$?
   if [[ "$exit_code" -eq 1 ]]; then
     echo "  PASS: $desc"
     ((PASS++)) || true
   else
     echo "  FAIL: $desc (expected exit 1, got $exit_code)"
+    echo "$output" | sed 's/^/      /'
     ((FAIL++)) || true
   fi
   rm -rf "$bin"

--- a/plugins/lean4/tools/lint_bash_compat.sh
+++ b/plugins/lean4/tools/lint_bash_compat.sh
@@ -221,16 +221,17 @@ done
 [[ $found -eq 0 ]] && ok "All runtime scripts use #!/usr/bin/env bash"
 
 # ---------------------------------------------------------------------------
-# Check 9: portable Python shebangs in runtime path
+# Check 9: portable Python shebangs in hooks/ and lib/scripts/
 #
-# Every .py file under hooks/ and lib/scripts/ that HAS a shebang must use
-# exactly '#!/usr/bin/env python3'. Library modules without a shebang
-# (imported, not executed) are out of scope. Intent: forbid the
-# '#!/usr/bin/env sh' polyglot trampoline (which leaks 'exec "$0"' into
-# __doc__ and surfaces in --help output) and absolute interpreter paths.
+# Every .py file under hooks/ and lib/scripts/ (recursively, including
+# lib/scripts/tests/) that HAS a shebang must use exactly
+# '#!/usr/bin/env python3'. Library modules without a shebang (imported,
+# not executed) are out of scope. Intent: forbid the '#!/usr/bin/env sh'
+# polyglot trampoline (which leaks 'exec "$0"' into __doc__ and surfaces
+# in --help output) and absolute interpreter paths.
 # ---------------------------------------------------------------------------
 echo ""
-echo "-- Check 9: portable Python shebangs in runtime path --"
+echo "-- Check 9: portable Python shebangs in hooks/ and lib/scripts/ --"
 found=0
 for f in "${PY_FILES[@]+"${PY_FILES[@]}"}"; do
   first_line=$(head -n1 "$f")

--- a/plugins/lean4/tools/lint_bash_compat.sh
+++ b/plugins/lean4/tools/lint_bash_compat.sh
@@ -50,7 +50,16 @@ ok() {
   echo "✓ $1"
 }
 
-# Collect all .sh files in the runtime path
+# Collect all .sh files in the runtime path.
+#
+# Note on the "${arr[@]+"${arr[@]}"}" idiom used below in the check
+# loops: on Bash 3.2 (macOS) with set -u, expanding "${arr[@]}" on an
+# empty array errors with "unbound variable" — a quirk fixed in Bash 4.4.
+# The alternative-value form "${arr[@]+...}" expands to nothing when the
+# array is empty and to "${arr[@]}" otherwise, dodging the bug. SHELL_FILES
+# and PY_FILES can each be empty during self-tests (when a probe of one
+# type is present without the other), so every loop over them uses this
+# guarded form.
 mapfile_compat() {
   # Can't use mapfile itself — this lint must run on Bash 3.2 too!
   local arr_name="$1"
@@ -94,7 +103,7 @@ echo ""
 # ---------------------------------------------------------------------------
 echo "-- Check 1: case-modifier syntax (\${var,,} / \${var,} / \${var^^} / \${var^}) --"
 found=0
-for f in "${SHELL_FILES[@]}"; do
+for f in "${SHELL_FILES[@]+"${SHELL_FILES[@]}"}"; do
   while IFS= read -r match; do
     warn "$match"
     found=1
@@ -108,7 +117,7 @@ done
 echo ""
 echo "-- Check 2: associative arrays (declare -A / local -A / typeset -A) --"
 found=0
-for f in "${SHELL_FILES[@]}"; do
+for f in "${SHELL_FILES[@]+"${SHELL_FILES[@]}"}"; do
   while IFS= read -r match; do
     warn "$match"
     found=1
@@ -122,7 +131,7 @@ done
 echo ""
 echo "-- Check 3: namerefs (declare -n / local -n / typeset -n) --"
 found=0
-for f in "${SHELL_FILES[@]}"; do
+for f in "${SHELL_FILES[@]+"${SHELL_FILES[@]}"}"; do
   while IFS= read -r match; do
     warn "$match"
     found=1
@@ -136,7 +145,7 @@ done
 echo ""
 echo "-- Check 4: mapfile / readarray --"
 found=0
-for f in "${SHELL_FILES[@]}"; do
+for f in "${SHELL_FILES[@]+"${SHELL_FILES[@]}"}"; do
   while IFS= read -r match; do
     warn "$match"
     found=1
@@ -150,7 +159,7 @@ done
 echo ""
 echo "-- Check 5: coproc --"
 found=0
-for f in "${SHELL_FILES[@]}"; do
+for f in "${SHELL_FILES[@]+"${SHELL_FILES[@]}"}"; do
   while IFS= read -r match; do
     warn "$match"
     found=1
@@ -164,7 +173,7 @@ done
 echo ""
 echo "-- Check 6: \${var@op} expansions --"
 found=0
-for f in "${SHELL_FILES[@]}"; do
+for f in "${SHELL_FILES[@]+"${SHELL_FILES[@]}"}"; do
   while IFS= read -r match; do
     warn "$match"
     found=1
@@ -178,7 +187,7 @@ done
 echo ""
 echo "-- Check 7: mktemp with suffix after X's --"
 found=0
-for f in "${SHELL_FILES[@]}"; do
+for f in "${SHELL_FILES[@]+"${SHELL_FILES[@]}"}"; do
   while IFS= read -r match; do
     warn "$match"
     found=1
@@ -202,7 +211,7 @@ done
 echo ""
 echo "-- Check 8: portable shebangs in runtime path --"
 found=0
-for f in "${SHELL_FILES[@]}"; do
+for f in "${SHELL_FILES[@]+"${SHELL_FILES[@]}"}"; do
   first_line=$(head -n1 "$f")
   if [[ "$first_line" != "#!/usr/bin/env bash" ]]; then
     warn "$(basename "$f"):1: non-portable shebang '$first_line' — runtime scripts must use exactly '#!/usr/bin/env bash'"
@@ -223,7 +232,7 @@ done
 echo ""
 echo "-- Check 9: portable Python shebangs in runtime path --"
 found=0
-for f in "${PY_FILES[@]}"; do
+for f in "${PY_FILES[@]+"${PY_FILES[@]}"}"; do
   first_line=$(head -n1 "$f")
   # Only validate files that declare a shebang. No-shebang library
   # modules can't be polyglot regressions and stay out of scope.

--- a/plugins/lean4/tools/lint_bash_compat.sh
+++ b/plugins/lean4/tools/lint_bash_compat.sh
@@ -19,6 +19,19 @@
 # outside this scope per the policy above. Set flags via 'set -...'
 # inside the script body, not via shebang args.
 #
+# Python shebang policy (Check 9): every .py file in hooks/ and lib/scripts/
+# that has a shebang must use exactly '#!/usr/bin/env python3'. Library
+# modules without a shebang are out of scope. The intent is to forbid the
+# '#!/usr/bin/env sh' polyglot trampoline pattern (which buries shell in
+# __doc__ and leaks into --help output) and absolute interpreter paths.
+#
+# Path policy (Check 10): plugins/lean4/bin must not exist as a symlink,
+# file, or directory. Such a shortcut would let callers invoke runtime
+# scripts via paths that guardrails.sh's Lean-script stderr-suppression
+# detector doesn't recognize (it matches lib/scripts/ and scripts/ only),
+# silently bypassing the safety check. Reintroduce only with a matching
+# guardrail update.
+#
 # Run:  bash plugins/lean4/tools/lint_bash_compat.sh
 # ---------------------------------------------------------------------------
 set -euo pipefail
@@ -55,13 +68,17 @@ mapfile_compat SHELL_FILES < <(find \
   "$PLUGIN_ROOT/lib/scripts" \
   -name '*.sh' -type f 2>/dev/null | sort)
 
-if [[ ${#SHELL_FILES[@]} -eq 0 ]]; then
-  echo "No .sh files found under hooks/ or lib/scripts/"
-  exit 0
-fi
+PY_FILES=()
+mapfile_compat PY_FILES < <(find \
+  "$PLUGIN_ROOT/hooks" \
+  "$PLUGIN_ROOT/lib/scripts" \
+  -name '*.py' -type f 2>/dev/null | sort)
 
-echo "Scanning ${#SHELL_FILES[@]} shell scripts for Bash 4+ constructs..."
+echo "Scanning ${#SHELL_FILES[@]} shell scripts and ${#PY_FILES[@]} Python files for runtime-portability issues..."
 echo ""
+# Note: we don't early-exit on empty arrays here. Check 10 (no bin shortcut
+# path) is a structural check that must always run regardless of file
+# counts; the per-file Checks 1–9 are no-ops with empty arrays anyway.
 
 # ---------------------------------------------------------------------------
 # Check 1: case-modifier syntax ${var,,}, ${var,}, ${var^^}, ${var^} (Bash 4.0+)
@@ -195,14 +212,59 @@ done
 [[ $found -eq 0 ]] && ok "All runtime scripts use #!/usr/bin/env bash"
 
 # ---------------------------------------------------------------------------
+# Check 9: portable Python shebangs in runtime path
+#
+# Every .py file under hooks/ and lib/scripts/ that HAS a shebang must use
+# exactly '#!/usr/bin/env python3'. Library modules without a shebang
+# (imported, not executed) are out of scope. Intent: forbid the
+# '#!/usr/bin/env sh' polyglot trampoline (which leaks 'exec "$0"' into
+# __doc__ and surfaces in --help output) and absolute interpreter paths.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- Check 9: portable Python shebangs in runtime path --"
+found=0
+for f in "${PY_FILES[@]}"; do
+  first_line=$(head -n1 "$f")
+  # Only validate files that declare a shebang. No-shebang library
+  # modules can't be polyglot regressions and stay out of scope.
+  case "$first_line" in
+    "#!"*) ;;
+    *) continue ;;
+  esac
+  if [[ "$first_line" != "#!/usr/bin/env python3" ]]; then
+    warn "$(basename "$f"):1: non-portable Python shebang '$first_line' — runtime .py with a shebang must use exactly '#!/usr/bin/env python3'"
+    found=1
+  fi
+done
+[[ $found -eq 0 ]] && ok "All shebanged Python runtime files use #!/usr/bin/env python3"
+
+# ---------------------------------------------------------------------------
+# Check 10: no plugins/lean4/bin shortcut path
+#
+# plugins/lean4/bin (as symlink, dir, or file) gives callers a shorter
+# invocation path that bypasses guardrails.sh's Lean-script
+# stderr-suppression detector, which matches '$LEAN4_SCRIPTS/...',
+# 'plugins/lean4/lib/scripts/...', and './scripts/...' only. A reappearance
+# means the safety check can be silently bypassed via 'bin/foo.py 2>/dev/null'.
+# Reintroduce only together with a matching detector update.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- Check 10: no plugins/lean4/bin shortcut path --"
+if [[ -L "$PLUGIN_ROOT/bin" || -e "$PLUGIN_ROOT/bin" ]]; then
+  warn "$PLUGIN_ROOT/bin exists — shortcut bypasses guardrails.sh stderr-suppression detector (matches lib/scripts/ and scripts/ only). Drop the path or update the detector first."
+else
+  ok "No plugins/lean4/bin shortcut path"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""
 echo "================================"
 if [[ $ISSUES -eq 0 ]]; then
-  echo "✓ All ${#SHELL_FILES[@]} scripts are Bash 3.2 compatible"
+  echo "✓ All ${#SHELL_FILES[@]} shell + ${#PY_FILES[@]} Python runtime files pass portability checks"
   exit 0
 else
-  echo "⚠️  $ISSUES issue(s) found — break on macOS /bin/bash 3.2 (Checks 1–7) or non-portable hosts like NixOS (Check 8)"
+  echo "⚠️  $ISSUES issue(s) found — see Checks 1–10 for context (Bash 3.2 compat, runtime shebangs, shortcut path)"
   exit 1
 fi


### PR DESCRIPTION
## Summary

Extends `plugins/lean4/tools/lint_bash_compat.sh` with two new mechanical checks that defend against the regressions cleaned up during PR #120 review:

- **Check 9** — every `.py` file in `hooks/` and `lib/scripts/` that has a shebang must use exactly `#!/usr/bin/env python3`. Library modules without a shebang stay out of scope (they can't be polyglot regressions). Catches the `#!/usr/bin/env sh` polyglot trampoline that leaked `exec "${LEAN4_PYTHON_BIN:-python3}" "$0" "$@"` into `__doc__`, plus absolute paths, missing version suffix, pinned minor versions, and token-boundary near-misses (`pythonfoo`).

- **Check 10** — `plugins/lean4/bin` must not exist as a symlink, file, or directory. The shortcut path bypasses `guardrails.sh`'s Lean-script stderr-suppression detector (which only matches `lib/scripts/` and `scripts/`), so `bin/foo.py 2>/dev/null` would silently skip the safety check. Reintroduce only with a matching detector update.

Both are pure structural checks; no per-file Bash-4+ scanning involved.

## Self-test additions (`test_lint_bash_compat.sh` — 44 → 55 probes)

- **Check 9**: 6 fail probes (`#!/usr/bin/env sh`, `#!/usr/bin/env python` (no version), `#!/usr/bin/python3` absolute, `#!/opt/homebrew/bin/python3` Homebrew, `#!/usr/bin/env python3.10` pinned minor, `#!/usr/bin/env pythonfoo` token-boundary) + 2 pass probes (exact `python3`, no-shebang library module).
- **Check 10**: 3 fail probes (`bin/` as symlink, plain dir, plain file). Implicit no-bin negative coverage via every other passing probe.

## One small support change

Removed the early-exit guard that bailed out of `lint_bash_compat.sh` when both `SHELL_FILES` and `PY_FILES` were empty. Check 10 is a structural check that must always run regardless of file counts; the per-file Checks 1–9 are no-ops with empty arrays anyway. Edge-case behavior: an empty `hooks/` / `lib/scripts/` now scans 0 files and still validates the no-`bin/` invariant.

## Verification (on the post-#122 main)

- [x] `lint_bash_compat.sh` — 9 shell + 12 Python files, all 10 checks green
- [x] Negative test: `validate_user_prompt.py` reverted to `#!/usr/bin/env sh` → Check 9 fires, exit 1
- [x] Negative test: `plugins/lean4/bin` symlink created → Check 10 fires, exit 1
- [x] `test_lint_bash_compat.sh` — 55/55
- [x] `test_bash3_smoke.sh` — 14/14
- [x] `test_cycle_tracker.sh` — 194/194
- [x] `test_guardrails.sh` — 75/75
- [x] `test_validate_user_prompt.sh` — 33/33
- [x] `test_contracts.sh` — 27/27
- [x] `command_args` unittests — 131/131
- [x] `bash3-compat` workflow on `macos-latest`

## Out of scope (separate PRs)

- **Rename `lint_bash_compat.sh`** — the file now covers Bash 3.2 compat + bash shebang + Python shebang + structural path checks. Name is a bit stretched but renaming touches CI workflow + tests + docs; leave for a separate housekeeping PR.
- **CI tooling adoption** (ruff + shellcheck)