### PR TITLE
ci(lint): ratchet ruff rules, add ruff format --check, add mypy --strict

### DIFF
--- a/.github/workflows/bash3-compat.yml
+++ b/.github/workflows/bash3-compat.yml
@@ -9,7 +9,7 @@ jobs:
   macos-bash3:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Verify /bin/bash is Bash 3.2 (macOS default)
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,9 +15,9 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -27,10 +27,42 @@ jobs:
       - name: ruff check (config in pyproject.toml)
         run: ruff check plugins/lean4/
 
+      - name: ruff format --check
+        run: ruff format --check plugins/lean4/
+
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          # Pin to the documented runtime floor (pyproject.toml's
+          # target-version = "py310") so mypy's stdlib stubs and
+          # version-sensitive checks match what the code actually runs
+          # against. mypy's --python-version flag below makes the
+          # target explicit even when the runner Python drifts.
+          python-version: "3.10"
+
+      - name: Install mypy (pinned)
+        run: pip install 'mypy==1.20.2'
+
+      - name: mypy --strict (lib/ + hooks/, targeting Python 3.10)
+        # MYPYPATH=lib mirrors validate_user_prompt.py's sys.path
+        # manipulation so `from command_args import ...` resolves the way
+        # it does at runtime, without needing a packaged install.
+        # --python-version 3.10 is the documented compatibility floor;
+        # without it mypy would analyze under whatever interpreter
+        # version it runs on.
+        working-directory: plugins/lean4
+        env:
+          MYPYPATH: lib
+        run: mypy --python-version 3.10 --strict lib/ hooks/
+
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Install a pinned shellcheck binary from the upstream release
       # tarball rather than relying on ubuntu-latest's pre-installed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,24 +1,28 @@
 # Ruff configuration for the lean4-skills repo.
 #
 # Scope: Python sources under plugins/lean4/. The workflow at
-# .github/workflows/lint.yml invokes `ruff check plugins/lean4/` against
-# this config.
+# .github/workflows/lint.yml invokes `ruff check plugins/lean4/` and
+# `ruff format --check plugins/lean4/` against this config.
 #
-# Rule selection rationale:
+# Selected rule families:
 #   E, F, W — pycodestyle errors/warnings + pyflakes (syntax, undefined
-#             names, unused imports, basic correctness).
-#   I       — import ordering, deterministic and cheap.
-#   E501    — line length not enforced; the existing code intentionally
-#             prefers longer descriptive lines in some places.
+#             names, unused imports, basic correctness)
+#   I       — import ordering
+#   B       — flake8-bugbear (likely bugs: mutable defaults, unused
+#             loop vars, etc.)
+#   C4      — flake8-comprehensions (unnecessary list/dict/set wraps)
+#   UP      — pyupgrade (PEP 585/604 modernization)
+#   SIM     — flake8-simplify (boolean / conditional simplifications)
+#   RUF     — ruff-specific (sorted __all__, ambiguous Unicode, etc.)
+#   N       — pep8-naming (CamelCase / snake_case consistency)
 #
-# Held off intentionally (revisit after CI stays quiet):
-#   B, C4, UP, SIM, RUF, N — opinion-heavy modernization / style rules.
-#   `ruff format --check`  — repo doesn't currently have an enforced
-#                            formatter policy.
+# Ignored:
+#   E501    — line length not enforced; some descriptive lines are
+#             intentionally long.
 
 [tool.ruff]
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I"]
+select = ["E", "F", "W", "B", "C4", "UP", "SIM", "I", "RUF", "N"]
 ignore = ["E501"]


### PR DESCRIPTION
## Summary

Three CI tooling additions, **all cleanly adoptable post-#120/#122 without any code changes** — each passes exit 0 on the current codebase. Verified locally before pushing. Plus three Node-20→24 action bumps from #126 review.

### 1. Ruff rule ratchet (`pyproject.toml`)

Widens `select` from `E,F,W,I` (PR #124 baseline) to the **full set** Holger ran during PR #120 cleanup: `E,F,W,B,C4,UP,SIM,I,RUF,N`. Adds:
- **B** — flake8-bugbear (mutable defaults, unused loop vars, …)
- **C4** — flake8-comprehensions (unnecessary list/dict/set wraps)
- **UP** — pyupgrade (PEP 585 / PEP 604 modernization)
- **SIM** — flake8-simplify (boolean / conditional simplifications)
- **RUF** — ruff-specific (sorted `__all__`, ambiguous Unicode, …)
- **N** — pep8-naming (CamelCase / snake_case consistency)

`E501` stays ignored. Result on current codebase: **all checks passed**.

### 2. `ruff format --check` (`lint.yml`, new step in `ruff` job)

Adds `ruff format --check plugins/lean4/` after the existing `ruff check`. `ruff format --diff` currently reports "**39 files already formatted**" — zero churn, locked in by Holger's `ruff format .` during PR #120.

### 3. mypy `--strict` job (`lint.yml`, new parallel job)

New `mypy` job runs in parallel with `ruff` and `shellcheck`:
- Pinned to `mypy==1.20.2` (matches PR #125's exact-pin policy)
- Runs **under Python 3.10** (matching `pyproject.toml`'s `target-version = "py310"`) instead of whatever Python the runner ships
- Invokes `mypy --python-version 3.10 --strict lib/ hooks/` so the analysis target is unambiguous even if the runner Python drifts
- Mirrors `validate_user_prompt.py`'s `sys.path` manipulation via `MYPYPATH=lib`

Result on current codebase: **26 source files, no issues, exit 0**.

### 4. Node 20 → Node 24 action bumps (post-review)

GitHub Actions runners default to Node 24 starting 2026-06-02. Bumped:
- `actions/checkout@v4` → `@v5` (3 occurrences in `lint.yml`, 1 in `bash3-compat.yml`)
- `actions/setup-python@v5` → `@v6` (2 occurrences in `lint.yml`)

Folded into this PR rather than a follow-up since we're already touching the lint infrastructure.

## Why this is adoptable now

Holger explicitly validated each of these three tools clean during PR #120's review:
> Ran ruff check --select E,F,W,B,C4,UP,SIM,I,RUF,N --ignore E501 . && ruff format .
> Ran mypy --strict lib/ hooks/

Those passed at PR #120 merge time. PRs since (#121, #122, #123, #124, #125) have been narrow enough that none introduced regressions vs the wider rules — re-verified by running each tool locally on the current branch state.

## Test plan

- [x] `ruff check plugins/lean4/` (wider select) → exit 0
- [x] `ruff format --check plugins/lean4/` → 39 files already formatted, exit 0
- [x] `cd plugins/lean4 && MYPYPATH=lib mypy --python-version 3.10 --strict lib/ hooks/` → 26 files, no issues, exit 0
- [x] YAMLs parse (lint.yml, bash3-compat.yml)
- [ ] CI: `ruff`, `mypy`, `shellcheck`, `macos-bash3` all pass on this PR
- [x] mypy 1.20.2 install resolvable on PyPI

## Out of scope

- **Ratcheting ruff further** (`PT`, `D` docstring rules, etc.) — weren't part of Holger's validated set and tend to have more contributor friction.
- **mypy `--strict` on tests/** — currently strict scope is `lib/` + `hooks/`. Could extend later.
- **`shellcheck --version | grep -q 'version: 0.10.0'`** defensive assertion — being folded into PR-F (polish bundle).