### PR TITLE
ci(lint): pin ruff 0.15.13 and shellcheck 0.10.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,11 @@
 name: lint
 
+# Tool versions are deliberately pinned (exact, not range) to prevent
+# silent CI drift — e.g. a new ruff release adding rules to a selected
+# sub-code set, or a shellcheck release enabling additional checks by
+# default. Bump intentionally via PR; update both pyproject.toml's
+# target-version and the pins below together when relevant.
+
 on:
   pull_request:
   push:
@@ -15,8 +21,8 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install ruff
-        run: pip install ruff
+      - name: Install ruff (pinned)
+        run: pip install 'ruff==0.15.13'
 
       - name: ruff check (config in pyproject.toml)
         run: ruff check plugins/lean4/
@@ -26,7 +32,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Verify shellcheck is installed
+      # Install a pinned shellcheck binary from the upstream release
+      # tarball rather than relying on ubuntu-latest's pre-installed
+      # version (which floats — 0.9.0 today, anything later tomorrow).
+      - name: Install shellcheck 0.10.0
+        run: |
+          cd "$RUNNER_TEMP"
+          curl -fsSL \
+            https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz \
+            -o shellcheck.tar.xz
+          tar -xJf shellcheck.tar.xz
+          echo "$RUNNER_TEMP/shellcheck-v0.10.0" >> "$GITHUB_PATH"
+
+      - name: Verify shellcheck version
         run: shellcheck --version
 
       - name: shellcheck (hooks/, lib/scripts/, tools/)


### PR DESCRIPTION
## Summary

Pins both lint tool versions in `.github/workflows/lint.yml` to prevent silent CI drift. Follow-up to PR #124's deferred item.

- **Ruff**: `pip install 'ruff==0.15.13'` (exact pin, not range). Range pins still allow patch drift; exact pin means version bumps are deliberate PRs.
- **Shellcheck**: previously used `ubuntu-latest`'s preinstalled shellcheck (currently 0.9.0; floats whenever the runner image is refreshed). Now downloads the official **0.10.0** binary from `koalaman/shellcheck`'s GitHub releases and prepends its directory to `GITHUB_PATH` so subsequent steps use the pinned binary.

Workflow now opens with a comment block stating the pinning policy so future bumps are visible and intentional. Inline `(pinned)` / `Install shellcheck 0.10.0` step names make the version choices easy to spot in review.

## Why exact pin rather than range

The whole point of pinning here is to make tool-version changes a deliberate code-review event. A range like `ruff>=0.15,<0.16` defeats that — patch releases would still upgrade silently. The cost of exact pinning is a small periodic PR to bump; the benefit is no surprises in CI.

## Test plan

- [x] YAML parses
- [x] Shellcheck 0.10.0 tarball URL resolves (HTTP 302 → release CDN)
- [x] Ruff 0.15.13 published on PyPI
- [x] `ruff check plugins/lean4/` locally on 0.15.13 — all checks passed
- [x] `shellcheck --shell=bash -x --exclude=SC2016 plugins/lean4/{hooks,lib/scripts,tools}/*.sh` locally on 0.10.0 — exit 0
- [x] **CI: both jobs (`ruff`, `shellcheck`) pass on this PR** (plus `macos-bash3` still green)

## Out of scope

- **SHA256 verification on the shellcheck tarball** — exact-version pin without bytes verification is weaker than pinning the bytes themselves. Adding `sha256sum -c` is a few lines but felt like supply-chain hardening beyond the scope of "stop CI drift." Easy to add later.
- **`shellcheck --version | grep -q 'version: 0.10.0'` assertion** — defends against PATH-order surprises (an unpinned shellcheck on PATH winning over our pinned binary). Reviewer-flagged nit, agreed "not a blocker"; happy to add as a follow-up if it accumulates with other defensive tweaks.
- **Bumping ruff to a newer release** — 0.15.13 was what I had installed locally and was known clean against the codebase. Bumping to the latest minor is a separate PR.
- **Tracking `target-version = "py310"` in pyproject.toml alongside the runtime floor** — they're already aligned; the header comment mentions to bump together when relevant.