### PR TITLE
ci: add ruff (E,F,W,I) and shellcheck workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+name: lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: ruff check (config in pyproject.toml)
+        run: ruff check plugins/lean4/
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify shellcheck is installed
+        run: shellcheck --version
+
+      - name: shellcheck (hooks/, lib/scripts/, tools/)
+        # Flags match the invocation Holger validated against in PR #120:
+        # --shell=bash forces bash dialect; -x follows `source` references;
+        # SC2016 (expressions in single quotes) is excluded because several
+        # scripts use single-quoted regex literals intentionally.
+        run: |
+          shellcheck --shell=bash -x --exclude=SC2016 \
+            plugins/lean4/hooks/*.sh \
+            plugins/lean4/lib/scripts/*.sh \
+            plugins/lean4/tools/*.sh

--- a/plugins/lean4/lib/scripts/check_axioms_inline.sh
+++ b/plugins/lean4/lib/scripts/check_axioms_inline.sh
@@ -36,7 +36,7 @@ set -euo pipefail
 # Track backup files for cleanup on interrupt using marker files
 # Marker files are more robust than arrays for SIGINT handling
 MARKER_DIR=$(mktemp -d)
-# shellcheck disable=SC2329  # invoked via trap below
+# shellcheck disable=SC2329,SC2317  # invoked via trap below; SC2317 fires per-line in the body for the same reason
 cleanup() {
     # Find all marker files and restore corresponding backups
     # Use nullglob to handle case when no markers exist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+# Ruff configuration for the lean4-skills repo.
+#
+# Scope: Python sources under plugins/lean4/. The workflow at
+# .github/workflows/lint.yml invokes `ruff check plugins/lean4/` against
+# this config.
+#
+# Rule selection rationale:
+#   E, F, W — pycodestyle errors/warnings + pyflakes (syntax, undefined
+#             names, unused imports, basic correctness).
+#   I       — import ordering, deterministic and cheap.
+#   E501    — line length not enforced; the existing code intentionally
+#             prefers longer descriptive lines in some places.
+#
+# Held off intentionally (revisit after CI stays quiet):
+#   B, C4, UP, SIM, RUF, N — opinion-heavy modernization / style rules.
+#   `ruff format --check`  — repo doesn't currently have an enforced
+#                            formatter policy.
+
+[tool.ruff]
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+ignore = ["E501"]


### PR DESCRIPTION
## Summary

Adopts ruff and shellcheck as CI gates so PR #120's lint cleanup doesn't decay. Conservative rule sets — easy to ratchet up later, hard to dial back once contributors expect the rules.

### Ruff

- **Scope**: `plugins/lean4/` (where all Python lives).
- **Rules**: `E, F, W, I` — pycodestyle errors/warnings, pyflakes, import ordering. Skips `B, C4, UP, SIM, RUF, N` for now: valuable but more opinionated; would create "why is CI failing?" friction before we've socialized the rules.
- Skips `ruff format --check` — repo doesn't currently have an enforced formatter policy.
- Ignores `E501` (line length) — preserves the existing intentional longer lines.
- Config in `pyproject.toml` at repo root.

### Shellcheck

- **Scope**: `plugins/lean4/{hooks,lib/scripts,tools}/*.sh` (13 scripts).
- **Flags**: `--shell=bash -x --exclude=SC2016` — matches the invocation Holger validated clean during PR #120. `SC2016` (expressions in single quotes) is excluded because several scripts use single-quoted regex literals intentionally.
- Uses `ubuntu-latest`'s pre-installed shellcheck (no install step). Current version on `ubuntu-latest` is **0.9.0**; verified locally against **0.10.0** as well.

### One small fixup (commit `c6639f7`)

`shellcheck` on `ubuntu-latest` (0.9.0 at the time of this PR; same behavior on 0.10.0 locally) fires `SC2317` ("command unreachable") on every line in `check_axioms_inline.sh`'s `cleanup()` body. Same root reason as the `SC2329` ("function never invoked") that Holger silenced on the same function in PR #120 — `cleanup()` is registered as a trap handler and isn't statically reachable. Extended the existing inline annotation from `# shellcheck disable=SC2329` to `# shellcheck disable=SC2329,SC2317`. Targeted fix keeps `SC2317` active globally so genuine unreachable code in future PRs still surfaces.

### Workflow shape

- Two parallel jobs (`ruff` + `shellcheck`), each ~8-9s on `ubuntu-latest`.
- Triggers: `pull_request` + `push` to `main` (matches `bash3-compat.yml`).
- Lives at `.github/workflows/lint.yml`. The existing `bash3-compat.yml` stays focused on macOS Bash-3.2 runtime portability.

## Test plan

- [x] `ruff check plugins/lean4/` locally — all checks passed
- [x] `pyproject.toml` is valid TOML; `lint.yml` parses as valid YAML
- [x] `shellcheck --shell=bash -x --exclude=SC2016 plugins/lean4/{hooks,lib/scripts,tools}/*.sh` locally on shellcheck 0.10.0 — exit 0, no output
- [x] Both jobs (`ruff`, `shellcheck`) pass on CI for this PR (plus existing `macos-bash3` still green); CI's shellcheck is 0.9.0

## Follow-ups (separate)

- **Pinning ruff and shellcheck versions** — unpinned for first adoption. Worth pinning if/when version drift causes CI flakiness (e.g., a new ruff release adds rules to a selected sub-code set, or shellcheck enables a new check by default).
- **Adding mypy**. Tracked separately. `--strict` is a high bar; if added, probably starts non-strict or scoped narrowly to `lib/command_args/` first.
- **Ratcheting ruff up to `B, C4, UP, SIM, RUF, N`** once the team is comfortable with the conservative baseline.
- **`ruff format --check`** if/when the repo decides to enforce formatting policy.