### PR TITLE
feat(bin): prefixed wrappers for model-facing scripts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Lean 4 theorem proving with guided + autonomous proving, LSP-first workflows, guardrails, and contribution helpers",
-    "version": "4.5.0"
+    "version": "4.5.1"
   },
   "plugins": [
     {

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -93,7 +93,7 @@ jobs:
         # --shell=bash forces bash dialect; -x follows `source` references;
         # SC2016 (expressions in single quotes) is excluded because several
         # scripts use single-quoted regex literals intentionally.
-        # The bin/lean4-skills-* wrappers (added in #129) are extensionless
+        # The bin/lean4-skills-* wrappers (added in #130, for #117) are extensionless
         # bash scripts, included explicitly so shellcheck covers them too.
         run: |
           shellcheck --shell=bash -x --exclude=SC2016 \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -88,13 +88,16 @@ jobs:
           shellcheck --version
           shellcheck --version | grep -Fxq 'version: 0.10.0'
 
-      - name: shellcheck (hooks/, lib/scripts/, tools/)
+      - name: shellcheck (hooks/, lib/scripts/, tools/, bin/lean4-skills-*)
         # Flags match the invocation Holger validated against in PR #120:
         # --shell=bash forces bash dialect; -x follows `source` references;
         # SC2016 (expressions in single quotes) is excluded because several
         # scripts use single-quoted regex literals intentionally.
+        # The bin/lean4-skills-* wrappers (added in #129) are extensionless
+        # bash scripts, included explicitly so shellcheck covers them too.
         run: |
           shellcheck --shell=bash -x --exclude=SC2016 \
             plugins/lean4/hooks/*.sh \
             plugins/lean4/lib/scripts/*.sh \
-            plugins/lean4/tools/*.sh
+            plugins/lean4/tools/*.sh \
+            plugins/lean4/bin/lean4-skills-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## v4.5.1 (June 2026)
+
+Adds prefixed `bin/` wrappers for model-facing scripts (closes #117). Claude Code's plugin loader appends `plugins/lean4/bin/` to the Bash tool's `PATH`, so wrappers like `lean4-skills-cycle-tracker` resolve as bare commands and become statically allowlistable as `Bash(lean4-skills-cycle-tracker:*)` — eliminating the per-invocation permission prompts that issue #117 reported on every `$LEAN4_SCRIPTS/...` call.
+
+### `bin/` wrappers (model-facing, curated)
+
+- 9 new executables under `plugins/lean4/bin/`, each a thin Bash wrapper resolving `PLUGIN_ROOT` via `BASH_SOURCE` and delegating to `lib/scripts/<script>`:
+  - `lean4-skills-cycle-tracker` (autoprove hot path — mandatory)
+  - `lean4-skills-sorry-analyzer`, `lean4-skills-find-golfable`, `lean4-skills-find-exact-candidates`, `lean4-skills-analyze-let-usage`
+  - `lean4-skills-check-axioms-inline`
+  - `lean4-skills-find-usages`, `lean4-skills-search-mathlib`, `lean4-skills-smart-search`
+- Bootstrap hook adds `plugins/lean4/bin/` to the Bash tool's `PATH` so wrappers resolve bare; non-Claude hosts can mirror via `export PATH="$LEAN4_BIN:$PATH"` (`INSTALLATION.md` documents both).
+- Internal helpers (`parse_command_args.py`, `parse_lean_errors.py`, `solver_cascade.py`, test fixtures, etc.) intentionally stay unwrapped — wrappers are a curated public surface, not a CLI for every script.
+
+### Guardrails & lint
+
+- `hooks/guardrails.sh`'s Lean-script stderr-suppression detector recognizes wrapper invocations in all four call forms (bare, `bin/...`, `./bin/...`, full-path).
+- `tools/lint_runtime_portability.sh` Check 10 enforces shape on `bin/` contents: only `lean4-skills-*` regular executables, no symlinks, no non-prefixed files. Checks 1–8 (Bash 3.2 portability, exact shebang) extended to scan the wrappers as runtime targets.
+- `tools/test_contracts.sh` Check 26 asserts every wrapper is referenced by at least one model-facing doc surface; Check 27 (new) asserts no stale `$LEAN4_SCRIPTS/<wrapped-script>` examples remain outside marked compatibility-fallback regions.
+- `.github/workflows/lint.yml` extends shellcheck scope to `bin/lean4-skills-*`.
+
+### Docs
+
+- Model-facing references (`subagent-workflows`, `axiom-elimination`, `compiler-guided-repair`, `command-examples`, `agent-workflows`) updated to invoke wrappers directly.
+- `INSTALLATION.md` rewritten to show wrapper-first usage; legacy `$LEAN4_SCRIPTS/...` form kept only for intentionally-unwrapped scripts.
+- `commands/doctor.md` lists the `bin/` directory and recommends `command -v lean4-skills-*` as the wrapper-first check.
+
 ## v4.5.0 (June 2026)
 
 Add `/lean4:disprove`, an always-interactive command for **certified counterexample search**. It reports `REFUTED` **only** when Lean typechecks a proof of the negation under `lake env lean` (no `sorry`/`admit`) with its axioms inside an explicit whitelist; otherwise `WITNESS_UNCERTIFIED` (candidate found, gate rejected) or `INCONCLUSIVE` (no candidate within budgets). New command (the 7th parameter-heavy command); existing workflows are unaffected. **Requires Python 3.11+** for the method-registry loader (`tomllib`); the rest of the plugin remains 3.10+.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -2,13 +2,25 @@
 
 ## Environment Bootstrap (All Hosts)
 
-All hosts need these three variables. Claude Code sets them automatically via its
-bootstrap hook. Other hosts set them manually in shell profile or agent config.
+All hosts need these variables. Claude Code sets them automatically via its
+bootstrap hook and also adds `plugins/lean4/bin/` to the Bash tool's PATH so
+model-facing `lean4-skills-*` wrappers resolve as bare commands. Other hosts
+(Codex, Gemini, Cursor, OpenCode, generic) need to set everything manually,
+including the PATH export — without it, the model may invoke
+`lean4-skills-sorry-analyzer …` and the shell won't find the wrapper.
 
 ```bash
 export LEAN4_PLUGIN_ROOT=/path/to/lean4-skills/plugins/lean4
 export LEAN4_SCRIPTS=$LEAN4_PLUGIN_ROOT/lib/scripts
 export LEAN4_REFS=$LEAN4_PLUGIN_ROOT/skills/lean4/references
+export PATH="$LEAN4_PLUGIN_ROOT/bin:$PATH"   # so `lean4-skills-*` wrappers resolve
+```
+
+Verify the wrappers are on PATH:
+
+```bash
+command -v lean4-skills-sorry-analyzer
+# expected: /…/plugins/lean4/bin/lean4-skills-sorry-analyzer
 ```
 
 ## Claude Code (Native Plugin)
@@ -77,6 +89,7 @@ Set env vars in your shell profile (replace `/path/to` with your actual clone lo
 export LEAN4_PLUGIN_ROOT=/path/to/lean4-skills/plugins/lean4
 export LEAN4_SCRIPTS=$LEAN4_PLUGIN_ROOT/lib/scripts
 export LEAN4_REFS=$LEAN4_PLUGIN_ROOT/skills/lean4/references
+export PATH="$LEAN4_PLUGIN_ROOT/bin:$PATH"   # so `lean4-skills-*` wrappers resolve
 ```
 
 Add to your project's `AGENTS.md` (model context — not shell env):
@@ -108,7 +121,7 @@ the exact commands — examples:
 
 ```bash
 echo "$LEAN4_SCRIPTS"
-python3 "$LEAN4_SCRIPTS/sorry_analyzer.py" . --format=summary --report-only
+lean4-skills-sorry-analyzer . --format=summary --report-only
 # If MCP configured: test lean_goal on a .lean file
 ```
 
@@ -137,13 +150,14 @@ Set env vars in your shell profile:
 export LEAN4_PLUGIN_ROOT=/path/to/lean4-skills/plugins/lean4
 export LEAN4_SCRIPTS=$LEAN4_PLUGIN_ROOT/lib/scripts
 export LEAN4_REFS=$LEAN4_PLUGIN_ROOT/skills/lean4/references
+export PATH="$LEAN4_PLUGIN_ROOT/bin:$PATH"   # so `lean4-skills-*` wrappers resolve
 ```
 
 ### Verify
 
 ```bash
 echo "$LEAN4_SCRIPTS"
-python3 "$LEAN4_SCRIPTS/sorry_analyzer.py" . --format=summary --report-only
+lean4-skills-sorry-analyzer . --format=summary --report-only
 ```
 
 ## Cursor
@@ -169,7 +183,7 @@ Set env vars in your terminal profile (Cursor runs commands in your shell).
 Open a `.lean` file, ask the agent to run:
 
 ```bash
-python3 "$LEAN4_SCRIPTS/sorry_analyzer.py" . --format=summary --report-only
+lean4-skills-sorry-analyzer . --format=summary --report-only
 ```
 
 ## Windsurf
@@ -208,6 +222,7 @@ Set env vars in your shell profile:
 export LEAN4_PLUGIN_ROOT=/path/to/lean4-skills/plugins/lean4
 export LEAN4_SCRIPTS=$LEAN4_PLUGIN_ROOT/lib/scripts
 export LEAN4_REFS=$LEAN4_PLUGIN_ROOT/skills/lean4/references
+export PATH="$LEAN4_PLUGIN_ROOT/bin:$PATH"   # so `lean4-skills-*` wrappers resolve
 ```
 
 OpenCode supports MCP servers — see [OpenCode docs](https://opencode.ai/docs/)
@@ -217,7 +232,7 @@ for current MCP setup commands.
 
 ```bash
 echo "$LEAN4_SCRIPTS"
-python3 "$LEAN4_SCRIPTS/sorry_analyzer.py" . --format=summary --report-only
+lean4-skills-sorry-analyzer . --format=summary --report-only
 ```
 
 ## Any Agent (Generic)
@@ -229,7 +244,7 @@ Any LLM coding agent that can read markdown and run shell commands can use this 
 3. Point your agent at `plugins/lean4/skills/lean4/SKILL.md` as system context
 4. Scripts work standalone — no adapter needed:
    ```bash
-   python3 "$LEAN4_SCRIPTS/sorry_analyzer.py" . --format=summary --report-only
+   lean4-skills-sorry-analyzer . --format=summary --report-only
    bash "$LEAN4_SCRIPTS/check_axioms_inline.sh" path/to/YourFile.lean --report-only
    bash "$LEAN4_SCRIPTS/search_mathlib.sh" "continuous" name
    ```
@@ -262,7 +277,7 @@ Copy-Item -Recurse "path\to\lean4-skills\plugins\lean4\skills\lean4" .agents\ski
 ```bash
 echo "$LEAN4_SCRIPTS"
 ls "$LEAN4_SCRIPTS/sorry_analyzer.py"
-python3 "$LEAN4_SCRIPTS/sorry_analyzer.py" . --format=summary --report-only
+lean4-skills-sorry-analyzer . --format=summary --report-only
 ```
 
 ## Lean LSP MCP Server (All Hosts)

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -77,6 +77,17 @@ The `LEAN4_SCRIPTS` etc. variables are set by the bootstrap hook. If missing:
 
 #### Scripts Not Executable
 
+The `lean4-skills-*` wrappers under `$LEAN4_PLUGIN_ROOT/bin/` are shipped
+executable. Confirm with:
+
+```bash
+command -v lean4-skills-sorry-analyzer
+```
+
+If you invoke the unwrapped internals under `$LEAN4_SCRIPTS/` directly
+(e.g. test fixtures, internal helpers), and a fresh clone left them
+non-executable:
+
 ```bash
 chmod +x $LEAN4_SCRIPTS/*.sh $LEAN4_SCRIPTS/*.py
 ```
@@ -240,13 +251,13 @@ lean4-skills-sorry-analyzer . --format=summary --report-only
 Any LLM coding agent that can read markdown and run shell commands can use this pack:
 
 1. Clone the repo
-2. Set the three env vars (see [Environment Bootstrap](#environment-bootstrap-all-hosts) above)
+2. Set the four env vars (see [Environment Bootstrap](#environment-bootstrap-all-hosts) above) — including `PATH` so the `lean4-skills-*` wrappers resolve as bare commands
 3. Point your agent at `plugins/lean4/skills/lean4/SKILL.md` as system context
 4. Scripts work standalone — no adapter needed:
    ```bash
    lean4-skills-sorry-analyzer . --format=summary --report-only
-   bash "$LEAN4_SCRIPTS/check_axioms_inline.sh" path/to/YourFile.lean --report-only
-   bash "$LEAN4_SCRIPTS/search_mathlib.sh" "continuous" name
+   lean4-skills-check-axioms-inline path/to/YourFile.lean --report-only
+   lean4-skills-search-mathlib "continuous" name
    ```
 5. If your agent supports MCP, add lean-lsp-mcp for faster mathlib search and sub-second feedback
 
@@ -275,8 +286,8 @@ Copy-Item -Recurse "path\to\lean4-skills\plugins\lean4\skills\lean4" .agents\ski
 ### Verify
 
 ```bash
-echo "$LEAN4_SCRIPTS"
-ls "$LEAN4_SCRIPTS/sorry_analyzer.py"
+echo "$LEAN4_SCRIPTS"                        # bootstrap set the env var
+command -v lean4-skills-sorry-analyzer        # wrapper resolves on PATH
 lean4-skills-sorry-analyzer . --format=summary --report-only
 ```
 

--- a/plugins/lean4/.claude-plugin/plugin.json
+++ b/plugins/lean4/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lean4",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "Unified Lean 4 plugin (draft, formalize, autoformalize, prove, autoprove, disprove, checkpoint, review, refactor, golf, learn, doctor) — LSP-first, scripts fallback",
   "author": {"name": "Cameron Freer", "email": "cameronfreer@gmail.com"}
 }

--- a/plugins/lean4/README.md
+++ b/plugins/lean4/README.md
@@ -299,9 +299,9 @@ Optional user overrides (not set by bootstrap):
 
 **Script troubleshooting:**
 ```bash
-echo "$LEAN4_SCRIPTS"
-ls -l "$LEAN4_SCRIPTS/sorry_analyzer.py"
-${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/sorry_analyzer.py" . --format=summary --report-only
+echo "$LEAN4_SCRIPTS"                       # bootstrap set the env var
+command -v lean4-skills-sorry-analyzer       # wrapper resolves on PATH
+lean4-skills-sorry-analyzer . --format=summary --report-only
 ```
 
 If `$LEAN4_SCRIPTS` is unset, run `/lean4:doctor` to reinitialize.

--- a/plugins/lean4/agents/axiom-eliminator.md
+++ b/plugins/lean4/agents/axiom-eliminator.md
@@ -15,12 +15,12 @@ model: opus
 
 1. **Audit current state**:
    - Start with `lean_diagnostic_messages(file)` on the target file(s) before broader verification
-   - Use `bash $LEAN4_SCRIPTS/check_axioms_inline.sh FILE.lean` (or `.` for project-wide audit) to measure current axiom state
-   - Use `bash $LEAN4_SCRIPTS/find_usages.sh axiom_name` for dependency inventory
+   - Use `lean4-skills-check-axioms-inline FILE.lean` (or `.` for project-wide audit) to measure current axiom state
+   - Use `lean4-skills-find-usages axiom_name` for dependency inventory
 
    > **MCP canary:** If `lean_diagnostic_messages` is missing from context (tool not
    > listed), emit "⚠ Lean MCP tools unavailable in this subagent context" and fall
-   > back immediately to `$LEAN4_SCRIPTS/check_axioms_inline.sh` and `lake build` for
+   > back immediately to `lean4-skills-check-axioms-inline` and `lake build` for
    > validation. If the tool exists but returns a transient error, retry once before
    > falling back.
    >
@@ -92,7 +92,7 @@ Total: ~2000-3000 tokens per batch
 
 ---
 
-Searching: bash $LEAN4_SCRIPTS/search_mathlib.sh "helper" name
+Searching: lean4-skills-search-mathlib "helper" name
 Found: Mathlib.Foo.helper_lemma
 
 ## Axiom Eliminated: helper_lemma
@@ -111,10 +111,10 @@ lean_local_search("keyword")
 lean_loogle("type pattern")
 lean_run_code("code")
 # Script fallback:
-$LEAN4_SCRIPTS/check_axioms_inline.sh
-$LEAN4_SCRIPTS/find_usages.sh
-$LEAN4_SCRIPTS/search_mathlib.sh
-$LEAN4_SCRIPTS/smart_search.sh
+lean4-skills-check-axioms-inline
+lean4-skills-find-usages
+lean4-skills-search-mathlib
+lean4-skills-smart-search
 lake build
 ```
 

--- a/plugins/lean4/agents/proof-golfer.md
+++ b/plugins/lean4/agents/proof-golfer.md
@@ -17,16 +17,16 @@ model: opus
 
 1. **Find patterns** (in policy order: directness → structural → conditional) with false-positive filtering:
    ```bash
-   ${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/find_golfable.py" FILE.lean --filter-false-positives
+   lean4-skills-find-golfable FILE.lean --filter-false-positives
    ```
    For direct-proof discovery when search_mode ≠ off or syntactic pass stalls:
    ```bash
-   ${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/find_exact_candidates.py" FILE.lean
+   lean4-skills-find-exact-candidates FILE.lean
    ```
 
 2. **Verify safety** before inlining any binding:
    ```bash
-   ${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/analyze_let_usage.py" FILE.lean --line LINE
+   lean4-skills-analyze-let-usage FILE.lean --line LINE
    ```
    - 1-2 uses: Safe to inline
    - 3-4 uses: Check carefully (40% worth optimizing)
@@ -119,7 +119,7 @@ Pattern found at line 45:
   let x := expr
   exact property x
 
-Running: ${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/analyze_let_usage.py" --line 45
+Running: lean4-skills-analyze-let-usage --line 45
 Result: x used 1 time → Safe
 
 Before (2 lines):
@@ -147,8 +147,8 @@ lean_diagnostic_messages(file)         # Per-edit validation
 
 **Scripts:**
 ```bash
-${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/find_golfable.py"       # Pattern detection
-${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/analyze_let_usage.py"  # Safety verification (CRITICAL)
+lean4-skills-find-golfable       # Pattern detection
+lean4-skills-analyze-let-usage  # Safety verification (CRITICAL)
 lake build                              # Final verification
 ```
 

--- a/plugins/lean4/agents/proof-repair.md
+++ b/plugins/lean4/agents/proof-repair.md
@@ -107,7 +107,8 @@ lean_run_code("code")               # Isolated scratch experiments
 ```
 
 **Script fallback** (only when LSP is unavailable, rate-limited, or inconclusive after bounded attempts):
-```lean4-skills-search-mathlib    # Search by pattern
+```bash
+lean4-skills-search-mathlib    # Search by pattern
 lean4-skills-smart-search      # Multi-source
 ```
 

--- a/plugins/lean4/agents/proof-repair.md
+++ b/plugins/lean4/agents/proof-repair.md
@@ -32,7 +32,7 @@ Structured error context (JSON):
 2. **Apply error-specific strategy** (see table below)
 3. **Search** if needed (LSP-first; fall back to scripts only when LSP is unavailable, rate-limited, or inconclusive after bounded attempts):
    - `lean_leanfinder("query")` or `lean_local_search("keyword")` first
-   - Script fallback: `$LEAN4_SCRIPTS/search_mathlib.sh` only after LSP exhausted
+   - Script fallback: `lean4-skills-search-mathlib` only after LSP exhausted
 4. **Generate minimal diff** (1-5 lines)
 5. **Output unified diff ONLY** - no explanations
 
@@ -107,9 +107,8 @@ lean_run_code("code")               # Isolated scratch experiments
 ```
 
 **Script fallback** (only when LSP is unavailable, rate-limited, or inconclusive after bounded attempts):
-```bash
-$LEAN4_SCRIPTS/search_mathlib.sh    # Search by pattern
-$LEAN4_SCRIPTS/smart_search.sh      # Multi-source
+```lean4-skills-search-mathlib    # Search by pattern
+lean4-skills-smart-search      # Multi-source
 ```
 
 ## See Also

--- a/plugins/lean4/agents/sorry-filler-deep.md
+++ b/plugins/lean4/agents/sorry-filler-deep.md
@@ -112,11 +112,10 @@ lean_run_code("code")               # Isolated scratch experiments
 ```
 
 **Scripts:**
-```bash
-$LEAN4_SCRIPTS/sorry_analyzer.py       # Context analysis
-$LEAN4_SCRIPTS/check_axioms_inline.sh  # Verify no axioms
-$LEAN4_SCRIPTS/find_usages.sh          # Dependency analysis
-$LEAN4_SCRIPTS/smart_search.sh         # Search fallback (after bounded LSP pass)
+```lean4-skills-sorry-analyzer       # Context analysis
+lean4-skills-check-axioms-inline  # Verify no axioms
+lean4-skills-find-usages          # Dependency analysis
+lean4-skills-smart-search         # Search fallback (after bounded LSP pass)
 lake env lean path/to/File.lean         # File gate (project root, after LSP checks)
 lake build                              # Project gate / final verification only
 ```

--- a/plugins/lean4/agents/sorry-filler-deep.md
+++ b/plugins/lean4/agents/sorry-filler-deep.md
@@ -112,7 +112,8 @@ lean_run_code("code")               # Isolated scratch experiments
 ```
 
 **Scripts:**
-```lean4-skills-sorry-analyzer       # Context analysis
+```bash
+lean4-skills-sorry-analyzer       # Context analysis
 lean4-skills-check-axioms-inline  # Verify no axioms
 lean4-skills-find-usages          # Dependency analysis
 lean4-skills-smart-search         # Search fallback (after bounded LSP pass)

--- a/plugins/lean4/bin/lean4-skills-analyze-let-usage
+++ b/plugins/lean4/bin/lean4-skills-analyze-let-usage
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lean4-skills-analyze-let-usage — model-facing wrapper around lib/scripts/analyze_let_usage.py.
+# See lean4-skills-cycle-tracker for the rationale.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+exec "${LEAN4_PYTHON_BIN:-python3}" "$PLUGIN_ROOT/lib/scripts/analyze_let_usage.py" "$@"

--- a/plugins/lean4/bin/lean4-skills-check-axioms-inline
+++ b/plugins/lean4/bin/lean4-skills-check-axioms-inline
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lean4-skills-check-axioms-inline — model-facing wrapper around lib/scripts/check_axioms_inline.sh.
+# See lean4-skills-cycle-tracker for the rationale.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+exec bash "$PLUGIN_ROOT/lib/scripts/check_axioms_inline.sh" "$@"

--- a/plugins/lean4/bin/lean4-skills-cycle-tracker
+++ b/plugins/lean4/bin/lean4-skills-cycle-tracker
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# lean4-skills-cycle-tracker — model-facing wrapper around lib/scripts/cycle_tracker.sh.
+# Lives in plugins/lean4/bin/ so Claude Code's auto-PATH allowlists it
+# statically as Bash(lean4-skills-cycle-tracker:*) without needing
+# $LEAN4_SCRIPTS env-var resolution. See issue #117.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+exec bash "$PLUGIN_ROOT/lib/scripts/cycle_tracker.sh" "$@"

--- a/plugins/lean4/bin/lean4-skills-find-exact-candidates
+++ b/plugins/lean4/bin/lean4-skills-find-exact-candidates
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lean4-skills-find-exact-candidates — model-facing wrapper around lib/scripts/find_exact_candidates.py.
+# See lean4-skills-cycle-tracker for the rationale.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+exec "${LEAN4_PYTHON_BIN:-python3}" "$PLUGIN_ROOT/lib/scripts/find_exact_candidates.py" "$@"

--- a/plugins/lean4/bin/lean4-skills-find-golfable
+++ b/plugins/lean4/bin/lean4-skills-find-golfable
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lean4-skills-find-golfable — model-facing wrapper around lib/scripts/find_golfable.py.
+# See lean4-skills-cycle-tracker for the rationale.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+exec "${LEAN4_PYTHON_BIN:-python3}" "$PLUGIN_ROOT/lib/scripts/find_golfable.py" "$@"

--- a/plugins/lean4/bin/lean4-skills-find-usages
+++ b/plugins/lean4/bin/lean4-skills-find-usages
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lean4-skills-find-usages — model-facing wrapper around lib/scripts/find_usages.sh.
+# See lean4-skills-cycle-tracker for the rationale.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+exec bash "$PLUGIN_ROOT/lib/scripts/find_usages.sh" "$@"

--- a/plugins/lean4/bin/lean4-skills-search-mathlib
+++ b/plugins/lean4/bin/lean4-skills-search-mathlib
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lean4-skills-search-mathlib — model-facing wrapper around lib/scripts/search_mathlib.sh.
+# See lean4-skills-cycle-tracker for the rationale.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+exec bash "$PLUGIN_ROOT/lib/scripts/search_mathlib.sh" "$@"

--- a/plugins/lean4/bin/lean4-skills-smart-search
+++ b/plugins/lean4/bin/lean4-skills-smart-search
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lean4-skills-smart-search — model-facing wrapper around lib/scripts/smart_search.sh.
+# See lean4-skills-cycle-tracker for the rationale.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+exec bash "$PLUGIN_ROOT/lib/scripts/smart_search.sh" "$@"

--- a/plugins/lean4/bin/lean4-skills-sorry-analyzer
+++ b/plugins/lean4/bin/lean4-skills-sorry-analyzer
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lean4-skills-sorry-analyzer — model-facing wrapper around lib/scripts/sorry_analyzer.py.
+# See lean4-skills-cycle-tracker for the rationale.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+exec "${LEAN4_PYTHON_BIN:-python3}" "$PLUGIN_ROOT/lib/scripts/sorry_analyzer.py" "$@"

--- a/plugins/lean4/commands/autoformalize.md
+++ b/plugins/lean4/commands/autoformalize.md
@@ -38,7 +38,7 @@ Startup requirements:
 1. Emit a **Resolved Inputs** block with explicit values, defaults, coercions,
    ignored flags, and startup validation errors.
 2. Refuse to start on startup validation errors.
-3. Call `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" init` with resolved numeric
+3. Call `lean4-skills-cycle-tracker init` with resolved numeric
    values for `--max-cycles`, `--max-stuck-cycles`, `--max-total-runtime`,
    and `--max-deep-per-cycle`.
    A failed init (exit 2) is a startup validation error — do not proceed.
@@ -98,15 +98,15 @@ Summary:
 
 ## Stop Conditions
 
-Autoformalize checks stop budgets at cycle boundaries via `$LEAN4_SCRIPTS/cycle_tracker.sh tick --stuck=yes|no`.
+Autoformalize checks stop budgets at cycle boundaries via `lean4-skills-cycle-tracker tick --stuck=yes|no`.
 Limits are checked at cycle boundaries only — a long-running tool call within a cycle
 will not be interrupted.
 
 Autoformalize stops when the **first** of these is satisfied:
 
 1. **Queue empty** — all claims attempted (expected completion)
-2. **Max stuck cycles** — `--max-stuck-cycles` consecutive stuck cycles on current claim. Session-enforced via `$LEAN4_SCRIPTS/cycle_tracker.sh`.
-3. **Max cycles** — `--max-cycles` total cycles reached on current claim. Session-enforced via `$LEAN4_SCRIPTS/cycle_tracker.sh`.
+2. **Max stuck cycles** — `--max-stuck-cycles` consecutive stuck cycles on current claim. Session-enforced via `lean4-skills-cycle-tracker`.
+3. **Max cycles** — `--max-cycles` total cycles reached on current claim. Session-enforced via `lean4-skills-cycle-tracker`.
 4. **Max runtime** — best-effort wall-clock budget reached (`--max-total-runtime`). Checked at cycle boundaries and deep preflight.
 5. **Manual user stop** — user interrupts
 

--- a/plugins/lean4/commands/autoprove.md
+++ b/plugins/lean4/commands/autoprove.md
@@ -39,7 +39,7 @@ Startup requirements:
 1. Emit a **Resolved Inputs** block with explicit values, defaults, coercions,
    ignored flags, and startup validation errors.
 2. Refuse to start on startup validation errors.
-3. Call `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" init` with resolved numeric
+3. Call `lean4-skills-cycle-tracker init` with resolved numeric
    values for `--max-cycles`, `--max-stuck-cycles`, `--max-total-runtime`,
    `--max-deep-per-cycle`, and `--max-consecutive-deep-cycles`.
    A failed init (exit 2) is a startup validation error — do not proceed.
@@ -178,15 +178,15 @@ The inner 6-phase cycle is unchanged. The outer loop reads the stuck-mode `next_
 
 ## Stop Conditions
 
-Autoprove checks stop budgets at cycle boundaries via `$LEAN4_SCRIPTS/cycle_tracker.sh tick --stuck=yes|no`.
+Autoprove checks stop budgets at cycle boundaries via `lean4-skills-cycle-tracker tick --stuck=yes|no`.
 Limits are checked at cycle boundaries only — a long-running tool call within a cycle
 will not be interrupted.
 
 Autoprove stops when the **first** of these is satisfied:
 
 1. **Completion** — all sorries in scope are filled
-2. **Max stuck cycles** — `--max-stuck-cycles` consecutive stuck cycles (default: 3). Session-enforced via `$LEAN4_SCRIPTS/cycle_tracker.sh`.
-3. **Max cycles** — `--max-cycles` total cycles reached (default: 20). Session-enforced via `$LEAN4_SCRIPTS/cycle_tracker.sh`.
+2. **Max stuck cycles** — `--max-stuck-cycles` consecutive stuck cycles (default: 3). Session-enforced via `lean4-skills-cycle-tracker`.
+3. **Max cycles** — `--max-cycles` total cycles reached (default: 20). Session-enforced via `lean4-skills-cycle-tracker`.
 4. **Max runtime** — best-effort wall-clock budget reached (`--max-total-runtime`, default: 120m). Checked at cycle boundaries and deep preflight.
 5. **Manual user stop** — user interrupts
 6. **Queue empty** — all claims attempted; expected completion for `--formalize=auto` sessions

--- a/plugins/lean4/commands/checkpoint.md
+++ b/plugins/lean4/commands/checkpoint.md
@@ -31,12 +31,12 @@ Creates a checkpoint with per-file and project-wide build verification, axiom ch
 2. **Verify Build** - Run `lake build` for the project-wide gate (catches cross-file issues not visible in per-file compilation)
 3. **Best-effort Axiom Scan** - Scan for non-standard axioms in top-level declarations:
    ```bash
-   bash "$LEAN4_SCRIPTS/check_axioms_inline.sh" .
+   lean4-skills-check-axioms-inline .
    ```
    Note: checks top-level unindented declarations in the first namespace of each file. Nested namespaces, sections, and indented declarations may not be checked. The script temporarily edits files in place while running — only use on version-controlled files, and avoid concurrent editors or watchers.
 4. **Count Sorries** - Report current sorry count:
    ```bash
-   ${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/sorry_analyzer.py" . --format=summary
+   lean4-skills-sorry-analyzer . --format=summary
    ```
 5. **Stage and Commit** - Stage only files touched during this session, then commit:
    ```bash

--- a/plugins/lean4/commands/disprove.md
+++ b/plugins/lean4/commands/disprove.md
@@ -68,7 +68,7 @@ Startup requirements:
 1. Emit a **Resolved Inputs** block with explicit values, defaults,
    coercions, ignored flags, and startup validation errors.
 2. Refuse to start on startup validation errors.
-3. Call `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" init` with resolved
+3. Call `lean4-skills-cycle-tracker init` with resolved
    numeric values for `--max-cycles`, `--max-stuck-cycles`,
    `--max-runtime`, and
    `--max-knowledge-search-per-cycle=<--knowledge-search-budget>`.

--- a/plugins/lean4/commands/doctor.md
+++ b/plugins/lean4/commands/doctor.md
@@ -58,7 +58,14 @@ plugins/lean4/
 ├── hooks/        (executable .sh)
 ├── skills/lean4/ (SKILL.md + references/)
 ├── agents/       (4 files)
-└── lib/scripts/  (12 files, executable)
+├── bin/          (lean4-skills-* model-facing wrappers)
+└── lib/scripts/  (executable .py / .sh internals)
+```
+
+Verify wrappers resolve on PATH:
+```bash
+command -v lean4-skills-cycle-tracker  # autoprove hot path
+command -v lean4-skills-sorry-analyzer
 ```
 
 ### 3. Project Check
@@ -195,8 +202,9 @@ No changes made. Run `/lean4:doctor cleanup --apply` to remove.
 | Issue | Fix |
 |-------|-----|
 | LEAN4_SCRIPTS not set | Restart session, check hooks.json |
+| `lean4-skills-*` wrapper not found on PATH | Verify bootstrap appended `$LEAN4_PLUGIN_ROOT/bin` to `PATH`; restart session if missing |
 | lake not found | Install via elan |
-| Scripts not executable | `chmod +x $LEAN4_SCRIPTS/*.sh` |
+| Scripts not executable | Wrappers should be shipped executable — check `command -v lean4-skills-sorry-analyzer`. For unwrapped internals: `chmod +x $LEAN4_SCRIPTS/*.sh $LEAN4_SCRIPTS/*.py` |
 | Build fails | `lake update && lake clean && lake build` |
 | Fresh worktree rebuild is slow / LSP times out on first use | Prime cache (`lake cache get` or `lake exe cache get`), then `lake build`; do not symlink `.lake/build` from another worktree |
 | Stale build after `lake clean` | Hydrate cache (`lake cache get` or `lake exe cache get`), then `lake build` |

--- a/plugins/lean4/commands/doctor.md
+++ b/plugins/lean4/commands/doctor.md
@@ -58,14 +58,8 @@ plugins/lean4/
 ├── hooks/        (executable .sh)
 ├── skills/lean4/ (SKILL.md + references/)
 ├── agents/       (4 files)
-├── bin/          (lean4-skills-* model-facing wrappers)
+├── bin/          (lean4-skills-* wrappers; verify on PATH: `command -v lean4-skills-cycle-tracker`)
 └── lib/scripts/  (executable .py / .sh internals)
-```
-
-Verify wrappers resolve on PATH:
-```bash
-command -v lean4-skills-cycle-tracker  # autoprove hot path
-command -v lean4-skills-sorry-analyzer
 ```
 
 ### 3. Project Check

--- a/plugins/lean4/commands/formalize.md
+++ b/plugins/lean4/commands/formalize.md
@@ -165,7 +165,7 @@ Output format follows `--presentation`: `informal` → prose with math notation 
 
 `propext`, `Classical.choice`, `Quot.sound` — not flagged. All others reported as non-standard.
 
-Always run `bash "$LEAN4_SCRIPTS/check_axioms_inline.sh" <target> --report-only` before presenting final results.
+Always run `lean4-skills-check-axioms-inline <target> --report-only` before presenting final results.
 
 ## Safety
 
@@ -174,7 +174,7 @@ Always run `bash "$LEAN4_SCRIPTS/check_axioms_inline.sh" <target> --report-only`
 - **No commits in standalone mode.** `/formalize` never commits in standalone mode (`--commit` is accepted for prove-phase compatibility but inert — no staging, no committing). `--output=file` writes but does not stage or commit.
 - **Path restriction.** User-requested outputs (`--output=file`, `--output=scratch`) restricted to workspace root (scratch uses `.scratch/lean4/`). Reject path traversal (`../`) or absolute paths outside workspace. Internal temp files may use `/tmp/lean4-formalize/`.
 - **Overwrite protection.** `--output=file` with existing target requires `--overwrite`; otherwise startup validation error.
-- **Never add global axioms silently.** Assumptions go as explicit theorem parameters or in `namespace Assumptions`. Always verified with `bash "$LEAN4_SCRIPTS/check_axioms_inline.sh" <target> --report-only`.
+- **Never add global axioms silently.** Assumptions go as explicit theorem parameters or in `namespace Assumptions`. Always verified with `lean4-skills-check-axioms-inline <target> --report-only`.
 - **All `guardrails.sh` rules apply.**
 - **Line width.** Follow mathlib 100-char line width — do not wrap lines at 80 when they fit within 100.
 

--- a/plugins/lean4/commands/golf.md
+++ b/plugins/lean4/commands/golf.md
@@ -35,13 +35,13 @@ Improve Lean proofs that already compile. Score candidates by: correctness → d
 1. **Verify Build** - Ensure code compiles before optimizing
 2. **Find Patterns** - Detect golfable patterns (in policy order: directness → structural → conditional):
    ```bash
-   ${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/find_golfable.py" [file] --filter-false-positives
+   lean4-skills-find-golfable [file] --filter-false-positives
    ```
    For direct-proof discovery when `--search` is enabled or syntactic pass stalls:
    ```bash
-   ${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/find_exact_candidates.py" [file]
+   lean4-skills-find-exact-candidates [file]
    ```
-3. **Exact-Collapse Pass** (bounded) — For apply/exact chain anchors from `$LEAN4_SCRIPTS/find_golfable.py`:
+3. **Exact-Collapse Pass** (bounded) — For apply/exact chain anchors from `lean4-skills-find-golfable`:
    - **Mechanical** (≤30 anchors/file): Construct collapsed `exact` from tactic structure → `lean_multi_attempt` + `lean_diagnostic_messages` baseline check (no new diagnostics, no sorry increase). Accept if the replacement is more direct or clearer. Reject if it introduces heavier automation (simpa, rwa, broad simp) to replace an explicit proof, if term length exceeds ~80 chars, if dot-chain depth > 2, or if it removes meaningful intermediate names. A 1-line saving that raises inference burden is not a win.
    - **Exploratory** (when `--search≠off`; consumes `--search` budget): On remaining single-goal anchors, build candidate `exact` terms from chain lemmas + local hypotheses + dot-notation rewrites → `lean_multi_attempt` + diagnostics check. Probe caps are phase-local: `quick` ≤5 probes/file; `full` ≤15 probes/file; ≤2 probes/anchor. Time budget is shared with lemma replacement (step 4): `quick` 30s total, `full` 60s total across both phases.
    - Skip: `calc`, `cases`/`induction`, multi-goal branches, blocks >7 lines, semicolon-heavy (>3), blocks with `have`/`refine`. `constructor` chains are handled by the existing instant-win rule, not this pass.
@@ -52,7 +52,7 @@ Improve Lean proofs that already compile. Score candidates by: correctness → d
    - Hand off to axiom-eliminator if replacement needs statement changes or multi-file refactor
 5. **Verify Safety** - Check usage before inlining:
    ```bash
-   ${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/analyze_let_usage.py" [file] --line [line]
+   lean4-skills-analyze-let-usage [file] --line [line]
    ```
 6. **Apply** - Make changes with `lean_diagnostic_messages` after each; `lake build` for final verification
 7. **Report** - Show savings and saturation status

--- a/plugins/lean4/commands/learn.md
+++ b/plugins/lean4/commands/learn.md
@@ -106,7 +106,7 @@ Classify learning intent and establish a session Learning Profile: {intent, pres
 When `--mode=auto`, resolve by tie-breaking order:
 
 1. If topic resolves to an existing `.lean` file path → `repo`
-2. Resolve topic against project-local declarations (via `Grep`/`$LEAN4_SCRIPTS/find_usages.sh`). **Local wins** — if both local and mathlib match, prefer local → `repo`
+2. Resolve topic against project-local declarations (via `Grep`/`lean4-skills-find-usages`). **Local wins** — if both local and mathlib match, prefer local → `repo`
 3. Check mathlib namespace/theorem names (via `lean_local_search`, `lean_leanfinder`/`lean_leansearch`, `lean_loogle`) → `mathlib`
 4. If topic is a natural-language mathematical statement → suggest `/lean4:formalize`
 5. If ambiguous → ask the user
@@ -117,7 +117,7 @@ When no topic is provided, enter conversational discovery and set `--mode` after
 
 ### 2. Discovery (per mode)
 
-**repo:** `Glob`/`Grep` (file survey) → `Read` (targeted content) → `$LEAN4_SCRIPTS/find_usages.sh` (dependency pass). Build a map: key files, declarations, dependency flow, where proofs live.
+**repo:** `Glob`/`Grep` (file survey) → `Read` (targeted content) → `lean4-skills-find-usages` (dependency pass). Build a map: key files, declarations, dependency flow, where proofs live.
 
 **mathlib:** `lean_local_search` → one semantic search (`lean_leanfinder` for goal/proof-state shaped queries, `lean_leansearch` for natural-language concept queries) → `lean_loogle` (type-pattern gaps). Present canonical lemmas, type signatures, minimal usage examples.
 

--- a/plugins/lean4/commands/review.md
+++ b/plugins/lean4/commands/review.md
@@ -116,10 +116,10 @@ For strategy-level proof simplification (mathlib leverage, helper extraction, co
 The agent selects files based on scope, then runs these analyses (per file or directory):
 
 1. **Build Status** - `lake build` (project-wide); for scoped review (`--scope=file`), use `lean_diagnostic_messages(file)` + `lake env lean <path/to/File.lean>` (run from project root) first
-2. **Sorry Audit** - `${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/sorry_analyzer.py" <target> --format=json --report-only`
-3. **Axiom Check** - `bash "$LEAN4_SCRIPTS/check_axioms_inline.sh" <target> --report-only`
+2. **Sorry Audit** - `lean4-skills-sorry-analyzer <target> --format=json --report-only`
+3. **Axiom Check** - `lean4-skills-check-axioms-inline <target> --report-only`
 4. **Style Review** - Check mathlib conventions (naming, structure, tactics, 100-char line width). Flag lines wrapped under 100 chars that fit on one line (common: `mkAppM` calls, short struct literals, single-expression tactic lines).
-5. **Golfing Opportunities** - `${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/find_golfable.py" <target> --filter-false-positives`
+5. **Golfing Opportunities** - `lean4-skills-find-golfable <target> --filter-false-positives`
 6. **Complexity Metrics** - Proof sizes, longest proofs, tactic patterns
 
 **Stuck mode:** Steps 5–6 are skipped; focus is on blockers (steps 1–4) for quick triage.

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -335,9 +335,18 @@ seg_match() {
 # Lean script invocation + stderr suppression guard.
 # Rationale: hidden stderr from analysis scripts causes silent failures.
 # This guard is intentionally non-bypassable.
+#
+# The token alternation covers:
+#   * `$LEAN4_SCRIPTS/foo.sh` / `${LEAN4_SCRIPTS}/foo.py` — env-var paths
+#   * `plugins/lean4/lib/scripts/foo.sh` — repo-relative path
+#   * `(./)?(lib/scripts|scripts)/foo.sh` — `cd`-relative invocations
+#   * `lean4-skills-foo` — model-facing prefixed wrappers (issue #117),
+#     matching bare names (PATH lookup), `bin/lean4-skills-foo`,
+#     `./bin/lean4-skills-foo`, and `plugins/lean4/bin/lean4-skills-foo`.
+#     The leading boundary `(^|[[:space:]]|/)` accepts any of those.
 _has_lean_script_token() {
   local s="$1"
-  echo "$s" | grep -qE -- '(\$LEAN4_SCRIPTS/|\$\{LEAN4_SCRIPTS\}/|plugins/lean4/(lib/scripts|scripts)/|(^|[[:space:]])(\./)?(lib/scripts|scripts)/[^[:space:]]+\.(py|sh)\b)'
+  echo "$s" | grep -qE -- '(\$LEAN4_SCRIPTS/|\$\{LEAN4_SCRIPTS\}/|plugins/lean4/(lib/scripts|scripts)/|(^|[[:space:]])(\./)?(lib/scripts|scripts)/[^[:space:]]+\.(py|sh)\b|(^|[[:space:]]|/)lean4-skills-[a-z][a-z0-9-]*\b)'
 }
 
 _strip_quoted_literals() {

--- a/plugins/lean4/skills/lean4/SKILL.md
+++ b/plugins/lean4/skills/lean4/SKILL.md
@@ -171,7 +171,7 @@ Use `$LEAN4_SCRIPTS` for search and `lake env lean` / `lake build` for validatio
 - **No live goal inspection** — `lean_goal` is unavailable; you can read the file and check compilation output, but cannot see proof state at a specific line
 - **No tactic testing** — `lean_multi_attempt` is unavailable; edits must be validated by compiling the file (`lake env lean`)
 - **No real-time diagnostics** — `lean_diagnostic_messages` is unavailable; use `lake env lean <file>` (from project root) for compilation errors, but feedback is file-level, not line-level
-- **Search is script-based** — `$LEAN4_SCRIPTS/smart_search.sh` replaces LSP search tools
+- **Search is script-based** — `lean4-skills-smart-search` replaces LSP search tools
 
 This mode is functional for straightforward proofs but significantly slower and less precise than MCP-backed workflows.
 
@@ -274,9 +274,9 @@ If LSP tools aren't responding, check your operating profile above. In `scripts_
 **Script environment check:**
 ```bash
 echo "$LEAN4_SCRIPTS"
-ls -l "$LEAN4_SCRIPTS/sorry_analyzer.py"
+ls -l lean4-skills-sorry-analyzer
 # One-pass discovery for troubleshooting (human-readable default text):
-${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/sorry_analyzer.py" . --report-only
+lean4-skills-sorry-analyzer . --report-only
 # Structured output (optional): --format=json
 # Counts only (optional): --format=summary
 ```

--- a/plugins/lean4/skills/lean4/SKILL.md
+++ b/plugins/lean4/skills/lean4/SKILL.md
@@ -205,13 +205,37 @@ See [sorry-filling.md](references/sorry-filling.md) for the full scratch-work pr
 
 **Usage:** Invoked by commands automatically. See [references/](references/) for details.
 
-**Invocation contract:** Never run bare script names. Always use:
-- Python: `${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/script.py" ...`
-- Shell: `bash "$LEAN4_SCRIPTS/script.sh" ...`
-- Report-only calls: add `--report-only` to `sorry_analyzer.py`, `check_axioms_inline.sh`, `unused_declarations.sh` — suppresses exit 1 on findings; real errors still exit 1. Do not use in gate commands like `/lean4:checkpoint`.
-- Keep stderr visible for Lean scripts (no `/dev/null` redirection), so real errors are not hidden.
+**Invocation contract.** Preferred model-facing form:
 
-If `$LEAN4_SCRIPTS` is unset or missing, run `/lean4:doctor` and stay LSP-only until resolved.
+- **Use `lean4-skills-*` wrappers** for the supported helper scripts
+  (`lean4-skills-sorry-analyzer`, `lean4-skills-check-axioms-inline`,
+  `lean4-skills-find-golfable`, `lean4-skills-find-exact-candidates`,
+  `lean4-skills-analyze-let-usage`, `lean4-skills-find-usages`,
+  `lean4-skills-search-mathlib`, `lean4-skills-smart-search`,
+  `lean4-skills-cycle-tracker`). These are bare commands on PATH —
+  no `$LEAN4_SCRIPTS`, no `${LEAN4_PYTHON_BIN:-python3}`, no `~`, no
+  command substitution. Stable invocation surface that Claude Code
+  can statically allowlist.
+- **Report-only calls**: add `--report-only` to
+  `lean4-skills-sorry-analyzer`, `lean4-skills-check-axioms-inline`
+  (and `unused_declarations.sh` if invoked via env-var fallback) —
+  suppresses exit 1 on findings; real errors still exit 1. Do not
+  use in gate commands like `/lean4:checkpoint`.
+- **Keep stderr visible** for Lean script invocations (no `/dev/null`
+  redirection). The guardrails detector recognizes both wrapper and
+  env-var call forms; suppressing stderr is blocked either way.
+
+Compatibility fallback (when a wrapper is unavailable):
+
+- If `lean4-skills-*` isn't resolvable on PATH, use the host's
+  documented setup (see INSTALLATION.md) to add `$LEAN4_PLUGIN_ROOT/bin`
+  to PATH. Claude Code does this automatically.
+- Only as a last resort for an unwrapped script, use the explicit
+  env-var form: `bash "$LEAN4_SCRIPTS/script.sh" …` or
+  `${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/script.py" …`.
+
+If `$LEAN4_SCRIPTS` is unset or missing, run `/lean4:doctor` and stay
+LSP-only until resolved.
 
 ## Automation
 
@@ -274,7 +298,7 @@ If LSP tools aren't responding, check your operating profile above. In `scripts_
 **Script environment check:**
 ```bash
 echo "$LEAN4_SCRIPTS"
-ls -l lean4-skills-sorry-analyzer
+command -v lean4-skills-sorry-analyzer
 # One-pass discovery for troubleshooting (human-readable default text):
 lean4-skills-sorry-analyzer . --report-only
 # Structured output (optional): --format=json

--- a/plugins/lean4/skills/lean4/references/agent-workflows.md
+++ b/plugins/lean4/skills/lean4/references/agent-workflows.md
@@ -147,7 +147,7 @@ Stage 1 outputs (after 3 failures, escalates to Stage 2):
 ```
 
 LSP search: `lean_leanfinder("continuous real function")` → `Real.continuous_ofReal`
-Fallback if needed: `$LEAN4_SCRIPTS/search_mathlib.sh "continuous.*real" name`
+Fallback if needed: `lean4-skills-search-mathlib "continuous.*real" name`
 
 ```diff
 --- Core.lean
@@ -174,7 +174,7 @@ Pattern found at line 45:
   have h := property x
   exact h
 
-Running: $LEAN4_SCRIPTS/analyze_let_usage.py Core.lean --line 45
+Running: lean4-skills-analyze-let-usage Core.lean --line 45
 Result: x used 1 time, h used 1 time
 
 Safety: ✓ Safe to inline (both used ≤2 times)
@@ -199,7 +199,7 @@ Pattern found at line 78:
   let bound := expensive_computation
   ...uses bound 6 times...
 
-Running: $LEAN4_SCRIPTS/analyze_let_usage.py Core.lean --line 78
+Running: lean4-skills-analyze-let-usage Core.lean --line 78
 Result: bound used 6 times
 
 Safety: ✗ SKIP - would expand code 6× (from 1 expr to 6)
@@ -314,7 +314,7 @@ Handoff: not needed (single-line, no statement change)
 
 **Search results:**
 LSP: lean_leanfinder("continuous composition") → Continuous.comp (Mathlib.Topology.Basic)
-Fallback: $LEAN4_SCRIPTS/search_mathlib.sh "continuous.*comp" name
+Fallback: lean4-skills-search-mathlib "continuous.*comp" name
 
 **Changes made:**
 - Removed `axiom helper_continuous`

--- a/plugins/lean4/skills/lean4/references/axiom-elimination.md
+++ b/plugins/lean4/skills/lean4/references/axiom-elimination.md
@@ -17,8 +17,8 @@ Quick reference for systematically eliminating custom axioms from Lean 4 proofs.
 
 **Check axiom usage:**
 ```bash
-bash $LEAN4_SCRIPTS/check_axioms_inline.sh FILE.lean
-bash $LEAN4_SCRIPTS/check_axioms_inline.sh .          # scan entire project
+lean4-skills-check-axioms-inline FILE.lean
+lean4-skills-check-axioms-inline .          # scan entire project
 ```
 
 **For individual theorems:**
@@ -32,8 +32,8 @@ EOF
 
 **Always prefer the script over manual checks:**
 ```bash
-$LEAN4_SCRIPTS/check_axioms_inline.sh path/to/file.lean
-$LEAN4_SCRIPTS/check_axioms_inline.sh src/   # scan directory recursively
+lean4-skills-check-axioms-inline path/to/file.lean
+lean4-skills-check-axioms-inline src/   # scan directory recursively
 ```
 
 The script handles namespace inference and filters standard axioms automatically.
@@ -92,17 +92,17 @@ axiom helper_theorem : P
 
 **Search by name:**
 ```bash
-bash $LEAN4_SCRIPTS/search_mathlib.sh "axiom_name_pattern" name
+lean4-skills-search-mathlib "axiom_name_pattern" name
 ```
 
 **Search by type/description:**
 ```bash
-bash $LEAN4_SCRIPTS/smart_search.sh "property description" --source=leansearch
+lean4-skills-smart-search "property description" --source=leansearch
 ```
 
 **Search by type pattern:**
 ```bash
-bash $LEAN4_SCRIPTS/smart_search.sh "type signature pattern" --source=loogle
+lean4-skills-smart-search "type signature pattern" --source=loogle
 ```
 
 ### Phase 4: Eliminate Axioms
@@ -185,7 +185,7 @@ theorem infrastructure : Property := by
 **Dependency tracking:**
 ```bash
 # Find what uses an axiom
-bash $LEAN4_SCRIPTS/find_usages.sh axiom_name
+lean4-skills-find-usages axiom_name
 ```
 
 ## Progress Tracking
@@ -193,7 +193,7 @@ bash $LEAN4_SCRIPTS/find_usages.sh axiom_name
 After each elimination:
 ```bash
 # Verify axiom count decreased
-bash $LEAN4_SCRIPTS/check_axioms_inline.sh FILE.lean
+lean4-skills-check-axioms-inline FILE.lean
 
 # Compare before/after
 echo "Before: N custom axioms"

--- a/plugins/lean4/skills/lean4/references/command-examples.md
+++ b/plugins/lean4/skills/lean4/references/command-examples.md
@@ -123,7 +123,7 @@ theorem padic_complete (p : ℕ) [hp : Fact (Nat.Prime p)] :
   sorry -- ⚠ proof blocked: needs Mathlib.NumberTheory.Padics.PadicIntegers
 ```
 
-bash "$LEAN4_SCRIPTS/check_axioms_inline.sh" <target>.lean --report-only → ✓ standard axioms only
+lean4-skills-check-axioms-inline <target>.lean --report-only → ✓ standard axioms only
 
 Note: Mathlib likely has this as an instance. Searching...
 lean_leanfinder("CompleteSpace Padic") → `Padic.instCompleteSpace`

--- a/plugins/lean4/skills/lean4/references/compiler-guided-repair.md
+++ b/plugins/lean4/skills/lean4/references/compiler-guided-repair.md
@@ -542,7 +542,7 @@ lean_loogle("type pattern")        # Type-based
 
 **Fallback scripts:**
 ```bash
-bash $LEAN4_SCRIPTS/smart_search.sh "query" --source=all
+lean4-skills-smart-search "query" --source=all
 ```
 
 ---

--- a/plugins/lean4/skills/lean4/references/cycle-engine.md
+++ b/plugins/lean4/skills/lean4/references/cycle-engine.md
@@ -35,12 +35,12 @@ LSP tools are the normative first-pass for all discovery, search, and validation
 5. `lean_diagnostic_messages(file)` — verify; if "Try this" → `lean_code_actions(file, line)` → apply → `lean_diagnostic_messages(file)` to re-verify
 6. Prefer shortest passing candidate; only then edit/commit
 
-**Fallback gate:** Script fallback (`$LEAN4_SCRIPTS/smart_search.sh`, `$LEAN4_SCRIPTS/search_mathlib.sh`) and repair agents are permitted when:
+**Fallback gate:** Script fallback (`lean4-skills-smart-search`, `lean4-skills-search-mathlib`) and repair agents are permitted when:
 - LSP search budget is exhausted (at least 2 searches returning empty/inconclusive), OR
 - LSP server is confirmed unavailable, timing out, or rate-limited
 
 For sorry discovery fallback, prefer one-pass structured output:
-`${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/sorry_analyzer.py" <target> --format=json --report-only`.
+`lean4-skills-sorry-analyzer <target> --format=json --report-only`.
 Use default `text` for quick human review and `summary` only for counts.
 Do not suppress script stderr via `/dev/null`; surfaced errors are part of the fallback signal.
 
@@ -238,14 +238,14 @@ Do NOT create an empty commit. Checkpoint requires a non-empty diff.
 
 > This section describes the concrete Claude Code implementation of the enforcement classes defined in [command-invocation.md](command-invocation.md). The invocation contract is host-agnostic; `cycle_tracker.sh` is one implementation that fulfills it. Other hosts may provide equivalent enforcement through different mechanisms, or may rely on model-mediated tracking alone.
 
-Autonomous commands (`autoprove`, `autoformalize`) use `$LEAN4_SCRIPTS/cycle_tracker.sh` for deterministic session counter tracking. Guided commands (`prove`, `formalize`) do not — user presence provides the control loop.
+Autonomous commands (`autoprove`, `autoformalize`) use `lean4-skills-cycle-tracker` for deterministic session counter tracking. Guided commands (`prove`, `formalize`) do not — user presence provides the control loop.
 
 ### Initialization
 
 After emitting the Resolved Inputs block, call:
 
 ```bash
-bash "$LEAN4_SCRIPTS/cycle_tracker.sh" init \
+lean4-skills-cycle-tracker init \
   --max-cycles=<resolved> \
   --max-stuck=<resolved> \
   --max-runtime=<resolved> \
@@ -260,7 +260,7 @@ A failed init (exit 2) is a startup validation error — do not proceed. On succ
 At the end of every cycle, call:
 
 ```bash
-bash "$LEAN4_SCRIPTS/cycle_tracker.sh" tick --stuck=yes|no
+lean4-skills-cycle-tracker tick --stuck=yes|no
 ```
 
 This is one atomic operation that:
@@ -276,11 +276,11 @@ If exit code is 1 (`LIMIT_REACHED`), stop immediately and emit the structured su
 
 Before dispatching a deep-mode subagent:
 
-1. Call `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" can-deep`
+1. Call `lean4-skills-cycle-tracker can-deep`
 2. If exit 1 (`denied`), handle based on the `reason` field:
    - `reason=max-deep-per-cycle` or `reason=max-consecutive-deep`: deep denied by policy — skip deep for this sorry without marking it stuck
    - `reason=max-runtime`: session budget exhausted — let the next `tick` trigger session stop
-3. If exit 0: call `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" deep` to record the invocation, then dispatch
+3. If exit 0: call `lean4-skills-cycle-tracker deep` to record the invocation, then dispatch
 
 ### Claim Boundary Protocol (autoformalize)
 
@@ -288,15 +288,15 @@ Autoformalize processes claims sequentially. `--max-cycles` and `--max-stuck-cyc
 
 **Lifecycle:** `init` → (`start-claim` → inner cycle ticks → `reset-claim`) × N-1 → `start-claim` → inner cycle ticks → `status`/`stop`
 
-- Call `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" start-claim` when dequeuing each claim
-- Call `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" reset-claim` when a claim completes or stops (before the next `start-claim`)
+- Call `lean4-skills-cycle-tracker start-claim` when dequeuing each claim
+- Call `lean4-skills-cycle-tracker reset-claim` when a claim completes or stops (before the next `start-claim`)
 - The final claim does not need `reset-claim` — session totals (`cycles_total`, `stuck_cycles_total`, `deep_total`) are accumulated live by `tick`/`deep`
 
 `status` always reflects the full session: `claims_attempted` includes the in-progress claim. Summary metrics (`Cycles run`, `Stuck cycles`, `Deep invocations`) come from session-total accumulators.
 
 ### On Stop
 
-Call `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" status` for the structured summary counters, then `bash "$LEAN4_SCRIPTS/cycle_tracker.sh" stop` for cleanup.
+Call `lean4-skills-cycle-tracker status` for the structured summary counters, then `lean4-skills-cycle-tracker stop` for cleanup.
 
 ### Enforcement Levels
 

--- a/plugins/lean4/skills/lean4/references/disprove-engine.md
+++ b/plugins/lean4/skills/lean4/references/disprove-engine.md
@@ -249,7 +249,7 @@ etc.). Examples per shape:
 ### Cycle-Tracker init
 
 ```bash
-bash "$LEAN4_SCRIPTS/cycle_tracker.sh" init \
+lean4-skills-cycle-tracker init \
   --max-cycles=<resolved> --max-stuck-cycles=<resolved> \
   --max-runtime=<resolved> \
   --max-knowledge-search-per-cycle=<resolved --knowledge-search-budget>
@@ -955,11 +955,11 @@ After the user decides:
 
 ```bash
 # At every cycle boundary:
-bash "$LEAN4_SCRIPTS/cycle_tracker.sh" tick --stuck=<yes|no>
+lean4-skills-cycle-tracker tick --stuck=<yes|no>
 
 # Just before emitting the Disprove Summary (on session stop):
-bash "$LEAN4_SCRIPTS/cycle_tracker.sh" status
-bash "$LEAN4_SCRIPTS/cycle_tracker.sh" stop
+lean4-skills-cycle-tracker status
+lean4-skills-cycle-tracker stop
 ```
 
 `tick` enforces `--max-cycles` and `--max-stuck-cycles` at the cycle

--- a/plugins/lean4/skills/lean4/references/proof-golfing.md
+++ b/plugins/lean4/skills/lean4/references/proof-golfing.md
@@ -133,7 +133,7 @@ grep -A 1 "rw \[" file.lean | grep "exact"
 
 For each let+have+exact pattern:
 
-1. Count let binding uses (or use `$LEAN4_SCRIPTS/analyze_let_usage.py`)
+1. Count let binding uses (or use `lean4-skills-analyze-let-usage`)
 2. If used ≥3 times → SKIP (false positive)
 3. If used ≤2 times → Proceed with optimization
 

--- a/plugins/lean4/skills/lean4/references/sorry-filling.md
+++ b/plugins/lean4/skills/lean4/references/sorry-filling.md
@@ -33,7 +33,7 @@ Quick reference for filling Lean 4 sorries systematically.
 
 **Session-end reporting:** Report `files_touched` (files edited) and `scratch_files_created` (any `/tmp` files used for experiments). The caller uses this for staging and cleanup.
 
-Only fall back to scripts (`$LEAN4_SCRIPTS/sorry_analyzer.py`, `$LEAN4_SCRIPTS/smart_search.sh`) if:
+Only fall back to scripts (`$LEAN4_SCRIPTS/sorry_analyzer.py`, `$LEAN4_SCRIPTS/smart_search.sh`) if: <!-- guardrails: compatibility-fallback -->
 - LSP server unavailable
 - LSP results inconclusive after 2-3 searches
 
@@ -73,12 +73,12 @@ Continue with the next sorry in the TODO list.
 
 **By name pattern:**
 ```bash
-bash $LEAN4_SCRIPTS/search_mathlib.sh "continuous compact" name
+bash $LEAN4_SCRIPTS/search_mathlib.sh "continuous compact" name   # guardrails: compatibility-fallback
 ```
 
 **Multi-source smart search:**
 ```bash
-bash $LEAN4_SCRIPTS/smart_search.sh "property description" --source=leansearch
+bash $LEAN4_SCRIPTS/smart_search.sh "property description" --source=leansearch   # guardrails: compatibility-fallback
 ```
 
 **Get tactic suggestions:**

--- a/plugins/lean4/skills/lean4/references/subagent-workflows.md
+++ b/plugins/lean4/skills/lean4/references/subagent-workflows.md
@@ -88,7 +88,7 @@
 
 **When to use:**
 - "Find all files using MeasurableSpace"
-- "Run $LEAN4_SCRIPTS/sorry_analyzer.py and report count"
+- "Run lean4-skills-sorry-analyzer and report count"
 - "Search mathlib for continuous function lemmas"
 
 ### General-Purpose Agent (Thorough, Multi-Step)
@@ -126,10 +126,10 @@ You do not invoke these directly. See [agent-workflows.md](agent-workflows.md) f
 ```
 Task: "Optimize these 5 proofs"
 ✅ Use /lean4:golf (specialized workflow with safety checks)
-❌ Dispatch general-purpose agent to run $LEAN4_SCRIPTS/find_golfable.py (misses false-positive filtering)
+❌ Dispatch general-purpose agent to run lean4-skills-find-golfable (misses false-positive filtering)
 
 Task: "Find mathlib lemmas for this sorry"
-✅ Dispatch Explore agent to run $LEAN4_SCRIPTS/smart_search.sh (simple delegation)
+✅ Dispatch Explore agent to run lean4-skills-smart-search (simple delegation)
 ✅ Use lean_local_search or lean_leanfinder LSP tools directly
 
 Task: "Fill all 15 sorries in this file"
@@ -143,7 +143,7 @@ Task: "Fill all 15 sorries in this file"
 
 **Instead of this (inefficient):**
 ```
-You: Run $LEAN4_SCRIPTS/sorry_analyzer.py on the whole project
+You: Run lean4-skills-sorry-analyzer on the whole project
 
 Claude (in main conversation):
 [Executes script directly]
@@ -153,7 +153,7 @@ Claude (in main conversation):
 
 **Do this (efficient):**
 ```
-You: Dispatch an Explore agent to run $LEAN4_SCRIPTS/sorry_analyzer.py and report top 5 sorries
+You: Dispatch an Explore agent to run lean4-skills-sorry-analyzer and report top 5 sorries
 
 Claude (in main conversation):
 "I'm dispatching an Explore agent to analyze sorries..."
@@ -176,7 +176,7 @@ Claude (in main conversation):
 Claude: "I'm dispatching an Explore agent to search for relevant lemmas..."
 
 [Dispatches with prompt]:
-"Run $LEAN4_SCRIPTS/smart_search.sh 'continuous functions compact spaces' --source=leansearch
+"Run lean4-skills-smart-search 'continuous functions compact spaces' --source=leansearch
  and report the top 3 most relevant results with their import paths"
 
 [Agent reports back]:
@@ -225,8 +225,8 @@ Claude: "I'm dispatching an Explore agent to run verification checks..."
 
 [Dispatches with prompt]:
 "Run the following verification tasks and report summary:
- 1. $LEAN4_SCRIPTS/sorry_analyzer.py src/ --format=json (count sorries)
- 2. $LEAN4_SCRIPTS/check_axioms_inline.sh 'src/**/*.lean' (check for non-standard axioms)
+ 1. lean4-skills-sorry-analyzer src/ --format=json (count sorries)
+ 2. lean4-skills-check-axioms-inline 'src/**/*.lean' (check for non-standard axioms)
  3. Report: Total sorries, any axiom issues, ready to commit?"
 
 [Agent reports back]:
@@ -248,7 +248,7 @@ Claude: "Let's use the interactive sorry navigator. This runs on your terminal
 so you can browse and select which sorry to tackle."
 
 You (in terminal):
-$ $LEAN4_SCRIPTS/sorry_analyzer.py . --interactive
+$ lean4-skills-sorry-analyzer . --interactive
 
 [TUI shows]:
 Files with sorries:
@@ -291,8 +291,8 @@ to find the right mathlib lemma..."
 **Example:**
 ```
 "Dispatch Explore agent to:
- 1. Run $LEAN4_SCRIPTS/sorry_analyzer.py src/ and report total count
- 2. Run $LEAN4_SCRIPTS/check_axioms_inline.sh 'src/**/*.lean' and report any issues
+ 1. Run lean4-skills-sorry-analyzer src/ and report total count
+ 2. Run lean4-skills-check-axioms-inline 'src/**/*.lean' and report any issues
  3. Analyze proofs in src/ and report 5 largest proofs with sorries
  4. Summarize: What's the state of the codebase?"
 ```
@@ -313,7 +313,7 @@ to find the right mathlib lemma..."
 **Example:**
 ```
 "Dispatch general-purpose agent to:
- 1. Search mathlib for continuous function lemmas using $LEAN4_SCRIPTS/smart_search.sh
+ 1. Search mathlib for continuous function lemmas using lean4-skills-smart-search
  2. Filter results to those mentioning compact spaces
  3. For top 3 results, check their type signatures
  4. Recommend which lemma best fits our use case: proving f(K) is compact when K is compact
@@ -337,7 +337,7 @@ to find the right mathlib lemma..."
 **Example:**
 ```
 "Dispatch Explore agent to investigate how conditional expectation is used in this project:
- 1. Run $LEAN4_SCRIPTS/search_mathlib.sh 'condExp' name in project files (not mathlib)
+ 1. Run lean4-skills-search-mathlib 'condExp' name in project files (not mathlib)
  2. Read the top 3 files that use it most
  3. Report: What patterns do you see? How is it typically combined with other operations?"
 ```
@@ -354,7 +354,7 @@ to find the right mathlib lemma..."
 
 ### Token Economics
 
-**Scenario:** Running $LEAN4_SCRIPTS/sorry_analyzer.py on a medium project
+**Scenario:** Running lean4-skills-sorry-analyzer on a medium project
 
 **Without subagent (direct execution):**
 - Script output: ~500 tokens (100 lines @ 5 tokens/line)
@@ -427,7 +427,7 @@ lean_local_search("keyword")       # Search results
  Search: lean_local_search('Nat.add_comm') → [Nat.add_comm]"
 
 # Delegate batch operations to subagents
-"Dispatch Explore agent to run $LEAN4_SCRIPTS/check_axioms_inline.sh on all changed files"
+"Dispatch Explore agent to run lean4-skills-check-axioms-inline on all changed files"
 ```
 
 **Why pre-collect context?**
@@ -581,7 +581,7 @@ Alternatives:
 **Use script directly (faster, simpler):**
 ```
 "Dispatch Explore agent to:
-Run $LEAN4_SCRIPTS/sorry_analyzer.py . --format=text
+Run lean4-skills-sorry-analyzer . --format=text
 and report total sorry count"
 ```
 

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -168,5 +168,31 @@ run_test_policy "unset: plain push (block=ask)"         ""   "git push origin ma
 run_test_policy "unset: bypass push (allow=ask)"        ""   "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"   0
 
 echo ""
+echo "-- Lean script stderr-suppression detector: \$LEAN4_SCRIPTS paths --"
+run_test "\$LEAN4_SCRIPTS/cycle_tracker.sh 2>/dev/null (block)"  'bash "$LEAN4_SCRIPTS/cycle_tracker.sh" tick 2>/dev/null'    2
+run_test "\${LEAN4_SCRIPTS}/sorry_analyzer.py 2>/dev/null (block)" 'python3 "${LEAN4_SCRIPTS}/sorry_analyzer.py" . 2>/dev/null' 2
+run_test "plugins/lean4/lib/scripts/foo.sh 2>/dev/null (block)"   'bash plugins/lean4/lib/scripts/cycle_tracker.sh tick 2>/dev/null' 2
+run_test "./lib/scripts/foo.sh 2>/dev/null (block)"               'bash ./lib/scripts/cycle_tracker.sh tick 2>/dev/null' 2
+
+echo ""
+echo "-- Lean script stderr-suppression detector: lean4-skills-* wrappers (all 4 call forms) --"
+# Bare name (PATH lookup — the autoprove-hot-path case)
+run_test "bare lean4-skills-cycle-tracker 2>/dev/null (block)"  "lean4-skills-cycle-tracker tick 2>/dev/null"  2
+run_test "bare lean4-skills-sorry-analyzer 2>/dev/null (block)" "lean4-skills-sorry-analyzer . 2>/dev/null"   2
+# Relative bin/ path
+run_test "bin/lean4-skills-cycle-tracker 2>/dev/null (block)"   "bin/lean4-skills-cycle-tracker tick 2>/dev/null" 2
+# Explicit ./ relative path
+run_test "./bin/lean4-skills-cycle-tracker 2>/dev/null (block)" "./bin/lean4-skills-cycle-tracker tick 2>/dev/null" 2
+# Full plugin-rooted path
+run_test "plugins/lean4/bin/lean4-skills-foo 2>/dev/null (block)" "plugins/lean4/bin/lean4-skills-cycle-tracker tick 2>/dev/null" 2
+# &>/dev/null variant — should also block (matches detector's combined-redirect branch)
+run_test "lean4-skills-cycle-tracker &>/dev/null (block)" "lean4-skills-cycle-tracker tick &>/dev/null" 2
+# Without stderr suppression — should NOT block (wrappers without 2>/dev/null are fine)
+run_test "lean4-skills-cycle-tracker tick (allow)" "lean4-skills-cycle-tracker tick" 0
+run_test "lean4-skills-sorry-analyzer . --format=json (allow)" "lean4-skills-sorry-analyzer . --format=json" 0
+# Token boundary — only the exact prefix counts; "leaning4-skills" or "lean4-skillsfoo" are non-tokens
+run_test "leaning4-skills-cycle 2>/dev/null (allow — not a real token)" "leaning4-skills-cycle 2>/dev/null" 0
+
+echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [[ "$FAIL" -eq 0 ]]

--- a/plugins/lean4/tests/test_lint_runtime_portability.sh
+++ b/plugins/lean4/tests/test_lint_runtime_portability.sh
@@ -308,25 +308,30 @@ expect_py_lint_pass 'no shebang — library module is out of scope' '"""Library 
 def f(): pass'
 
 # ---------------------------------------------------------------------------
-# Check 10 self-tests — no plugins/lean4/bin shortcut path
+# Check 10 self-tests — bin/ shape (curated lean4-skills-* wrappers only)
 #
-# Creates $TMPDIR_ROOT/bin as a symlink, file, or directory and asserts
-# the linter exits 1. Cleans up after each. The no-bin negative case is
-# implicitly verified by every other probe (none of them creates bin/),
-# so all the prior "lint exits 0" expectations also cover Check 10.
+# bin/ may be absent OR a real directory containing only `lean4-skills-*`
+# regular executable files. The implicit no-bin negative case is verified
+# by every other probe (none of them creates bin/). These tests cover the
+# bin/-exists shape rules.
+#
+# Each helper sets up a bin/ in $TMPDIR_ROOT, runs the lint, and tears
+# down. Inner setup blocks can populate `lib/scripts/` symlink targets,
+# add extra files inside bin/, etc.
 # ---------------------------------------------------------------------------
 echo ""
-echo "-- Check 10 self-tests (no bin shortcut) --"
+echo "-- Check 10 self-tests (bin/ shape) --"
 
-expect_bin_lint_fail() {
-  local desc="$1" kind="$2" output  # kind: symlink|file|dir
+# expect_bin_setup_fail "description" "setup commands"
+#   `setup` is bash code that runs in a fresh $TMPDIR_ROOT/bin context.
+#   The helper expects the lint to exit 1 (Check 10 catches the bad shape).
+expect_bin_setup_fail() {
+  local desc="$1" setup="$2" output
   local bin="$TMPDIR_ROOT/bin"
-  case "$kind" in
-    symlink) ln -s lib/scripts "$bin" ;;
-    file) touch "$bin" ;;
-    dir) mkdir "$bin" ;;
-    *) echo "  FAIL: $desc (internal: unknown kind '$kind')"; ((FAIL++)) || true; return ;;
-  esac
+  rm -rf "$bin"
+  ( cd "$TMPDIR_ROOT" && eval "$setup" ) || {
+    echo "  FAIL: $desc (internal: setup failed)"; ((FAIL++)) || true; return
+  }
   local exit_code=0
   output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_runtime_portability.sh" 2>&1) || exit_code=$?
   if [[ "$exit_code" -eq 1 ]]; then
@@ -340,9 +345,71 @@ expect_bin_lint_fail() {
   rm -rf "$bin"
 }
 
-expect_bin_lint_fail 'bin/ as symlink to lib/scripts' symlink
-expect_bin_lint_fail 'bin/ as plain directory'        dir
-expect_bin_lint_fail 'bin/ as plain file'             file
+# expect_bin_setup_pass "description" "setup commands"
+#   Same as expect_bin_setup_fail but expects exit 0.
+expect_bin_setup_pass() {
+  local desc="$1" setup="$2" output
+  local bin="$TMPDIR_ROOT/bin"
+  rm -rf "$bin"
+  ( cd "$TMPDIR_ROOT" && eval "$setup" ) || {
+    echo "  FAIL: $desc (internal: setup failed)"; ((FAIL++)) || true; return
+  }
+  local exit_code=0
+  output=$("$BASH_FOR_COMPAT" "$TMPDIR_ROOT/tools/lint_runtime_portability.sh" 2>&1) || exit_code=$?
+  if [[ "$exit_code" -eq 0 ]]; then
+    echo "  PASS: $desc"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: $desc (expected exit 0, got $exit_code)"
+    echo "$output" | sed 's/^/      /'
+    ((FAIL++)) || true
+  fi
+  rm -rf "$bin"
+}
+
+# --- Failure cases ---
+
+# Whole-directory symlink — the original PR #120 mistake.
+expect_bin_setup_fail 'bin/ as symlink to lib/scripts (the #120 mistake)' \
+  'ln -s lib/scripts bin'
+
+# bin/ as a regular file (not a directory).
+expect_bin_setup_fail 'bin/ as a plain file (not a directory)' \
+  'touch bin'
+
+# bin/ directory containing a non-prefixed file.
+expect_bin_setup_fail 'bin/ contains non-prefixed file oops.sh' \
+  'mkdir bin && printf "#!/usr/bin/env bash\nexit 0\n" > bin/oops.sh && chmod +x bin/oops.sh'
+
+# bin/ directory containing a file with the right prefix but uppercase chars.
+expect_bin_setup_fail 'bin/ contains lean4-skills-FOO (uppercase rejected)' \
+  'mkdir bin && printf "#!/usr/bin/env bash\nexit 0\n" > bin/lean4-skills-FOO && chmod +x bin/lean4-skills-FOO'
+
+# Prefixed file but not executable.
+expect_bin_setup_fail 'bin/lean4-skills-foo not executable' \
+  'mkdir bin && printf "#!/usr/bin/env bash\nexit 0\n" > bin/lean4-skills-foo'
+
+# Prefixed file but a symlink (not a regular file).
+expect_bin_setup_fail 'bin/lean4-skills-foo as symlink (not regular file)' \
+  'mkdir -p lib/scripts && printf "#!/usr/bin/env bash\nexit 0\n" > lib/scripts/target.sh && chmod +x lib/scripts/target.sh && mkdir bin && ln -s ../lib/scripts/target.sh bin/lean4-skills-foo'
+
+# Nested directory inside bin/.
+expect_bin_setup_fail 'bin/ contains nested directory' \
+  'mkdir -p bin/nested && printf "#!/usr/bin/env bash\nexit 0\n" > bin/nested/inner && chmod +x bin/nested/inner'
+
+# --- Pass cases ---
+
+# Empty bin/ directory — vacuously OK.
+expect_bin_setup_pass 'empty bin/ directory' \
+  'mkdir bin'
+
+# bin/ with a single valid wrapper.
+expect_bin_setup_pass 'bin/ with one valid lean4-skills-foo wrapper' \
+  'mkdir bin && printf "#!/usr/bin/env bash\nexit 0\n" > bin/lean4-skills-foo && chmod +x bin/lean4-skills-foo'
+
+# bin/ with multiple valid wrappers.
+expect_bin_setup_pass 'bin/ with three valid lean4-skills-* wrappers' \
+  'mkdir bin && for w in lean4-skills-alpha lean4-skills-beta-gamma lean4-skills-delta9; do printf "#!/usr/bin/env bash\nexit 0\n" > "bin/$w" && chmod +x "bin/$w"; done'
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/plugins/lean4/tools/lint_runtime_portability.sh
+++ b/plugins/lean4/tools/lint_runtime_portability.sh
@@ -36,7 +36,7 @@
 # OR be a real directory containing only `lean4-skills-*` regular
 # executable files (no symlinks-to-dir, no non-prefixed files, no
 # non-executable files). The model-facing wrapper scripts under bin/
-# (added in #129 to fix issue #117) get Claude Code's auto-PATH
+# (introduced to fix issue #117) get Claude Code's auto-PATH
 # allowlist; the guardrails.sh stderr-suppression detector recognizes
 # both bare and path-form invocations of `lean4-skills-*`. Check 10
 # enforces shape only — adding a new wrapper file doesn't require
@@ -278,7 +278,7 @@ done
 # ---------------------------------------------------------------------------
 # Check 10: bin/ shape — curated lean4-skills-* wrappers only
 #
-# plugins/lean4/bin is allowed (and expected, post-#129) to exist as a real
+# plugins/lean4/bin is allowed (and expected) to exist as a real
 # directory containing the model-facing wrapper scripts. The shape rules:
 #
 #   * bin/ must be a directory, not a symlink. A whole-directory symlink

--- a/plugins/lean4/tools/lint_runtime_portability.sh
+++ b/plugins/lean4/tools/lint_runtime_portability.sh
@@ -32,12 +32,16 @@
 # '#!/usr/bin/env sh' polyglot trampoline pattern (which buries shell in
 # __doc__ and leaks into --help output) and absolute interpreter paths.
 #
-# Path policy (Check 10): plugins/lean4/bin must not exist as a symlink,
-# file, or directory. Such a shortcut would let callers invoke runtime
-# scripts via paths that guardrails.sh's Lean-script stderr-suppression
-# detector doesn't recognize (it matches lib/scripts/ and scripts/ only),
-# silently bypassing the safety check. Reintroduce only with a matching
-# guardrail update.
+# Bin/ shape policy (Check 10): plugins/lean4/bin must EITHER not exist
+# OR be a real directory containing only `lean4-skills-*` regular
+# executable files (no symlinks-to-dir, no non-prefixed files, no
+# non-executable files). The model-facing wrapper scripts under bin/
+# (added in #129 to fix issue #117) get Claude Code's auto-PATH
+# allowlist; the guardrails.sh stderr-suppression detector recognizes
+# both bare and path-form invocations of `lean4-skills-*`. Check 10
+# enforces shape only — adding a new wrapper file doesn't require
+# editing this check; the expected wrapper-coverage assertion lives
+# separately in test_contracts.sh.
 #
 # Run:  bash plugins/lean4/tools/lint_runtime_portability.sh
 # ---------------------------------------------------------------------------
@@ -90,7 +94,23 @@ mapfile_compat PY_FILES < <(find \
   "$PLUGIN_ROOT/lib/scripts" \
   -name '*.py' -type f 2>/dev/null | sort)
 
-echo "Scanning ${#SHELL_FILES[@]} shell scripts and ${#PY_FILES[@]} Python files for runtime-portability issues..."
+# Curated model-facing wrappers under bin/ (see issue #117). Extensionless
+# executables, named `lean4-skills-*`. Scanned alongside .sh files by
+# Checks 1-8 (Bash 3.2 portability + shebang), and validated separately
+# by Check 10 (shape: name pattern + regular file + exec bit).
+WRAPPER_FILES=()
+mapfile_compat WRAPPER_FILES < <(find \
+  "$PLUGIN_ROOT/bin" \
+  -maxdepth 1 -name 'lean4-skills-*' -type f 2>/dev/null | sort)
+
+# Append wrappers to SHELL_FILES so Checks 1-8 scan their bodies for
+# Bash 4+ / BSD-incompat constructs without code duplication. Check 10
+# below additionally enforces the bin/ shape constraints.
+for _w in "${WRAPPER_FILES[@]+"${WRAPPER_FILES[@]}"}"; do
+  SHELL_FILES+=("$_w")
+done
+
+echo "Scanning ${#SHELL_FILES[@]} shell files (${#WRAPPER_FILES[@]} bin/ wrappers + $((${#SHELL_FILES[@]} - ${#WRAPPER_FILES[@]})) under hooks/+lib/scripts/) and ${#PY_FILES[@]} Python files for runtime-portability issues..."
 echo ""
 # Note: we don't early-exit on empty arrays here. Check 10 (no bin shortcut
 # path) is a structural check that must always run regardless of file
@@ -256,22 +276,63 @@ done
 [[ $found -eq 0 ]] && ok "All shebanged Python runtime files use #!/usr/bin/env python3"
 
 # ---------------------------------------------------------------------------
-# Check 10: no plugins/lean4/bin shortcut path
+# Check 10: bin/ shape — curated lean4-skills-* wrappers only
 #
-# plugins/lean4/bin (as symlink, dir, or file) gives callers a shorter
-# invocation path that bypasses guardrails.sh's Lean-script
-# stderr-suppression detector, which matches '$LEAN4_SCRIPTS/...',
-# 'plugins/lean4/lib/scripts/...', and './scripts/...' only. A reappearance
-# means the safety check can be silently bypassed via 'bin/foo.py 2>/dev/null'.
-# Reintroduce only together with a matching detector update.
+# plugins/lean4/bin is allowed (and expected, post-#129) to exist as a real
+# directory containing the model-facing wrapper scripts. The shape rules:
+#
+#   * bin/ must be a directory, not a symlink. A whole-directory symlink
+#     (e.g. bin -> lib/scripts) was the original PR #120 approach that
+#     bypassed the guardrails detector wholesale; banned permanently.
+#   * Every entry directly under bin/ must:
+#     - be a regular file (no symlinks, no nested directories)
+#     - be executable (the wrappers exist precisely so Claude Code's auto-
+#       PATH allowlists them; non-executable files would be useless and
+#       suggest someone forgot `chmod +x`)
+#     - have a name matching ^lean4-skills-[a-z][a-z0-9-]*$
+#
+# Check 10 enforces *shape*, not a hardcoded list of wrapper names. Adding
+# or removing wrappers is a docs / test_contracts.sh concern, not a lint
+# change. Absent bin/ is also fine — the shape rule only fires when bin/
+# exists and contains the wrong things.
 # ---------------------------------------------------------------------------
 echo ""
-echo "-- Check 10: no plugins/lean4/bin shortcut path --"
-if [[ -L "$PLUGIN_ROOT/bin" || -e "$PLUGIN_ROOT/bin" ]]; then
-  warn "$PLUGIN_ROOT/bin exists — shortcut bypasses guardrails.sh stderr-suppression detector (matches lib/scripts/ and scripts/ only). Drop the path or update the detector first."
-else
-  ok "No plugins/lean4/bin shortcut path"
+echo "-- Check 10: bin/ shape (curated lean4-skills-* wrappers only) --"
+found=0
+if [[ -L "$PLUGIN_ROOT/bin" ]]; then
+  warn "$PLUGIN_ROOT/bin is a symlink — whole-directory bin/ symlinks bypass the guardrails stderr-suppression detector wholesale. Replace with a real directory containing curated lean4-skills-* wrappers."
+  found=1
+elif [[ -e "$PLUGIN_ROOT/bin" && ! -d "$PLUGIN_ROOT/bin" ]]; then
+  warn "$PLUGIN_ROOT/bin exists but is not a directory — bin/ must be a directory of curated lean4-skills-* wrappers (or absent)."
+  found=1
+elif [[ -d "$PLUGIN_ROOT/bin" ]]; then
+  # Walk bin/ entries and enforce per-entry shape.
+  # Using find with -mindepth 1 -maxdepth 1 to catch direct entries
+  # (regular files, symlinks, and subdirs all).
+  while IFS= read -r entry; do
+    base=$(basename "$entry")
+    if [[ -L "$entry" ]]; then
+      warn "$PLUGIN_ROOT/bin/$base: symlink in bin/ is not allowed; wrappers must be regular files."
+      found=1
+      continue
+    fi
+    if [[ ! -f "$entry" ]]; then
+      warn "$PLUGIN_ROOT/bin/$base: non-file entry in bin/ (directory or device); bin/ must contain only regular files."
+      found=1
+      continue
+    fi
+    if [[ ! "$base" =~ ^lean4-skills-[a-z][a-z0-9-]*$ ]]; then
+      warn "$PLUGIN_ROOT/bin/$base: name does not match ^lean4-skills-[a-z][a-z0-9-]*\$ — bin/ is reserved for model-facing wrappers with that prefix."
+      found=1
+      continue
+    fi
+    if [[ ! -x "$entry" ]]; then
+      warn "$PLUGIN_ROOT/bin/$base: wrapper is not executable. Run 'chmod +x' on it."
+      found=1
+    fi
+  done < <(find "$PLUGIN_ROOT/bin" -mindepth 1 -maxdepth 1 2>/dev/null | sort)
 fi
+[[ $found -eq 0 ]] && ok "bin/ shape OK (${#WRAPPER_FILES[@]} curated lean4-skills-* wrappers)"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/plugins/lean4/tools/test_contracts.sh
+++ b/plugins/lean4/tools/test_contracts.sh
@@ -417,8 +417,8 @@ check25_ok=1
 
 for cmd_file in "$AUTOPROVE" "$AUTOFORMALIZE"; do
     base=$(basename "$cmd_file")
-    if ! grep -q 'cycle_tracker\.sh' "$cmd_file" 2>/dev/null; then
-        fail "Check 25: $base missing cycle_tracker.sh reference in Invocation Contract"
+    if ! grep -q 'lean4-skills-cycle-tracker' "$cmd_file" 2>/dev/null; then
+        fail "Check 25: $base missing lean4-skills-cycle-tracker reference in Invocation Contract"
         check25_ok=0
     fi
 done
@@ -458,8 +458,8 @@ done
 
 # Flag-name consistency: autoprove init contract block must reference long user-facing flags.
 # The init contract spans multiple lines around "cycle_tracker.sh init", so extract a window.
-if grep -q "cycle_tracker.sh.*init" "$AUTOPROVE" 2>/dev/null; then
-    init_block=$(grep -A 3 "cycle_tracker.sh.*init" "$AUTOPROVE" 2>/dev/null)
+if grep -q "lean4-skills-cycle-tracker.*init" "$AUTOPROVE" 2>/dev/null; then
+    init_block=$(grep -A 3 "lean4-skills-cycle-tracker.*init" "$AUTOPROVE" 2>/dev/null)
     for flag in max-stuck-cycles max-total-runtime max-consecutive-deep-cycles; do
         if ! echo "$init_block" | grep -q "$flag"; then
             fail "Check 25: autoprove.md init contract missing --$flag"
@@ -469,8 +469,8 @@ if grep -q "cycle_tracker.sh.*init" "$AUTOPROVE" 2>/dev/null; then
 fi
 
 # autoformalize must NOT reference autoprove-only flag --max-consecutive-deep-cycles in init contract
-if grep -q "cycle_tracker.sh.*init" "$AUTOFORMALIZE" 2>/dev/null; then
-    af_init_block=$(grep -A 3 "cycle_tracker.sh.*init" "$AUTOFORMALIZE" 2>/dev/null)
+if grep -q "lean4-skills-cycle-tracker.*init" "$AUTOFORMALIZE" 2>/dev/null; then
+    af_init_block=$(grep -A 3 "lean4-skills-cycle-tracker.*init" "$AUTOFORMALIZE" 2>/dev/null)
     if echo "$af_init_block" | grep -q "max-consecutive-deep-cycles"; then
         fail "Check 25: autoformalize.md init contract references autoprove-only --max-consecutive-deep-cycles"
         check25_ok=0
@@ -490,6 +490,37 @@ fi
 
 if [[ "$check25_ok" -eq 1 ]]; then
     ok "Check 25: Session tracking contract verified across all files"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 26: every lean4-skills-* wrapper is referenced by at least one
+# model-facing doc surface (commands/, agents/, or SKILL.md). The
+# lint's Check 10 enforces *shape* only; this contract test enforces
+# *coverage* — i.e. wrappers don't drift away from their documented
+# call sites, and the curated set stays aligned with what the model
+# actually invokes.
+#
+# Acceptance: the wrapper name appears either as a bare token
+# (lean4-skills-foo …) or path-form (bin/lean4-skills-foo, etc.) in
+# any of those doc surfaces. Adding a new wrapper file without adding
+# at least one doc reference triggers this check.
+# ---------------------------------------------------------------------------
+check26_ok=1
+BIN_DIR="$PLUGIN_ROOT/bin"
+DOCS_DIRS=("$PLUGIN_ROOT/commands" "$PLUGIN_ROOT/agents" "$PLUGIN_ROOT/skills/lean4/SKILL.md")
+if [[ -d "$BIN_DIR" ]]; then
+    while IFS= read -r wrapper; do
+        name=$(basename "$wrapper")
+        # Search each docs dir/file for the wrapper name as a word token.
+        # \b for word boundary catches both bare invocation and path-form.
+        if ! grep -qrE -- "\\b${name}\\b" "${DOCS_DIRS[@]}" 2>/dev/null; then
+            fail "Check 26: wrapper $name has no doc reference under commands/, agents/, or SKILL.md"
+            check26_ok=0
+        fi
+    done < <(find "$BIN_DIR" -mindepth 1 -maxdepth 1 -name 'lean4-skills-*' -type f 2>/dev/null | sort)
+fi
+if [[ "$check26_ok" -eq 1 ]]; then
+    ok "Check 26: bin/lean4-skills-* wrappers are all doc-referenced"
 fi
 
 echo ""

--- a/plugins/lean4/tools/test_contracts.sh
+++ b/plugins/lean4/tools/test_contracts.sh
@@ -523,6 +523,65 @@ if [[ "$check26_ok" -eq 1 ]]; then
     ok "Check 26: bin/lean4-skills-* wrappers are all doc-referenced"
 fi
 
+# ---------------------------------------------------------------------------
+# Check 27: no stale `$LEAN4_SCRIPTS/<wrapped-script>` invocations in
+# model-facing docs. Catches doc drift after a wrapper is added — every
+# wrapped script's env-var-form invocation should become the bare wrapper
+# name in model-facing surfaces, unless the line is explicitly marked
+# with the sentinel `guardrails: compatibility-fallback` (for intentional
+# fallback documentation).
+#
+# Sentinel form is syntax-appropriate:
+#   - Inside fenced code blocks: trailing `# guardrails: compatibility-fallback`
+#   - In markdown prose:         trailing `<!-- guardrails: compatibility-fallback -->`
+# The grep filter is the same in both cases (substring match on
+# `guardrails: compatibility-fallback`).
+#
+# Wrapper-to-script mapping is derived from each wrapper's body
+# (looking for the `lib/scripts/<basename>` delegation), not by
+# inferring an extension from the wrapper name (some target .py,
+# some .sh; not safe to guess).
+# ---------------------------------------------------------------------------
+check27_ok=1
+DOC_SURFACES=(
+    "$PLUGIN_ROOT/commands"
+    "$PLUGIN_ROOT/agents"
+    "$PLUGIN_ROOT/skills/lean4/SKILL.md"
+    "$PLUGIN_ROOT/skills/lean4/references"
+    "$PLUGIN_ROOT/README.md"
+    "$PLUGIN_ROOT/../../INSTALLATION.md"
+)
+if [[ -d "$BIN_DIR" ]]; then
+    while IFS= read -r wrapper; do
+        # Derive underlying script basename by parsing the wrapper body.
+        # Anchored to the .py / .sh extension so we don't accidentally
+        # pick up trailing punctuation from a docstring (e.g.,
+        # `wrapper around lib/scripts/foo.py.` would otherwise yield
+        # `foo.py.`). Prefer the exec/invocation line over any docstring.
+        script=$(grep -oE 'lib/scripts/[a-zA-Z0-9_-]+\.(py|sh)' "$wrapper" 2>/dev/null \
+            | tail -1 \
+            | sed 's|lib/scripts/||')
+        [[ -z "$script" ]] && continue
+        # Escape for grep regex.
+        sc_re=$(printf '%s' "$script" | sed 's/[][\/.^$*+?{}|()]/\\&/g')
+        # Match both spellings: $LEAN4_SCRIPTS/<script> and ${LEAN4_SCRIPTS}/<script>.
+        pat='\$\{?LEAN4_SCRIPTS\}?/'"$sc_re"
+        # Search each doc surface; -I skips binaries; --include keeps it to .md.
+        matches=$(grep -rnIE --include='*.md' -- "$pat" "${DOC_SURFACES[@]}" 2>/dev/null \
+            | grep -v 'guardrails: compatibility-fallback' || true)
+        if [[ -n "$matches" ]]; then
+            fail "Check 27: stale \$LEAN4_SCRIPTS/$script invocation(s) in model-facing docs (use wrapper $(basename "$wrapper") or add a 'guardrails: compatibility-fallback' sentinel):"
+            while IFS= read -r m; do
+                echo "    $m" >&2
+            done <<<"$matches"
+            check27_ok=0
+        fi
+    done < <(find "$BIN_DIR" -mindepth 1 -maxdepth 1 -name 'lean4-skills-*' -type f 2>/dev/null | sort)
+fi
+if [[ "$check27_ok" -eq 1 ]]; then
+    ok "Check 27: no stale \$LEAN4_SCRIPTS/<wrapped> invocations in model-facing docs"
+fi
+
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Closes #117. Drops Claude Code's per-invocation permission prompts on hot-path scripts (cycle-tracker, sorry-analyzer, find-golfable, etc.) by shipping them as **prefixed wrappers under `plugins/lean4/bin/`** that Claude Code statically allowlists via its auto-PATH plugin convention.

Branched off the previous v4.4.10 baseline; **merged v4.5.0 main into the branch** (commit `d963b86`) to pick up #131 (three-tier guardrails) and #134 (disprove command). After the merge, six pre-merge review items from the latest pass are addressed and version bumps to **v4.5.1**.

## Wrapper set (curated, model-facing only)

```
lean4-skills-cycle-tracker         (autoprove hot path)
lean4-skills-sorry-analyzer
lean4-skills-find-golfable
lean4-skills-find-exact-candidates
lean4-skills-analyze-let-usage
lean4-skills-check-axioms-inline
lean4-skills-find-usages
lean4-skills-search-mathlib
lean4-skills-smart-search
```

Internal plumbing (`parse_command_args.py`, `solver_cascade.py`, `try_exact_at_step.py`, test fixtures, etc.) is intentionally **not** wrapped — #117 is about reducing **repeated** permission prompts on **model-emitted** Bash calls, not creating a public CLI for every helper. `$LEAN4_SCRIPTS` / `LEAN4_PYTHON_BIN` env vars stay exported for non-Claude-Code hosts.

## Commits

**Original 8 (pre-main-merge):**

1. **`feat(bin)`** (`b0c33da`) — 9 new `lean4-skills-*` wrapper scripts under `plugins/lean4/bin/`.
2. **`feat(guardrails)`** (`f869eaf`) — guardrails detector regex extended to recognize `lean4-skills-*` invocations in all four call forms.
3. **`feat(lint)`** (`861dd33`) — `lint_runtime_portability.sh` Checks 1–8 expanded to scan wrappers; Check 10 rewritten to enforce `bin/` shape.
4. **`ci(lint)`** (`1fa2c1a`) — `lint.yml` shellcheck step covers wrappers too.
5. **`test(contracts)`** (`5f2de9f`) — Check 25 updated for renamed `cycle-tracker` invocation; new Check 26 asserts every wrapper file is doc-referenced.
6. **`docs`** (`f96cef6`) — `commands/`, `agents/`, `SKILL.md` switched from `$LEAN4_SCRIPTS/script.sh` to `lean4-skills-script` for the wrapped 9.
7. **`docs`** (`4cdfae0`) — restore bash code-fence openers eaten by the wrapper-replace regex.
8. **`docs`** (`2b7898e`) — non-Claude-host PATH setup + wrapper-first invocation contract.

**Merge + cleanup (this round):**

9. **`merge`** (`d963b86`) — bring v4.5.0 main into the branch. Cleanly applied; only `guardrails.sh` needed a port to keep the wrapper token alternative alongside main's three-tier `_has_lean_script_token` helper.
10. **`release: v4.5.1`** (`31b35d0`) — plugin.json + marketplace.json bumped 4.5.0 → 4.5.1; CHANGELOG entry for the wrapper feature; corrected `.github/workflows/lint.yml` comment typo (#129 → #130, for #117).
11. **`docs(subagent-workflows)`** (`38e96de`) — 16 stale `$LEAN4_SCRIPTS/<wrapped>` invocations rewritten to wrapper names.
12. **`docs(axiom-elimination)`** (`19f6ba7`) — 9 stale invocations rewritten.
13. **`docs(references)`** (`9445b27`) — 6 stale invocations across compiler-guided-repair, command-examples, agent-workflows rewritten.
14. **`docs(installation)`** (`5ac33e8`) — INSTALLATION.md wrapper-first: 'Scripts Not Executable' troubleshooting leads with `command -v lean4-skills-sorry-analyzer`; "three env vars" → "four env vars" (PATH is now in bootstrap); verify block aligned on wrapper-form.
15. **`docs(doctor)`** (`2986472`) — `commands/doctor.md` lists `bin/` in plugin structure with inline PATH-resolution check; troubleshooting table gains a "lean4-skills-* wrapper not found on PATH" row; "Scripts not executable" row leads with wrapper-first check.
16. **`test(contracts) Check 27`** (`329c328`) — new negative-grep contract test asserts no stale `$LEAN4_SCRIPTS/<wrapped>` invocations remain in model-facing docs (commands/, agents/, SKILL.md, references/, README.md, INSTALLATION.md). Wrapper-to-script mapping parsed from each wrapper's body (not inferred from extension). Line-local sentinel `guardrails: compatibility-fallback` (trailing HTML comment in prose, trailing `#` in code fences) opts a line out — used for documented fallback contracts in `sorry-filling.md`. Check 27 immediately surfaced 7 audit-missed stale references (disprove-engine, disprove.md, proof-golfing, README); all rewritten.
17. **`docs(doctor)`** (`c4a425d`) — compact the bin/ surface addition to stay under `lint_docs.sh`'s 225-line target on doctor.md.

## Three pre-merge concerns the reviewer flagged

| # | Concern | Resolution |
|---|---|---|
| 1 | Branch behind v4.5.0 main; plugin.json still 4.4.10 | Phase A merge + Phase B bump to v4.5.1 with CHANGELOG entry |
| 2 | Model-facing reference docs still teach `$LEAN4_SCRIPTS/<wrapped>` | Phase C rewrites in 4 commits across subagent-workflows / axiom-elimination / 3 smaller files / INSTALLATION |
| 3 | `commands/doctor.md` doesn't list `bin/` and recommends `chmod +x $LEAN4_SCRIPTS/*.sh` | Phase D adds `bin/` row with inline `command -v` PATH check; troubleshooting table updated |
| 4 | Contract test Check 26 confirms wrappers are *mentioned* but doesn't catch stale `$LEAN4_SCRIPTS/<wrapped>` examples | Phase E adds Check 27 (negative grep + line-local sentinels); 7 audit-missed stales surfaced and fixed |
| 5 | `lint.yml` comment "added in #129" | Fixed: "added in #130, for #117" |
| 6 | INSTALLATION.md says "three env vars" / has env-var-form invocations | Phase C commit 6 updates to "four env vars" + wrapper-first examples + wrapper-PATH verify block |

## Verification

- `bash plugins/lean4/tests/test_guardrails.sh` — 270 passed, 0 failed (both PRs' coverage).
- `bash plugins/lean4/tools/test_contracts.sh` — 29 passed, 0 failed (Check 26 wrapper-coverage + Check 27 no-stale-env-var-form).
- `bash plugins/lean4/tools/lint_runtime_portability.sh` — 18 shell + 17 Python files pass (wrappers included in scope).
- `bash plugins/lean4/tools/lint_docs.sh` — version-consistency check confirms 4.5.1 marketplace/plugin.json match; CHANGELOG entry present.
- **CI is currently stale** from 2026-05-20 against head `2b7898e` (pre-merge of #131 and #134). Expect fresh CI runs on the new head; final merge gate is fresh green on macos-bash3 + mypy + ruff + shellcheck.
- **Sandbox smoke (manual, before merge):** install the PR build in Claude Code with sandbox mode enabled; run `lean4-skills-cycle-tracker tick` / `lean4-skills-sorry-analyzer .` / etc. and confirm first invocation is allowlisted as `Bash(lean4-skills-*:*)` and subsequent invocations do **not** prompt per-call. This is the actual product behavior the PR is meant to fix; CI cannot cover it.
