### PR TITLE
release: v4.4.10 (portability + lint/CI infrastructure)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Lean 4 theorem proving with guided + autonomous proving, LSP-first workflows, guardrails, and contribution helpers",
-    "version": "4.4.9"
+    "version": "4.4.10"
   },
   "plugins": [
     {

--- a/.github/workflows/bash3-compat.yml
+++ b/.github/workflows/bash3-compat.yml
@@ -18,10 +18,10 @@ jobs:
             || { echo "Expected /bin/bash 3.2, got ${BASH_VERSION}"; exit 1; }'
 
       - name: Static lint — Bash 4+ / BSD-incompat constructs
-        run: /bin/bash plugins/lean4/tools/lint_bash_compat.sh
+        run: /bin/bash plugins/lean4/tools/lint_runtime_portability.sh
 
       - name: Self-test — lint catches all advertised constructs
-        run: /bin/bash plugins/lean4/tests/test_lint_bash_compat.sh
+        run: /bin/bash plugins/lean4/tests/test_lint_runtime_portability.sh
 
       - name: Runtime smoke — cycle_tracker.sh under /bin/bash
         run: /bin/bash plugins/lean4/tests/test_bash3_smoke.sh

--- a/.github/workflows/bash3-compat.yml
+++ b/.github/workflows/bash3-compat.yml
@@ -17,10 +17,10 @@ jobs:
           /bin/bash -c '[[ "${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}" == "3.2" ]] \
             || { echo "Expected /bin/bash 3.2, got ${BASH_VERSION}"; exit 1; }'
 
-      - name: Static lint — Bash 4+ / BSD-incompat constructs
+      - name: Static lint — runtime portability checks
         run: /bin/bash plugins/lean4/tools/lint_runtime_portability.sh
 
-      - name: Self-test — lint catches all advertised constructs
+      - name: Self-test — lint catches all advertised policy violations
         run: /bin/bash plugins/lean4/tests/test_lint_runtime_portability.sh
 
       - name: Runtime smoke — cycle_tracker.sh under /bin/bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## v4.4.10 (May 2026)
+
+Portability hardening, lint/CI infrastructure, and a broad code-quality sweep. No new commands or user-facing behavior changes.
+
+### Portability
+
+- Replace `#!/bin/bash` with `#!/usr/bin/env bash` in runtime scripts so the plugin works on NixOS / minimal containers where `/bin/bash` doesn't exist (#118, FernandoChu)
+- Replace hardcoded `/tmp` with `$TMPDIR` in `cycle_tracker.sh` for macOS / sandboxed-runtime correctness (#112)
+- Document `bash` on `PATH` as an explicit requirement (#127)
+
+### Lint / CI infrastructure
+
+- Add Bash 3.2 compatibility lint for macOS (#107) — later expanded and renamed to `lint_runtime_portability.sh` (this release)
+- Harden shebang policy: exact `#!/usr/bin/env bash` for runtime `.sh`, exact `#!/usr/bin/env python3` for shebanged runtime `.py`, no `plugins/lean4/bin` shortcut bypassing guardrails (#121, #123)
+- Parameterize self-test via `BASH_FOR_COMPAT` so it skips gracefully on `/bin/bash`-less hosts (#121)
+- Add `lint` workflow with ruff (`E,F,W,B,C4,UP,SIM,I,RUF,N`), `ruff format --check`, mypy `--strict`, and shellcheck (#124, #126)
+- Pin tool versions for deterministic CI: ruff 0.15.13, mypy 1.20.2, shellcheck 0.10.0 (#125, #126)
+- Bump GitHub Actions to Node 24 (`checkout@v5`, `setup-python@v6`) ahead of the 2026-06-02 default switch (#126)
+- Tighten `bash3-compat.yml` to hard-assert `/bin/bash` is exactly Bash 3.2 (#121)
+- Rename `lint_bash_compat.sh` → `lint_runtime_portability.sh` to reflect its expanded scope (this release)
+
+### Code cleanup
+
+- Ruff / mypy / shellcheck sweep across `plugins/lean4/` Python and shell — type annotations, modern PEP-585/604 syntax, sorted `__all__`, quoted parameter expansions, dead-store removal, BSD-compatible `find -print0 | xargs -0` (#120, Holger Dell)
+- Normalize executable-script module docstrings to BLOCK form (`"""` on its own line) for a single repo convention (#122)
+- `print(__doc__)` callers use `.lstrip()` to avoid a leading blank line; `parse_command_args.py --help` now exits 0 to stdout instead of 1 to stderr (#127)
+- `lint_docs.sh` always derives `PLUGIN_ROOT` from `BASH_SOURCE` (no longer false-positives a Bash 3.2 failure when the harness cache is stale) (#127)
+
 ## v4.4.9 (April 2026)
 
 - Add shared slash-command parser and `UserPromptSubmit` hook for pre-validation of the six parameter-heavy commands (#103, #106) — Phase 3 of the command invocation fix

--- a/plugins/lean4/.claude-plugin/plugin.json
+++ b/plugins/lean4/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lean4",
-  "version": "4.4.9",
+  "version": "4.4.10",
   "description": "Unified Lean 4 plugin (draft, formalize, autoformalize, prove, autoprove, checkpoint, review, refactor, golf, learn, doctor) — LSP-first, scripts fallback",
   "author": {"name": "Cameron Freer", "email": "cameronfreer@gmail.com"}
 }

--- a/plugins/lean4/tests/test_lint_runtime_portability.sh
+++ b/plugins/lean4/tests/test_lint_runtime_portability.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Self-test for lint_bash_compat.sh — verifies it catches all advertised
+# Self-test for lint_runtime_portability.sh — verifies it catches all advertised
 # Bash 4+ / BSD-incompatible constructs (Checks 1–7), runtime shebang
 # regressions for both shell and Python (Checks 8–9), and the
 # guardrail-bypassing bin/ shortcut path (Check 10) — and does NOT
@@ -27,7 +27,7 @@ if [[ ! -x "$BASH_FOR_COMPAT" ]]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-LINT="$SCRIPT_DIR/../tools/lint_bash_compat.sh"
+LINT="$SCRIPT_DIR/../tools/lint_runtime_portability.sh"
 
 PASS=0
 FAIL=0
@@ -36,7 +36,7 @@ TMPDIR_ROOT=$(mktemp -d)
 trap 'rm -rf "$TMPDIR_ROOT"' EXIT
 
 mkdir -p "$TMPDIR_ROOT/hooks" "$TMPDIR_ROOT/lib/scripts" "$TMPDIR_ROOT/tools"
-cp "$LINT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh"
+cp "$LINT" "$TMPDIR_ROOT/tools/lint_runtime_portability.sh"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -55,7 +55,7 @@ expect_lint_fail() {
   local probe="$TMPDIR_ROOT/lib/scripts/probe.sh"
   printf '#!/usr/bin/env bash\n%s\n' "$body" > "$probe"
   local exit_code=0
-  output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" 2>&1) || exit_code=$?
+  output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_runtime_portability.sh" 2>&1) || exit_code=$?
   if [[ "$exit_code" -eq 1 ]]; then
     echo "  PASS: $desc"
     ((PASS++)) || true
@@ -75,7 +75,7 @@ expect_lint_pass() {
   local probe="$TMPDIR_ROOT/lib/scripts/probe.sh"
   printf '#!/usr/bin/env bash\n%s\n' "$body" > "$probe"
   local exit_code=0
-  output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" 2>&1) || exit_code=$?
+  output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_runtime_portability.sh" 2>&1) || exit_code=$?
   if [[ "$exit_code" -eq 0 ]]; then
     echo "  PASS: $desc"
     ((PASS++)) || true
@@ -174,7 +174,7 @@ coproc mycoproc { cat; }
 echo "${myvar@Q}"
 PROBE
 
-combined_output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" 2>&1 || true)
+combined_output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_runtime_portability.sh" 2>&1 || true)
 # Count warn lines that report actual matches (filename:line:content),
 # excluding the summary line ("⚠️  N issue(s) found...").
 combined_issue_count=$(echo "$combined_output" | grep -c '^⚠️.*:[0-9]\+:' || true)
@@ -204,7 +204,7 @@ expect_shebang_lint_fail() {
   local probe="$TMPDIR_ROOT/lib/scripts/probe.sh"
   printf '%s\n: # no-op\n' "$shebang" > "$probe"
   local exit_code=0
-  output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" 2>&1) || exit_code=$?
+  output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_runtime_portability.sh" 2>&1) || exit_code=$?
   if [[ "$exit_code" -eq 1 ]]; then
     echo "  PASS: $desc"
     ((PASS++)) || true
@@ -264,7 +264,7 @@ expect_py_shebang_lint_fail() {
   local probe="$TMPDIR_ROOT/lib/scripts/probe.py"
   printf '%s\npass\n' "$shebang" > "$probe"
   local exit_code=0
-  output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" 2>&1) || exit_code=$?
+  output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_runtime_portability.sh" 2>&1) || exit_code=$?
   if [[ "$exit_code" -eq 1 ]]; then
     echo "  PASS: $desc"
     ((PASS++)) || true
@@ -281,7 +281,7 @@ expect_py_lint_pass() {
   local probe="$TMPDIR_ROOT/lib/scripts/probe.py"
   printf '%s\n' "$content" > "$probe"
   local exit_code=0
-  output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" 2>&1) || exit_code=$?
+  output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_runtime_portability.sh" 2>&1) || exit_code=$?
   if [[ "$exit_code" -eq 0 ]]; then
     echo "  PASS: $desc"
     ((PASS++)) || true
@@ -328,7 +328,7 @@ expect_bin_lint_fail() {
     *) echo "  FAIL: $desc (internal: unknown kind '$kind')"; ((FAIL++)) || true; return ;;
   esac
   local exit_code=0
-  output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_bash_compat.sh" 2>&1) || exit_code=$?
+  output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_runtime_portability.sh" 2>&1) || exit_code=$?
   if [[ "$exit_code" -eq 1 ]]; then
     echo "  PASS: $desc"
     ((PASS++)) || true

--- a/plugins/lean4/tools/lint_docs.sh
+++ b/plugins/lean4/tools/lint_docs.sh
@@ -12,7 +12,7 @@ VERBOSE="${1:-}"
 # Always derive PLUGIN_ROOT from this script's own location. Honoring
 # LEAN4_PLUGIN_ROOT (the harness-exported install-cache path) caused
 # false-positive failures when the cache was stale, because internal
-# checks like the lint_bash_compat.sh invocation would run against the
+# checks like the lint_runtime_portability.sh invocation would run against the
 # cache instead of the working copy. This is a maintainer dev tool;
 # it should operate on the working tree exclusively.
 PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -1666,10 +1666,10 @@ check_proof_complete_shortcut
 
 log ""
 log "Checking Bash 3.2 compatibility..."
-if bash "$PLUGIN_ROOT/tools/lint_bash_compat.sh" >/dev/null 2>&1; then
+if bash "$PLUGIN_ROOT/tools/lint_runtime_portability.sh" >/dev/null 2>&1; then
     ok "All shell scripts are Bash 3.2 compatible"
 else
-    warn "Bash 3.2 compatibility lint failed — run: bash plugins/lean4/tools/lint_bash_compat.sh"
+    warn "Bash 3.2 compatibility lint failed — run: bash plugins/lean4/tools/lint_runtime_portability.sh"
 fi
 
 log ""

--- a/plugins/lean4/tools/lint_docs.sh
+++ b/plugins/lean4/tools/lint_docs.sh
@@ -1665,11 +1665,11 @@ check_command_invocation_contract
 check_proof_complete_shortcut
 
 log ""
-log "Checking Bash 3.2 compatibility..."
+log "Checking runtime portability lint..."
 if bash "$PLUGIN_ROOT/tools/lint_runtime_portability.sh" >/dev/null 2>&1; then
-    ok "All shell scripts are Bash 3.2 compatible"
+    ok "Runtime portability lint passed"
 else
-    warn "Bash 3.2 compatibility lint failed — run: bash plugins/lean4/tools/lint_runtime_portability.sh"
+    warn "Runtime portability lint failed — run: bash plugins/lean4/tools/lint_runtime_portability.sh"
 fi
 
 log ""

--- a/plugins/lean4/tools/lint_runtime_portability.sh
+++ b/plugins/lean4/tools/lint_runtime_portability.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 # ---------------------------------------------------------------------------
-# Bash 3.2 Compatibility Lint
+# Runtime Portability Lint
 # ---------------------------------------------------------------------------
-# Scans all .sh files in the plugin runtime path (hooks/ and lib/scripts/)
-# for Bash 4+ constructs that break on macOS's default /bin/bash 3.2.
+# Scans .sh and .py files in the plugin runtime path (hooks/ and
+# lib/scripts/) for portability issues across three policies:
 #
-# Policy: every .sh file in hooks/ and lib/scripts/ must run on Bash 3.2.
+#   * Bash 3.2 compatibility (Checks 1-7) — Bash 4+ / BSD-incompatible
+#     constructs that break on macOS's default /bin/bash 3.2
+#   * Shebang portability (Checks 8-9) — env-based shebangs only,
+#     no absolute paths or polyglot trampolines
+#   * Path structure (Check 10) — no shortcut paths that bypass
+#     guardrail detectors
+#
+# Bash 3.2 policy: every .sh file in hooks/ and lib/scripts/ must run on Bash 3.2.
 # If a script genuinely requires Bash 4+, it must say so in its shebang
 # (e.g. #!/opt/homebrew/bin/bash) and NOT be called from the plugin
 # runtime path.
@@ -32,7 +39,7 @@
 # silently bypassing the safety check. Reintroduce only with a matching
 # guardrail update.
 #
-# Run:  bash plugins/lean4/tools/lint_bash_compat.sh
+# Run:  bash plugins/lean4/tools/lint_runtime_portability.sh
 # ---------------------------------------------------------------------------
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

Final PR in the portability / lint-tooling series. Two commits:

1. **`refactor(lint)`** (`276c4f3`) — Rename `lint_bash_compat.sh` → `lint_runtime_portability.sh` (and `test_lint_bash_compat.sh` → `test_lint_runtime_portability.sh`). The file's role expanded across PRs #121 and #123 from "Bash 3.2 compatibility" alone to a broader runtime-portability lint covering shebang policy (Checks 8–9) and structural path policy (Check 10). Updates 12 references across 4 files; header retitled.

2. **`chore`** (`fd6f0e5`) — Bump version 4.4.9 → 4.4.10 (`plugin.json` + `marketplace.json`) and add a CHANGELOG entry summarizing everything since v4.4.9: PRs #107, #112, #118, #120, #121, #122, #123, #124, #125, #126, #127 plus this release's rename.

No new commands or user-facing behavior changes. The whole release is maintainer tooling, runtime portability, and code cleanup.

## What's in v4.4.10 (changelog preview)

### Portability
- Replace `#!/bin/bash` with `#!/usr/bin/env bash` in runtime scripts (#118)
- Replace hardcoded `/tmp` with `$TMPDIR` in `cycle_tracker.sh` (#112)
- Document `bash` on `PATH` requirement (#127)

### Lint / CI infrastructure
- Add Bash 3.2 compatibility lint (#107) → expanded + renamed to `lint_runtime_portability.sh` (this release)
- Harden shebang policy: exact `#!/usr/bin/env bash` + `#!/usr/bin/env python3`; no `bin/` shortcut (#121, #123)
- Parameterize self-test via `BASH_FOR_COMPAT` (#121)
- Add `lint` workflow (ruff E,F,W,B,C4,UP,SIM,I,RUF,N + format check + mypy --strict + shellcheck) (#124, #126)
- Pin tool versions: ruff 0.15.13, mypy 1.20.2, shellcheck 0.10.0 (#125, #126)
- Bump GitHub Actions to Node 24 (#126)
- Hard-assert `/bin/bash` is exactly 3.2 (#121)

### Code cleanup
- Ruff/mypy/shellcheck sweep (#120, Holger Dell)
- BLOCK-form module docstrings normalized (#122)
- `print(__doc__)` lstrip + `parse_command_args.py --help` → exit 0 / stdout (#127)
- `lint_docs.sh` no longer false-positives on Bash 3.2 (#127)

## Test plan

- [x] All test suites green after rename:
  - `lint_runtime_portability.sh`: 9 shell + 12 Python runtime files pass
  - `test_lint_runtime_portability.sh`: 55/55
  - `test_bash3_smoke.sh`: 14/14
  - `lint_docs.sh`: no Bash 3.2 false-positive (3 pre-existing warnings remain)
- [x] No stray `lint_bash_compat` references anywhere in the repo
- [x] `git mv` detected both file moves as renames (94% similarity each), preserving blame
- [x] `ruff check`, `ruff format --check`, `shellcheck` — all clean
- [x] `plugin.json` and `marketplace.json` still parse as valid JSON
- [x] CI: all 4 jobs pass on this PR (`bash3-compat` + `lint` workflow with 3 sub-jobs all green on fd6f0e5) (`macos-bash3`, `ruff`, `mypy`, `shellcheck`)