### PR TITLE
polish: 4 small follow-up fixes (lint_docs, __doc__, README, shellcheck assert)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -76,8 +76,17 @@ jobs:
           tar -xJf shellcheck.tar.xz
           echo "$RUNNER_TEMP/shellcheck-v0.10.0" >> "$GITHUB_PATH"
 
-      - name: Verify shellcheck version
-        run: shellcheck --version
+      - name: Verify shellcheck version (assert exactly 0.10.0)
+        # Belt-and-suspenders against PATH-order surprises: even though
+        # the previous step prepends our pinned binary's dir to
+        # GITHUB_PATH, the grep ensures any other shellcheck on PATH
+        # (e.g. ubuntu-latest's preinstalled 0.9.0) doesn't silently
+        # win the lookup. -F treats the pattern as a fixed literal
+        # string; -x requires a full-line match so neither future
+        # "0.10.0-rc1" nor "0.10.01" would pass.
+        run: |
+          shellcheck --version
+          shellcheck --version | grep -Fxq 'version: 0.10.0'
 
       - name: shellcheck (hooks/, lib/scripts/, tools/)
         # Flags match the invocation Holger validated against in PR #120:

--- a/plugins/lean4/lib/scripts/README.md
+++ b/plugins/lean4/lib/scripts/README.md
@@ -183,6 +183,7 @@ Analyze let binding usage to avoid bad optimizations.
 ## Requirements
 
 - **Bash 3.2+** (for shell scripts)
+- **`bash` on `PATH`** — runtime scripts use `#!/usr/bin/env bash`, so the kernel needs to find `bash` via `PATH` (no longer `/bin/bash`-specific). NixOS / minimal containers must ensure `bash` is resolvable.
 - **Python 3.10+** (for Python scripts; `lib/command_args/types.py` evaluates `str | None` and `tuple[...]` at module-import time — PEP 604 runtime, not just annotations)
 - **Lean 4 project** with `lake`
 - **mathlib** in `.lake/packages/mathlib` (for search)

--- a/plugins/lean4/lib/scripts/parse_command_args.py
+++ b/plugins/lean4/lib/scripts/parse_command_args.py
@@ -29,7 +29,9 @@ def main() -> int:
     args = sys.argv[1:]
 
     if not args or args[0] in ("-h", "--help"):
-        print(__doc__, file=sys.stderr)
+        # lstrip() avoids printing a leading blank line when the module
+        # docstring is block-form (opening `"""` on its own line).
+        print((__doc__ or "").lstrip(), file=sys.stderr)
         return 1
 
     # Parse CLI: <command> [--cwd PATH] -- <single raw tail string>

--- a/plugins/lean4/lib/scripts/parse_command_args.py
+++ b/plugins/lean4/lib/scripts/parse_command_args.py
@@ -28,9 +28,14 @@ from command_args import COMMAND_SPECS, parse_invocation  # noqa: E402
 def main() -> int:
     args = sys.argv[1:]
 
-    if not args or args[0] in ("-h", "--help"):
-        # lstrip() avoids printing a leading blank line when the module
-        # docstring is block-form (opening `"""` on its own line).
+    # lstrip() avoids printing a leading blank line when the module
+    # docstring is block-form (opening `"""` on its own line).
+    if args and args[0] in ("-h", "--help"):
+        # Explicit --help is not a usage error; print to stdout and exit 0
+        # so it composes cleanly in shell pipelines and scripts.
+        print((__doc__ or "").lstrip())
+        return 0
+    if not args:
         print((__doc__ or "").lstrip(), file=sys.stderr)
         return 1
 

--- a/plugins/lean4/lib/scripts/sorry_analyzer.py
+++ b/plugins/lean4/lib/scripts/sorry_analyzer.py
@@ -448,7 +448,9 @@ def show_sorry_details(sorry: Sorry) -> None:
 
 def main() -> None:
     if len(sys.argv) < 2:
-        print(__doc__)
+        # lstrip() avoids printing a leading blank line when the module
+        # docstring is block-form (opening `"""` on its own line).
+        print((__doc__ or "").lstrip())
         sys.exit(1)
 
     # Catch common mistake: flag where target path is expected

--- a/plugins/lean4/tools/lint_docs.sh
+++ b/plugins/lean4/tools/lint_docs.sh
@@ -9,7 +9,13 @@
 set -euo pipefail
 
 VERBOSE="${1:-}"
-PLUGIN_ROOT="${LEAN4_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+# Always derive PLUGIN_ROOT from this script's own location. Honoring
+# LEAN4_PLUGIN_ROOT (the harness-exported install-cache path) caused
+# false-positive failures when the cache was stale, because internal
+# checks like the lint_bash_compat.sh invocation would run against the
+# cache instead of the working copy. This is a maintainer dev tool;
+# it should operate on the working tree exclusively.
+PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ISSUES=0
 
 # Single source of truth for known commands (used by check_commands and check_cross_refs)


### PR DESCRIPTION
## Summary

Five small unrelated follow-ups bundled into one polish PR. Each is its own commit. No new functionality — just fixes / docs / defensive CI assertions / a small CLI exit-code correction. CI stays green across all 4 jobs (`macos-bash3`, `ruff`, `mypy`, `shellcheck`).

### 1. `fix(lint_docs)`: always derive PLUGIN_ROOT from `BASH_SOURCE` (`bc46f6b`)

`tools/lint_docs.sh:12` was honoring the harness-exported `LEAN4_PLUGIN_ROOT` env var, which points at a (potentially stale) install cache. The internal lint-bash-compat invocation would then run against the cache, fail with exit 127 (swallowed by `>/dev/null`), and emit a spurious "Bash 3.2 compatibility lint failed" warning even though the working-copy lint passes clean.

Dropped the env fallback; now matches `lint_bash_compat.sh`'s `BASH_SOURCE`-based derivation. Before: 9 lint_docs warnings. After: 6 (only pre-existing line-length / broken-link warnings remain).

### 2. `fix`: lstrip `print(__doc__)` callers (`c5bcddf`)

Scripts with block-form module docstrings (opening `"""` on its own line) were printing a leading blank line on `--help` / no-args output, because `__doc__` starts with `\n` in that style. Affected:
- `parse_command_args.py:32` — argparse-style `--help` path
- `sorry_analyzer.py:451` — no-args usage print

Both now use `(__doc__ or "").lstrip()`. The `or ""` guards the (mostly hypothetical) `__doc__ is None` case under `-OO`.

### 3. `docs`: add `bash` on PATH to scripts README requirements (`d587499`)

After #118 and #121, runtime shell scripts use `#!/usr/bin/env bash` (not `/bin/bash`), so the kernel needs to find `bash` on `PATH`. The Requirements section already mentioned Bash 3.2+ but didn't surface the PATH dependency. NixOS / minimal-container users now have an explicit bullet.

### 4. `ci(lint)`: assert shellcheck reports the pinned 0.10.0 version (`4ae5cd0`)

Follow-up nit from PR #125 review. Adds `shellcheck --version | grep -Fxq 'version: 0.10.0'`. `-F` treats the pattern as a fixed literal string; `-x` requires a full-line match, so neither a future `0.10.0-rc1` nor a `0.10.01` could pass the substring check. Belt-and-suspenders — the previous `Install shellcheck 0.10.0` step already prepends our binary's dir to `GITHUB_PATH`.

### 5. `fix(cli)`: `parse_command_args.py --help` → exit 0 / stdout (`34e3d84`)

Previously the `--help` / `-h` branch was bundled with the no-args fallthrough, so both printed `__doc__` to stderr and exited 1. That treated explicit `--help` as a usage error — surprising in shell pipelines.

Split:
- `--help` / `-h` → print to stdout, return 0
- no args → print to stderr, return 1 (usage error, unchanged)

Suggested as a non-blocking optional cleanup in PR #127 review; folded in.

## Test plan

- [x] `bash plugins/lean4/tools/lint_docs.sh` — no spurious "Bash 3.2 compatibility lint failed" warning; remaining warnings are pre-existing
- [x] `python3 plugins/lean4/lib/scripts/parse_command_args.py --help` — exit 0, stdout, no leading blank
- [x] `python3 plugins/lean4/lib/scripts/parse_command_args.py` (no args) — exit 1, stderr, no leading blank
- [x] `python3 plugins/lean4/lib/scripts/sorry_analyzer.py` — no leading blank
- [x] `lint.yml` YAML parses; `grep -Fxq 'version: 0.10.0'` correctly accepts `0.10.0`, rejects `0.10.0-rc1` and `0.10.01`
- [x] `ruff check plugins/lean4/` — all checks passed
- [x] `ruff format --check plugins/lean4/` — 39 files already formatted
- [x] `mypy --python-version 3.10 --strict lib/ hooks/` — 26 files, no issues
- [x] `shellcheck --shell=bash -x --exclude=SC2016 plugins/lean4/{hooks,lib/scripts,tools}/*.sh` — exit 0
- [x] **CI: all 4 jobs pass on this PR**