### PR TITLE
chore(guardrails): three-tier git policy (path-scoped destructive ops soft-gated)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Lean 4 theorem proving with guided + autonomous proving, LSP-first workflows, guardrails, and contribution helpers",
-    "version": "4.4.10"
+    "version": "4.4.11"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v4.4.11 (May 2026)
+
+Three-tier git-op policy. Path-scoped `git checkout` / `git restore` operations move from absolute hard-block to a new policy-controlled soft-gate; whole-worktree and force-branch-switch destructive ops remain absolute. No new commands or workflow changes; default behavior is backward-compatible.
+
+### Guardrail tiers (`plugins/lean4/hooks/guardrails.sh`)
+
+- Add `LEAN4_GUARDRAILS_DESTRUCTIVE_POLICY` (`ask` default, `allow`, `block`) covering path-scoped `git checkout` / `git restore` forms — independent of the existing `LEAN4_GUARDRAILS_COLLAB_POLICY` (#131)
+- `LEAN4_GUARDRAILS_BYPASS=1` one-shot prefix applies to either soft-gate category
+- Whole-worktree variants (`git checkout .` / `./` / `:/` / `HEAD -- .`, `git restore .` / `--staged --worktree`, `git reset --hard`, `git clean -f`) stay absolute hard-block; pure unstaging (`git restore --staged <path>`) stays implicit-allow
+- Force-branch checkout/switch (`git checkout -f|--force <branch-or-ref>`, `git switch -f|--force|--discard-changes`) hard-block; option ordering and ref shorthand (`@{-1}`, `-`, `@`, `HEAD~3`, `HEAD@{1}`) all covered
+- `--pathspec-from-file=…` hard-blocks for both checkout and restore (opaque paths file the guardrail can't inspect); `--staged --pathspec-from-file=…` stays allowed
+- Path-scoped soft-gate covers `<tree-ish> <path>`, `--ours` / `--theirs` / `-2` / `-3` / `--merge` / `--conflict=<style>`, `-f <path-like>`, `./<path>` / `:/<path>` / `../<path>` (incl. dotfiles), `--ignore-skip-worktree-bits` / `--no-overlay` / `--overlay` / `--recurse-submodules`, `-p` / `--patch`, all with non-destructive flag prefix/interleaving
+
+### Tests
+
+- `test_guardrails.sh` grows from 75 to 251 probes; new tier-boundary coverage for the forms above, including empirical temp-repo verification of which checkout/switch shapes actually discard a dirty worktree (audit posted as a PR comment)
+
+### Docs
+
+- `plugins/lean4/README.md` and `plugins/lean4/MIGRATION.md` document the three-tier model, the new env var, the bypass token's scope, and the path-scoped vs whole-worktree distinction
+
 ## v4.4.10 (May 2026)
 
 Portability hardening, lint/CI infrastructure, and a broad code-quality sweep. No new commands or user-facing behavior changes.

--- a/plugins/lean4/.claude-plugin/plugin.json
+++ b/plugins/lean4/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lean4",
-  "version": "4.4.10",
+  "version": "4.4.11",
   "description": "Unified Lean 4 plugin (draft, formalize, autoformalize, prove, autoprove, checkpoint, review, refactor, golf, learn, doctor) — LSP-first, scripts fallback",
   "author": {"name": "Cameron Freer", "email": "cameronfreer@gmail.com"}
 }

--- a/plugins/lean4/MIGRATION.md
+++ b/plugins/lean4/MIGRATION.md
@@ -120,8 +120,14 @@ V4 blocks certain git operations when working inside a Lean project (detected by
 - `gh pr create` - Review first with `/lean4:review`
 
 Override with `LEAN4_GUARDRAILS_DISABLE=1` (skip all) or `LEAN4_GUARDRAILS_FORCE=1` (enforce everywhere). `LEAN4_GUARDRAILS_DISABLE` takes precedence over `LEAN4_GUARDRAILS_FORCE`.
-Set `LEAN4_GUARDRAILS_COLLAB_POLICY` to control collaboration ops: `ask` (default, current behavior), `allow` (no prompts), or `block` (unconditional block). Default `ask` mode preserves current behavior — set `allow` for no prompts on collaboration ops.
-For a single collaboration command in `ask` mode, prefix with the bypass token instead (command prefix only, not an env var): `LEAN4_GUARDRAILS_BYPASS=1 git push origin main`. Destructive operations remain hard-blocked regardless of policy.
+
+Two independent soft-gate policies (each `ask` | `allow` | `block`, default `ask`):
+- `LEAN4_GUARDRAILS_COLLAB_POLICY` — controls `git push`, `git commit --amend`, `gh pr create`.
+- `LEAN4_GUARDRAILS_DESTRUCTIVE_POLICY` — controls path-scoped destructive ops (`git checkout -- <path…>`, `git restore <path…>`).
+
+For a single soft-gated command in `ask` mode, prefix with the bypass token instead (command prefix only, not an env var): `LEAN4_GUARDRAILS_BYPASS=1 git push origin main`. The token applies to either soft-gate category.
+
+**Whole-worktree** destructive operations (`git reset --hard`, `git clean -f`/`-fd`/`-fdx`, `git checkout .`/`-- .`/`-- :/`/`HEAD -- .`, `git restore .`/`./`/`:/`, `git restore --staged --worktree`) remain **hard-blocked** regardless of either policy or the bypass token. The blast radius is unbounded and reflog can't recover uncommitted edits; `clean -f` can't recover untracked files at all. Pure unstaging (`git restore --staged <anything>` without `--worktree`) is always allowed since it only touches the index.
 
 ### Memory System (REMOVED)
 

--- a/plugins/lean4/README.md
+++ b/plugins/lean4/README.md
@@ -180,28 +180,49 @@ Blocked during Lean project sessions:
 | `LEAN4_GUARDRAILS_DISABLE=1` | Skip all guardrails regardless of context |
 | `LEAN4_GUARDRAILS_FORCE=1` | Enforce guardrails even outside Lean projects |
 | `LEAN4_GUARDRAILS_COLLAB_POLICY` | Collaboration op policy: `ask` (default), `allow`, `block` |
+| `LEAN4_GUARDRAILS_DESTRUCTIVE_POLICY` | Path-scoped destructive op policy: `ask` (default), `allow`, `block` |
 
 `LEAN4_GUARDRAILS_DISABLE` overrides everything. `LEAN4_GUARDRAILS_FORCE` controls whether guardrails activate outside Lean projects.
 
+Git operations fall into **three tiers**:
+
+1. **Allow** (implicit, no gate): `git status`, `diff`, `log`, `show`, `branch`, `add`, `commit`, `stash push`, `switch <branch>`, `checkout <branch>`, `restore --staged <path>` (pure unstaging, any pathspec including `.`).
+2. **Soft-gate** (policy-controlled, bypass-able): collaboration ops + path-scoped destructive ops. See subsections below.
+3. **Hard-block** (absolute, never bypassable): `git reset --hard`, `git clean -f`/`-fd`/`-fdx`, plus the whole-worktree variants — `git checkout .`/`./`/`-- .`/`-- ./`/`-- :/`/`HEAD -- .`, `git restore .`/`./`/`:/`, `git restore --staged --worktree`. These wipe state across the whole worktree (or untracked files); reflog can't recover uncommitted edits and `clean -f` can't recover untracked files at all.
+
 **Collaboration policy (`LEAN4_GUARDRAILS_COLLAB_POLICY`):**
 
-Controls how collaboration ops (`git push`, `git commit --amend`, `gh pr create`) are handled:
+Controls how collaboration ops (`git push`, `git commit --amend`, `gh pr create`) — operations that affect shared state — are handled:
 
 - **`ask`** (default) — block unless a one-shot bypass token is present. The hook is non-interactive; in `ask` mode the assistant asks you yes/no, then reruns the command with the bypass token once.
 - **`allow`** — permit collaboration ops without a bypass token.
 - **`block`** — block collaboration ops unconditionally, even with a bypass token.
 
-Invalid values fall back to `ask`. Destructive operations (`checkout --`, `restore`, `reset --hard`, `clean -f`) are always blocked regardless of policy.
+Invalid values fall back to `ask`.
 
-**One-shot bypass (collaboration ops only):**
+**Destructive policy (`LEAN4_GUARDRAILS_DESTRUCTIVE_POLICY`):**
 
-To override a single blocked collaboration command (`git push`, `git commit --amend`, `gh pr create`), prefix it with the bypass token:
+Controls how **path-scoped** destructive ops — `git checkout -- <path…>` and `git restore <path…>` (without `--staged`) — are handled. These have bounded blast radius (the named pathset only) but still discard uncommitted edits the reflog can't recover.
+
+- **`ask`** (default) — block unless a one-shot bypass token is present.
+- **`allow`** — permit path-scoped destructive ops without a bypass token (useful when routinely reverting experimental files).
+- **`block`** — block unconditionally, even with a bypass token.
+
+Invalid values fall back to `ask`. Whole-worktree destructive variants (tier 3 above) are independent of this policy and **always block** regardless of its value or the bypass token.
+
+The two policies are independent: `DESTRUCTIVE_POLICY=allow` does not unblock collab ops, and `COLLAB_POLICY=allow` does not unblock path-scoped destructive ops.
+
+**One-shot bypass (soft-gated ops):**
+
+To override a single blocked soft-gated command, prefix it with the bypass token:
 
 ```bash
 LEAN4_GUARDRAILS_BYPASS=1 git push origin main
+LEAN4_GUARDRAILS_BYPASS=1 git checkout -- experiment.lean
+LEAN4_GUARDRAILS_BYPASS=1 git restore src/some_file.lean
 ```
 
-The token must appear in the leading env-assignment prefix of the command (command prefix only, not an environment variable). Bypass is effective only in `ask` mode (default); it is unnecessary in `allow` mode and ignored in `block` mode. Destructive operations (`checkout --`, `restore`, `reset --hard`, `clean -f`) are always blocked — bypass does not apply to them.
+The token must appear in the leading env-assignment prefix of the command (command prefix only, not an environment variable). Bypass is effective only in `ask` mode (default for both policies); it is unnecessary in `allow` mode and ignored in `block` mode. Bypass does **not** apply to whole-worktree hard-blocked ops (`reset --hard`, `clean -f`, `checkout .`, etc.) — those are absolute.
 
 ### LSP-First Approach
 

--- a/plugins/lean4/README.md
+++ b/plugins/lean4/README.md
@@ -170,8 +170,8 @@ Guarded during Lean project sessions (policy/tier details below):
 - `git push` → Use `/lean4:checkpoint`, then push manually (soft-gate, bypass-able)
 - `git commit --amend` → Each change is a new commit for safe rollback (soft-gate, bypass-able)
 - `gh pr create` → Review first with `/lean4:review` (soft-gate, bypass-able)
-- Path-scoped destructive git (`checkout -- <path>`, `restore <path>`, `checkout <tree-ish> <path>`) → soft-gate, bypass-able; default `ask` mode
-- Whole-worktree destructive git (`reset --hard`, `clean -f`, `checkout .` / `-- .` / `HEAD -- .`, `restore .`, `restore --staged --worktree`) → absolute hard-block; bypass does not apply
+- Path-scoped destructive git (`checkout -- <path>`, `checkout <tree-ish> <path>`, `checkout {--ours,--theirs,-2,-3,--conflict=…} <path>`, `checkout -f <path>`, `checkout ./<path>`, `restore <path>` and short-flag variants) → soft-gate, bypass-able; default `ask` mode
+- Whole-worktree / force-branch destructive git (`reset --hard`, `clean -f`, `checkout .` / `-- .` / `HEAD -- .` / `-f .` / `--ours .`, `restore .` / `-SW`, `checkout --pathspec-from-file`, `restore --pathspec-from-file` (non-staged), `checkout -f|--force <branch>`, `switch -f|--force|--discard-changes`) → absolute hard-block; bypass does not apply
 - Deep sorry-filling has snapshot, rollback, scope budgets, and regression gates — see [Cycle Engine](skills/lean4/references/cycle-engine.md#deep-mode)
 
 **Override environment variables:**
@@ -189,7 +189,7 @@ Git operations fall into **three tiers**:
 
 1. **Allow** (implicit, no gate): `git status`, `diff`, `log`, `show`, `branch`, `add`, `commit`, `stash push`, `switch <branch>`, `checkout <branch>`, `restore --staged <path>` (pure unstaging, any pathspec including `.`).
 2. **Soft-gate** (policy-controlled, bypass-able): collaboration ops + path-scoped destructive ops. See subsections below.
-3. **Hard-block** (absolute, never bypassable): `git reset --hard`, `git clean -f`/`-fd`/`-fdx`, plus the whole-worktree variants — `git checkout .`/`./`/`-- .`/`-- ./`/`-- :/`/`HEAD -- .`, `git restore .`/`./`/`:/`, `git restore --staged --worktree`. These wipe state across the whole worktree (or untracked files); reflog can't recover uncommitted edits and `clean -f` can't recover untracked files at all.
+3. **Hard-block** (absolute, never bypassable): `git reset --hard`, `git clean -f`/`-fd`/`-fdx`, plus the whole-worktree, opaque-pathspec, and force-branch variants — `git checkout .`/`./`/`-- .`/`-- ./`/`-- :/`/`HEAD -- .`/`-f .`/`--ours .`/`--theirs :/`, `git checkout --pathspec-from-file=…`, `git checkout -f|--force <branch>`, `git restore .`/`./`/`:/`, `git restore --staged --worktree` (incl. `-SW` short-flag bundle), `git restore --pathspec-from-file=…` (non-staged), `git switch -f|--force|--discard-changes <anything>`. These wipe state across the whole worktree (or untracked files), discard uncommitted edits during branch switching, or accept opaque path lists the guardrail can't inspect; reflog can't recover uncommitted edits and `clean -f` can't recover untracked files at all.
 
 **Collaboration policy (`LEAN4_GUARDRAILS_COLLAB_POLICY`):**
 
@@ -203,7 +203,16 @@ Invalid values fall back to `ask`.
 
 **Destructive policy (`LEAN4_GUARDRAILS_DESTRUCTIVE_POLICY`):**
 
-Controls how **path-scoped** destructive ops — `git checkout -- <path…>` and `git restore <path…>` (without `--staged`) — are handled. These have bounded blast radius (the named pathset only) but still discard uncommitted edits the reflog can't recover.
+Controls how **path-scoped** destructive ops are handled. The covered forms (each with bounded blast radius — the named pathset only — but still discarding uncommitted edits the reflog can't recover):
+
+- `git checkout -- <path…>`
+- `git checkout <tree-ish> <path…>` (without `--`, e.g. `git checkout HEAD file.lean`)
+- `git checkout {--ours,--theirs,-2,-3,--conflict=…} <path…>` (merge-conflict resolution flags)
+- `git checkout -f|--force <path-like>` (path-scoped force-restore; `-f <branch>` is hard-blocked)
+- `git checkout ./<path>` / `:/<path>` / `../<path>` (explicit path-prefix positionals, including dotfiles)
+- `git restore <path…>` (any worktree-touching flag combination, including `-W`, `-SW`, etc.)
+
+`git restore --staged <path>` (pure unstaging, including pathspec `.`) is always allowed regardless of policy — it's index-only and reversible.
 
 - **`ask`** (default) — block unless a one-shot bypass token is present.
 - **`allow`** — permit path-scoped destructive ops without a bypass token (useful when routinely reverting experimental files).

--- a/plugins/lean4/README.md
+++ b/plugins/lean4/README.md
@@ -170,8 +170,8 @@ Guarded during Lean project sessions (policy/tier details below):
 - `git push` → Use `/lean4:checkpoint`, then push manually (soft-gate, bypass-able)
 - `git commit --amend` → Each change is a new commit for safe rollback (soft-gate, bypass-able)
 - `gh pr create` → Review first with `/lean4:review` (soft-gate, bypass-able)
-- Path-scoped destructive git (`checkout -- <path>`, `checkout <tree-ish> <path>`, `checkout {--ours,--theirs,-2,-3,--conflict=…} <path>`, `checkout -f <path>`, `checkout ./<path>`, `restore <path>` and short-flag variants) → soft-gate, bypass-able; default `ask` mode
-- Whole-worktree / force-branch destructive git (`reset --hard`, `clean -f`, `checkout .` / `-- .` / `HEAD -- .` / `-f .` / `--ours .`, `restore .` / `-SW`, `checkout --pathspec-from-file`, `restore --pathspec-from-file` (non-staged), `checkout -f|--force <branch>`, `switch -f|--force|--discard-changes`) → absolute hard-block; bypass does not apply
+- Path-scoped destructive git (`checkout -- <path>`, `checkout [-q|--quiet] <tree-ish> <path>`, `checkout {--ours,--theirs,-2,-3,--merge,--conflict=…} <path>`, `checkout {--ignore-skip-worktree-bits,--no-overlay,--overlay,--recurse-submodules,-p,--patch} <path>`, `checkout -f <path-like>`, `checkout ./<path>` (incl. dotfiles), `restore <path>` and short-flag variants) → soft-gate, bypass-able; default `ask` mode
+- Whole-worktree / force-branch / interactive-sweep destructive git (`reset --hard`, `clean -f`, `checkout .` / `-- .` / `HEAD -- .` / `-f .` / `--ours .`, `restore .` / `-SW`, `checkout --pathspec-from-file`, `restore --pathspec-from-file` (non-staged), `checkout -f|--force <branch-or-ref>`, `checkout -p`/`--patch` with no path, `switch -f|--force|--discard-changes`) → absolute hard-block; bypass does not apply
 - Deep sorry-filling has snapshot, rollback, scope budgets, and regression gates — see [Cycle Engine](skills/lean4/references/cycle-engine.md#deep-mode)
 
 **Override environment variables:**
@@ -189,7 +189,7 @@ Git operations fall into **three tiers**:
 
 1. **Allow** (implicit, no gate): `git status`, `diff`, `log`, `show`, `branch`, `add`, `commit`, `stash push`, `switch <branch>`, `checkout <branch>`, `restore --staged <path>` (pure unstaging, any pathspec including `.`).
 2. **Soft-gate** (policy-controlled, bypass-able): collaboration ops + path-scoped destructive ops. See subsections below.
-3. **Hard-block** (absolute, never bypassable): `git reset --hard`, `git clean -f`/`-fd`/`-fdx`, plus the whole-worktree, opaque-pathspec, and force-branch variants — `git checkout .`/`./`/`-- .`/`-- ./`/`-- :/`/`HEAD -- .`/`-f .`/`--ours .`/`--theirs :/`, `git checkout --pathspec-from-file=…`, `git checkout -f|--force <branch>`, `git restore .`/`./`/`:/`, `git restore --staged --worktree` (incl. `-SW` short-flag bundle), `git restore --pathspec-from-file=…` (non-staged), `git switch -f|--force|--discard-changes <anything>`. These wipe state across the whole worktree (or untracked files), discard uncommitted edits during branch switching, or accept opaque path lists the guardrail can't inspect; reflog can't recover uncommitted edits and `clean -f` can't recover untracked files at all.
+3. **Hard-block** (absolute, never bypassable): `git reset --hard`, `git clean -f`/`-fd`/`-fdx`, plus the whole-worktree, opaque-pathspec, force-branch, and interactive-sweep variants — `git checkout .`/`./`/`-- .`/`-- ./`/`-- :/`/`HEAD -- .`/`-f .`/`--ours .`/`--theirs :/`, `git checkout --pathspec-from-file=…`, `git checkout -f|--force <branch-or-ref>` (incl. ref shorthand `@{-1}`, `-`, `@`, `HEAD~3`, `HEAD@{1}`), `git checkout -p`/`--patch` with no path positional (interactive whole-worktree sweep, bypassable by piped stdin), `git restore .`/`./`/`:/`, `git restore --staged --worktree` (incl. `-SW` short-flag bundle), `git restore --pathspec-from-file=…` (non-staged), `git switch -f|--force|--discard-changes <anything>`. These wipe state across the whole worktree (or untracked files), discard uncommitted edits during branch switching, sweep modified files interactively from an opaque stdin source, or accept opaque path lists the guardrail can't inspect; reflog can't recover uncommitted edits and `clean -f` can't recover untracked files at all.
 
 **Collaboration policy (`LEAN4_GUARDRAILS_COLLAB_POLICY`):**
 
@@ -206,9 +206,10 @@ Invalid values fall back to `ask`.
 Controls how **path-scoped** destructive ops are handled. The covered forms (each with bounded blast radius — the named pathset only — but still discarding uncommitted edits the reflog can't recover):
 
 - `git checkout -- <path…>`
-- `git checkout <tree-ish> <path…>` (without `--`, e.g. `git checkout HEAD file.lean`)
-- `git checkout {--ours,--theirs,-2,-3,--conflict=…} <path…>` (merge-conflict resolution flags)
-- `git checkout -f|--force <path-like>` (path-scoped force-restore; `-f <branch>` is hard-blocked)
+- `git checkout [-q|--quiet] <tree-ish> <path…>` (without `--`, e.g. `git checkout HEAD file.lean`; non-destructive flag prefix or interleaving OK)
+- `git checkout {--ours,--theirs,-2,-3,--merge,--conflict=<style>} <path…>` (merge-conflict resolution flags; long-form `--merge` covered, short-form `-m` deferred per `_strip_optvals` limitation)
+- `git checkout {--ignore-skip-worktree-bits,--no-overlay,--overlay,--recurse-submodules,-p,--patch} <path…>` (pathspec-oriented flags; `-p`/`--patch` is interactive but pipes like `yes y | …` bypass interactivity, so soft-gated regardless of TTY)
+- `git checkout -f|--force <path-like>` (path-scoped force-restore; `-f <branch-or-ref>` is hard-blocked instead)
 - `git checkout ./<path>` / `:/<path>` / `../<path>` (explicit path-prefix positionals, including dotfiles)
 - `git restore <path…>` (any worktree-touching flag combination, including `-W`, `-SW`, etc.)
 

--- a/plugins/lean4/README.md
+++ b/plugins/lean4/README.md
@@ -166,11 +166,12 @@ Checks your environment (lean, lake, python, git), plugin structure, project hea
 
 Guardrails activate only in Lean project context (a directory tree containing `lakefile.lean`, `lean-toolchain`, or `lakefile.toml`). Outside Lean projects, they are silently skipped.
 
-Blocked during Lean project sessions:
-- `git push` → Use `/lean4:checkpoint`, then push manually
-- `git commit --amend` → Each change is a new commit for safe rollback
-- `gh pr create` → Review first with `/lean4:review`
-- Destructive git operations (`checkout --`, `restore`, `reset --hard`, `clean -f`) → Commit or checkpoint first
+Guarded during Lean project sessions (policy/tier details below):
+- `git push` → Use `/lean4:checkpoint`, then push manually (soft-gate, bypass-able)
+- `git commit --amend` → Each change is a new commit for safe rollback (soft-gate, bypass-able)
+- `gh pr create` → Review first with `/lean4:review` (soft-gate, bypass-able)
+- Path-scoped destructive git (`checkout -- <path>`, `restore <path>`, `checkout <tree-ish> <path>`) → soft-gate, bypass-able; default `ask` mode
+- Whole-worktree destructive git (`reset --hard`, `clean -f`, `checkout .` / `-- .` / `HEAD -- .`, `restore .`, `restore --staged --worktree`) → absolute hard-block; bypass does not apply
 - Deep sorry-filling has snapshot, rollback, scope budgets, and regression gates — see [Cycle Engine](skills/lean4/references/cycle-engine.md#deep-mode)
 
 **Override environment variables:**

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -72,7 +72,7 @@ fi
 #          FOO="LEAN4_GUARDRAILS_BYPASS=1" git push ...  (token inside quoted value)
 # Applies to soft-gated ops (collaboration + path-scoped destructive);
 # the whole-worktree destructive ops (reset --hard, clean -f,
-# checkout .,restore .) remain non-bypassable regardless.
+# checkout ., restore .) remain non-bypassable regardless.
 # Never exits early — all destructive checks run first; bypass resolves at end.
 BYPASS=0
 

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -597,6 +597,30 @@ if seg_match git '\bswitch\b.*\s(-f|--force|--discard-changes)(\s|$)'; then
   exit 2
 fi
 
+# git checkout -p|--patch without a path positional — interactive
+# whole-worktree sweep. Same blast radius as `git checkout .` /
+# `git checkout HEAD --` (rewrites every modified file the user says
+# `y` to). Empirically verified (separate temp-repo probe) that both
+# `yes y | git checkout -p` AND `yes y | git checkout -p HEAD` wipe
+# every dirty file in the worktree — the interactive prompt isn't
+# protection against piped stdin. Tier-1 hard-block, no bypass.
+#
+# Heuristic for "no path positional": no token in the segment contains
+# `/`, `.`, or `:` after the leading non-flag char. With a path-like
+# positional (`-p file.lean`, `-p HEAD docs/foo.lean`), defers to the
+# pathspec-oriented flag soft-gate below.
+for _seg in "${SEGMENTS[@]}"; do
+  echo "$_seg" | grep -qE '^git\b' || continue
+  echo "$_seg" | grep -qE '\bcheckout\b' || continue
+  echo "$_seg" | grep -qE '\s(-p|--patch)(\s|$)' || continue
+  # Path-like positional present → defer to soft-gate.
+  if echo "$_seg" | grep -qE '(^|\s)[^-\s]\S*[/.:]\S*(\s|$)'; then
+    continue
+  fi
+  echo "BLOCKED (Lean guardrail): git checkout -p / --patch without a path is an interactive whole-worktree sweep that pipes (yes y | …) can bypass. Commit or checkpoint first, then narrow to specific paths." >&2
+  exit 2
+done
+
 # git checkout -f|--force — force-mode checkout. Order-insensitive
 # loop so `-f` may appear anywhere in the option run (e.g.
 # `git checkout -q -f main`, `--quiet --force main`, `-f --detach HEAD`,

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -656,7 +656,7 @@ fi
 # checkout context would require splitting the normalization pipeline
 # per-command; deferred. `--ours`/`--theirs`/`--conflict` are not
 # stripped and are detected normally.
-if seg_match git '\bcheckout\b.*\s(--ours|--theirs|--conflict[=[:space:]])\b'; then
+if seg_match git '\bcheckout\b.*\s(--ours|--theirs|-2|-3|--conflict[=[:space:]])(\s|$)'; then
   _check_destructive_op "git checkout <restore-flag>" "restores the named path(s) from the merge-conflict side, discarding uncommitted edits"
 fi
 

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -715,6 +715,28 @@ if seg_match git '\bcheckout\b.*\s(--ours|--theirs|-2|-3|--merge|--conflict(=\S+
   _check_destructive_op "git checkout <restore-flag>" "restores the named path(s) from the merge-conflict side, discarding uncommitted edits"
 fi
 
+# Pathspec-oriented checkout flags. When any of these appears in a
+# checkout segment, the operation is meaningfully a path restore even
+# with a single positional — distinguishing it from the deliberately-
+# deferred bare `git checkout file.lean` ambiguity. Empirically verified
+# (separate temp-repo probe) that all of these discard a dirty worktree
+# file when used with a path positional:
+#
+#   git checkout --ignore-skip-worktree-bits f   → DISCARDED
+#   git checkout --no-overlay f                  → DISCARDED
+#   git checkout --overlay f                     → DISCARDED
+#   git checkout --recurse-submodules f          → DISCARDED
+#
+# `--recurse-submodules` is also valid with branch switching; for the
+# branch case (`git checkout --recurse-submodules main`), git itself
+# refuses a dirty switch without `-f` (PRESERVED in the probe), so a
+# soft-gate here is at worst an extra confirmation prompt before a
+# no-op — the conservative trade-off is preferred over a silent
+# destructive false-negative.
+if seg_match git '\bcheckout\b.*\s(--ignore-skip-worktree-bits|--no-overlay|--overlay|--recurse-submodules)(\s|$)'; then
+  _check_destructive_op "git checkout <pathspec-flag> <path>" "restores the named path(s) from index, discarding uncommitted edits"
+fi
+
 # Path-scoped `git checkout -f <path>` was handled by the force-mode
 # loop above (outcome (b)) so its policy gate fires before this point.
 # Falling through here means the `--` form took outcome (a) and will be

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -679,15 +679,16 @@ fi
 # Note: bare `git checkout --ours` (no path) would soft-gate spuriously
 # but git would error on it anyway, so acceptable.
 #
-# Limitation: `-m` is NOT included here. The shared _strip_optvals
-# normalization (needed for `git commit -m "msg"` false-positive
-# avoidance in the collab checks) strips `-m <value>` from segments
-# before pattern matching, so `git checkout -m <path>` arrives at the
-# checkout checks with `-m <path>` already removed. Catching `-m` in
-# checkout context would require splitting the normalization pipeline
-# per-command; deferred. `--ours`/`--theirs`/`--conflict` are not
-# stripped and are detected normally.
-if seg_match git '\bcheckout\b.*\s(--ours|--theirs|-2|-3|--conflict(=\S+)?)(\s|$)'; then
+# Limitation: short-form `-m` is NOT included here. The shared
+# _strip_optvals normalization (needed for `git commit -m "msg"`
+# false-positive avoidance in the collab checks) strips `-m <value>`
+# from segments before pattern matching, so `git checkout -m <path>`
+# arrives at the checkout checks with `-m <path>` already removed.
+# Catching `-m` in checkout context would require splitting the
+# normalization pipeline per-command; deferred. The long form
+# `--merge` IS covered (below) — _strip_optvals only handles
+# `--(message|file|body|title)` long flags, not `--merge`.
+if seg_match git '\bcheckout\b.*\s(--ours|--theirs|-2|-3|--merge|--conflict(=\S+)?)(\s|$)'; then
   _check_destructive_op "git checkout <restore-flag>" "restores the named path(s) from the merge-conflict side, discarding uncommitted edits"
 fi
 

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -474,25 +474,52 @@ fi
 # below so a broad-blast pattern can't accidentally fall through into
 # ask/allow territory.
 
-# git checkout .            (whole-worktree revert)
-# git checkout -- .         (same semantics: -- with . as the path)
+# Whole-worktree pathspec variants for checkout:
+#   git checkout .                 (whole-worktree, no `--`)
+#   git checkout ./                (same — `./` is `.`)
+#   git checkout -- .              (`--` then `.`)
+#   git checkout -- ./             (`--` then `./`)
+#   git checkout -- :/             (pathspec for "top of repo")
+#   git checkout HEAD -- .         (with a ref before `--`)
+#   git checkout HEAD -- ./        (same)
+#   git checkout -- :(top)         (verbose pathspec form)
 # Note: this must precede the soft-gated `checkout -- <path>` check.
-if seg_match git '\bcheckout\b\s+(--\s+)?\.(\s|$)'; then
+#
+# Detection strategy:
+#   (a) `checkout` followed (anywhere) by `--` followed by a whole-worktree
+#       pathspec token (`.`, `./`, `:/`, `:(top)`)
+#   (b) `checkout` followed directly by `.` or `./` (no `--` separator)
+if seg_match git '\bcheckout\b.*\s--\s+(\.|\./|:/|:\(top\))(\s|$)' \
+   || seg_match git '\bcheckout\b\s+(\.|\./)(\s|$)'; then
   echo "BLOCKED (Lean guardrail): whole-worktree git checkout discards all changes. Commit or checkpoint first." >&2
   exit 2
 fi
 
-# git restore .             (whole-worktree restore)
-# git restore --staged --worktree  (still hard-block: combined restore is whole-worktree-ish)
+# Whole-worktree restore variants:
+#   git restore .                  (whole-worktree)
+#   git restore ./                 (same)
+#   git restore :/                 (top-of-repo pathspec)
+#   git restore --staged --worktree …  (restores both index and worktree)
+# But: pure `--staged` (no `--worktree`) is unstaging only — index-bounded,
+# recoverable, never touches worktree. ALWAYS allowed regardless of path,
+# so the unstaging exemption MUST be checked first, otherwise commands
+# like `git restore --staged .` (legitimate "unstage everything") would
+# be hard-blocked incorrectly.
 for _seg in "${SEGMENTS[@]}"; do
   echo "$_seg" | grep -qE '^git\b' || continue
   echo "$_seg" | grep -qE '\brestore\b' || continue
-  if echo "$_seg" | grep -qE '\brestore\b.*\s\.(\s|$)'; then
-    echo "BLOCKED (Lean guardrail): git restore . discards all worktree changes. Commit or checkpoint first." >&2
-    exit 2
+  # Pure unstaging — always allowed, must come first.
+  if echo "$_seg" | grep -qE -- '--staged\b' && ! echo "$_seg" | grep -qE -- '--worktree\b'; then
+    continue
   fi
+  # Combined --staged --worktree — restores worktree too, so destructive.
   if echo "$_seg" | grep -qE -- '--staged\b' && echo "$_seg" | grep -qE -- '--worktree\b'; then
     echo "BLOCKED (Lean guardrail): git restore --staged --worktree resets both index and worktree. Commit or checkpoint first." >&2
+    exit 2
+  fi
+  # Whole-worktree pathspec — `.`, `./`, `:/`, `:(top)`.
+  if echo "$_seg" | grep -qE '\brestore\b.*\s(\.|\./|:/|:\(top\))(\s|$)'; then
+    echo "BLOCKED (Lean guardrail): git restore on whole-worktree pathspec discards all worktree changes. Commit or checkpoint first." >&2
     exit 2
   fi
 done

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -687,7 +687,7 @@ fi
 # checkout context would require splitting the normalization pipeline
 # per-command; deferred. `--ours`/`--theirs`/`--conflict` are not
 # stripped and are detected normally.
-if seg_match git '\bcheckout\b.*\s(--ours|--theirs|-2|-3|--conflict[=[:space:]])(\s|$)'; then
+if seg_match git '\bcheckout\b.*\s(--ours|--theirs|-2|-3|--conflict(=\S+)?)(\s|$)'; then
   _check_destructive_op "git checkout <restore-flag>" "restores the named path(s) from the merge-conflict side, discarding uncommitted edits"
 fi
 

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -635,9 +635,12 @@ fi
 # git checkout ./file or git checkout :/file or git checkout ../path
 # Single positional with an explicit path prefix. Distinguishes
 # obviously-a-path arguments from branch names; matches `./file.lean`,
-# `:/file.lean`, `../subdir/foo.lean`. Whole-worktree-pathspec variants
-# (`./` / `:/` standalone) already short-circuited via the hard-block.
-if seg_match git '\bcheckout\b\s+(\.{1,2}/|:/?)[^\s.][^\s]*'; then
+# `./.env`, `./.github/workflows/foo.yml`, `:/file.lean`,
+# `../subdir/foo.lean`, etc. Whole-worktree-pathspec variants (`./` /
+# `:/` standalone) already short-circuited via the hard-block, so the
+# `[^\s]+` suffix only excludes the bare prefix without forbidding
+# dotfile-style paths.
+if seg_match git '\bcheckout\b\s+(\.{1,2}/|:/?)[^\s]+'; then
   _check_destructive_op "git checkout <path>" "restores the named path from index, discarding uncommitted edits"
 fi
 

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -551,6 +551,15 @@ for _seg in "${SEGMENTS[@]}"; do
   if [[ $_restore_staged -eq 1 && $_restore_worktree -eq 0 ]]; then
     continue
   fi
+  # --pathspec-from-file in worktree-touching restore: the paths file is
+  # opaque to the guardrail and could contain `.` or `:/`, which would be
+  # a whole-worktree wipe with no warning. Hard-block conservatively;
+  # pure-unstaging `--staged --pathspec-from-file=…` was already allowed
+  # by the exemption above.
+  if echo "$_seg" | grep -qE -- '--pathspec-from-file([=[:space:]])'; then
+    echo "BLOCKED (Lean guardrail): git restore --pathspec-from-file reads paths from a file the guardrail can't inspect; could contain whole-worktree pathspecs. Pass explicit paths on the command line." >&2
+    exit 2
+  fi
   # Combined staged+worktree (any flag combo) — restores worktree too.
   if [[ $_restore_staged -eq 1 && $_restore_worktree -eq 1 ]]; then
     echo "BLOCKED (Lean guardrail): git restore --staged --worktree (or -SW) resets both index and worktree. Commit or checkpoint first." >&2

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -726,6 +726,12 @@ fi
 #   git checkout --no-overlay f                  → DISCARDED
 #   git checkout --overlay f                     → DISCARDED
 #   git checkout --recurse-submodules f          → DISCARDED
+#   yes y | git checkout -p f                    → DISCARDED
+#   yes y | git checkout --patch f               → DISCARDED
+#
+# `-p` / `--patch` is interactive (per-hunk y/n), but interactivity
+# is not absolute protection — pipes like `yes y | …` bypass it.
+# Soft-gate consistently regardless of whether stdin is a TTY.
 #
 # `--recurse-submodules` is also valid with branch switching; for the
 # branch case (`git checkout --recurse-submodules main`), git itself
@@ -733,7 +739,7 @@ fi
 # soft-gate here is at worst an extra confirmation prompt before a
 # no-op — the conservative trade-off is preferred over a silent
 # destructive false-negative.
-if seg_match git '\bcheckout\b.*\s(--ignore-skip-worktree-bits|--no-overlay|--overlay|--recurse-submodules)(\s|$)'; then
+if seg_match git '\bcheckout\b.*\s(--ignore-skip-worktree-bits|--no-overlay|--overlay|--recurse-submodules|-p|--patch)(\s|$)'; then
   _check_destructive_op "git checkout <pathspec-flag> <path>" "restores the named path(s) from index, discarding uncommitted edits"
 fi
 

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -488,14 +488,21 @@ fi
 #   git checkout HEAD -- .         (with a ref before `--`)
 #   git checkout HEAD -- ./        (same)
 #   git checkout -- :(top)         (verbose pathspec form)
-# Note: this must precede the soft-gated `checkout -- <path>` check.
+#   git checkout HEAD .            (ref + whole-worktree pathspec, no `--`)
+#   git checkout HEAD ./           (same)
+#   git checkout main :/           (any ref form before whole-worktree pathspec)
+# Note: this must precede the soft-gated `checkout … <path>` check.
 #
 # Detection strategy:
 #   (a) `checkout` followed (anywhere) by `--` followed by a whole-worktree
 #       pathspec token (`.`, `./`, `:/`, `:(top)`)
 #   (b) `checkout` followed directly by `.` or `./` (no `--` separator)
+#   (c) `checkout` followed by a non-flag token (a tree-ish like `HEAD`,
+#       `main`, etc.) followed by a whole-worktree pathspec — git's
+#       `git checkout <tree-ish> <pathspec>` restore form without `--`.
 if seg_match git '\bcheckout\b.*\s--\s+(\.|\./|:/|:\(top\))(\s|$)' \
-   || seg_match git '\bcheckout\b\s+(\.|\./)(\s|$)'; then
+   || seg_match git '\bcheckout\b\s+(\.|\./)(\s|$)' \
+   || seg_match git '\bcheckout\b\s+[^-\s]\S*\s+(\.|\./|:/|:\(top\))(\s|$)'; then
   echo "BLOCKED (Lean guardrail): whole-worktree git checkout discards all changes. Commit or checkpoint first." >&2
   exit 2
 fi
@@ -552,9 +559,19 @@ fi
 # token), but the operator can opt into `allow` or paranoia-mode `block`
 # via LEAN4_GUARDRAILS_DESTRUCTIVE_POLICY.
 
-# git checkout -- <path…>   (one or more explicit path arguments)
+# git checkout -- <path…>   (one or more explicit path arguments after `--`)
 if seg_match git '\bcheckout\b.*\s--\s'; then
   _check_destructive_op "git checkout --" "discards uncommitted edits in the named path(s)"
+fi
+
+# git checkout <tree-ish> <path…>   (no `--` separator; restore from tree-ish)
+# Matches forms like `git checkout HEAD file.lean` or
+# `git checkout main src/foo.lean`. First positional must not start
+# with `-` (so `-b newbranch` doesn't match) and the second positional
+# must also be a non-flag token. Whole-worktree pathspec variants
+# above already short-circuited, so this only catches bounded paths.
+if seg_match git '\bcheckout\b\s+[^-\s]\S*\s+[^-\s]\S*'; then
+  _check_destructive_op "git checkout <tree-ish> <path>" "restores the named path(s) from the tree-ish, discarding uncommitted edits"
 fi
 
 # git restore <path…>       (worktree-only; pure --staged unstaging is allowed)

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -499,31 +499,34 @@ fi
 # below so a broad-blast pattern can't accidentally fall through into
 # ask/allow territory.
 
-# Whole-worktree pathspec variants for checkout:
-#   git checkout .                 (whole-worktree, no `--`)
-#   git checkout ./                (same — `./` is `.`)
-#   git checkout -- .              (`--` then `.`)
-#   git checkout -- ./             (`--` then `./`)
-#   git checkout -- :/             (pathspec for "top of repo")
-#   git checkout HEAD -- .         (with a ref before `--`)
-#   git checkout HEAD -- ./        (same)
-#   git checkout -- :(top)         (verbose pathspec form)
-#   git checkout HEAD .            (ref + whole-worktree pathspec, no `--`)
-#   git checkout HEAD ./           (same)
-#   git checkout main :/           (any ref form before whole-worktree pathspec)
-# Note: this must precede the soft-gated `checkout … <path>` check.
+# Whole-worktree pathspec variants for checkout. Detection generalized to
+# match ANY whole-worktree pathspec token (`.`, `./`, `:/`, `:(top)`)
+# appearing anywhere in the checkout segment, regardless of what comes
+# between `checkout` and the pathspec. That subsumes:
 #
-# Detection strategy:
-#   (a) `checkout` followed (anywhere) by `--` followed by a whole-worktree
-#       pathspec token (`.`, `./`, `:/`, `:(top)`)
-#   (b) `checkout` followed directly by `.` or `./` (no `--` separator)
-#   (c) `checkout` followed by a non-flag token (a tree-ish like `HEAD`,
-#       `main`, etc.) followed by a whole-worktree pathspec — git's
-#       `git checkout <tree-ish> <pathspec>` restore form without `--`.
-if seg_match git '\bcheckout\b.*\s--\s+(\.|\./|:/|:\(top\))(\s|$)' \
-   || seg_match git '\bcheckout\b\s+(\.|\./)(\s|$)' \
-   || seg_match git '\bcheckout\b\s+[^-\s]\S*\s+(\.|\./|:/|:\(top\))(\s|$)'; then
+#   git checkout .              git checkout HEAD .         (tree-ish form)
+#   git checkout ./             git checkout main :/
+#   git checkout -- .           git checkout HEAD -- .      (with `--`)
+#   git checkout -- ./          git checkout HEAD -- ./
+#   git checkout -- :/          git checkout -- :(top)
+#   git checkout -f .           git checkout --ours .       (with options)
+#   git checkout --theirs .     git checkout -m .
+#
+# Single regex: `\bcheckout\b.*\s<wp>(\s|$)` where `<wp>` is the pathspec
+# alternation. The `.*` swallows any combination of refs and options
+# before the whitespace-bounded pathspec token. Must run BEFORE soft-gate
+# checks so option-prefixed whole-worktree pathspecs short-circuit there.
+if seg_match git '\bcheckout\b.*\s(\.|\./|:/|:\(top\))(\s|$)'; then
   echo "BLOCKED (Lean guardrail): whole-worktree git checkout discards all changes. Commit or checkpoint first." >&2
+  exit 2
+fi
+
+# git checkout --pathspec-from-file=... reads pathspecs from a file the
+# guardrail can't inspect. The file could contain `.` or `:/` which would
+# be a whole-worktree wipe. Hard-block conservatively — operators with a
+# trustworthy paths file can stage the operation as explicit arguments.
+if seg_match git '\bcheckout\b.*\s--pathspec-from-file([=[:space:]])'; then
+  echo "BLOCKED (Lean guardrail): git checkout --pathspec-from-file reads paths from a file the guardrail can't inspect; could contain whole-worktree pathspecs. Pass explicit paths on the command line." >&2
   exit 2
 fi
 
@@ -596,6 +599,37 @@ fi
 # above already short-circuited, so this only catches bounded paths.
 if seg_match git '\bcheckout\b\s+[^-\s]\S*\s+[^-\s]\S*'; then
   _check_destructive_op "git checkout <tree-ish> <path>" "restores the named path(s) from the tree-ish, discarding uncommitted edits"
+fi
+
+# git checkout {--ours|--theirs|--conflict=…} <path…>
+# Merge-conflict resolution flags that take pathspecs. With a path
+# argument, these restore that path's "ours"/"theirs" version or
+# re-create the merge conflict, discarding uncommitted edits in that
+# path. Whole-worktree variants (`--ours .`) already short-circuited
+# via the hard-block above.
+#
+# Note: bare `git checkout --ours` (no path) would soft-gate spuriously
+# but git would error on it anyway, so acceptable.
+#
+# Limitation: `-m` is NOT included here. The shared _strip_optvals
+# normalization (needed for `git commit -m "msg"` false-positive
+# avoidance in the collab checks) strips `-m <value>` from segments
+# before pattern matching, so `git checkout -m <path>` arrives at the
+# checkout checks with `-m <path>` already removed. Catching `-m` in
+# checkout context would require splitting the normalization pipeline
+# per-command; deferred. `--ours`/`--theirs`/`--conflict` are not
+# stripped and are detected normally.
+if seg_match git '\bcheckout\b.*\s(--ours|--theirs|--conflict[=[:space:]])\b'; then
+  _check_destructive_op "git checkout <restore-flag>" "restores the named path(s) from the merge-conflict side, discarding uncommitted edits"
+fi
+
+# git checkout ./file or git checkout :/file or git checkout ../path
+# Single positional with an explicit path prefix. Distinguishes
+# obviously-a-path arguments from branch names; matches `./file.lean`,
+# `:/file.lean`, `../subdir/foo.lean`. Whole-worktree-pathspec variants
+# (`./` / `:/` standalone) already short-circuited via the hard-block.
+if seg_match git '\bcheckout\b\s+(\.{1,2}/|:/?)[^\s.][^\s]*'; then
+  _check_destructive_op "git checkout <path>" "restores the named path from index, discarding uncommitted edits"
 fi
 
 # git restore <path…>       (worktree-only; pure --staged/-S unstaging is allowed)

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -70,9 +70,9 @@ fi
 #          FOO="a b" LEAN4_GUARDRAILS_BYPASS=1 git push ...
 # Rejects: echo LEAN4_GUARDRAILS_BYPASS=1 && git push ... (token after a command word)
 #          FOO="LEAN4_GUARDRAILS_BYPASS=1" git push ...  (token inside quoted value)
-# Applies to soft-gated ops (collaboration + single-file destructive); the
-# whole-worktree destructive ops (reset --hard, clean -f, checkout .,
-# restore .) remain non-bypassable regardless.
+# Applies to soft-gated ops (collaboration + path-scoped destructive);
+# the whole-worktree destructive ops (reset --hard, clean -f,
+# checkout .,restore .) remain non-bypassable regardless.
 # Never exits early — all destructive checks run first; bypass resolves at end.
 BYPASS=0
 
@@ -88,10 +88,13 @@ BYPASS=0
 #                                   COLLAB_POLICY: push, amend, pr create
 #                                     (affects shared state, reversible
 #                                     via force-push / amend back / PR close)
-#                                   DESTRUCTIVE_POLICY: checkout -- <path>,
-#                                     restore <path>
-#                                     (single-file local data loss; smaller
-#                                     blast radius than whole-worktree wipes)
+#                                   DESTRUCTIVE_POLICY: checkout -- <path…>,
+#                                     restore <path…>
+#                                     (path-scoped local data loss — one
+#                                     file, multiple files, a directory,
+#                                     or any explicit pathset; smaller
+#                                     blast radius than whole-worktree
+#                                     wipes which use `.` / `./` / `:/`)
 #
 #   3. HARD-BLOCK (below)       — non-bypassable, no policy override.
 #                                 reset --hard, clean -f/-fd/-fdx,
@@ -423,9 +426,11 @@ _check_collab_op() {
   esac
 }
 
-# Destructive-op policy enforcement (single-file blast radius).
+# Destructive-op policy enforcement (path-scoped blast radius).
 # Same shape as _check_collab_op but governed by DESTRUCTIVE_POLICY.
-# Used by the soft-gated cases below. Whole-worktree destructive ops
+# Used by the soft-gated cases below — operations that name an
+# explicit pathset (one file, several files, a directory, etc.) but
+# don't target the whole worktree. Whole-worktree destructive ops
 # (reset --hard, clean -f, checkout ., restore .) bypass this helper
 # and exit 2 unconditionally — see the dedicated block further down.
 # $1 = short label, $2 = user-facing message suffix
@@ -470,7 +475,7 @@ fi
 # These wipe state across the whole worktree (or untracked files); reflog
 # can't recover uncommitted edits and `clean -f` can't recover untracked
 # files at all. No policy override; bypass token does not apply. The
-# whole-worktree variants run BEFORE the soft-gated single-file variants
+# whole-worktree variants run BEFORE the soft-gated path-scoped variants
 # below so a broad-blast pattern can't accidentally fall through into
 # ask/allow territory.
 
@@ -538,20 +543,21 @@ if seg_match git '\bclean\b.*(-[a-zA-Z]*f|--force)'; then
 fi
 
 # ---------------------------------------------------------------------------
-# Destructive ops: single-file (SOFT-GATE via DESTRUCTIVE_POLICY)
+# Destructive ops: path-scoped (SOFT-GATE via DESTRUCTIVE_POLICY)
 # ---------------------------------------------------------------------------
-# Bounded blast radius (the named paths only). Still loses uncommitted
-# edits — reflog won't help — so default mode is `ask` (block unless
-# bypass token), but the operator can opt into `allow` or paranoia-mode
-# `block` via LEAN4_GUARDRAILS_DESTRUCTIVE_POLICY. The whole-worktree
-# variants above have already short-circuited.
+# Bounded blast radius — the named pathset only (one file, several files,
+# a subdirectory, etc.; whole-worktree pathspecs `.` / `./` / `:/` are
+# excluded by the hard-block block above). Still loses uncommitted edits
+# — reflog won't help — so default mode is `ask` (block unless bypass
+# token), but the operator can opt into `allow` or paranoia-mode `block`
+# via LEAN4_GUARDRAILS_DESTRUCTIVE_POLICY.
 
-# git checkout -- <path>    (single or multiple specific paths)
+# git checkout -- <path…>   (one or more explicit path arguments)
 if seg_match git '\bcheckout\b.*\s--\s'; then
   _check_destructive_op "git checkout --" "discards uncommitted edits in the named path(s)"
 fi
 
-# git restore <path>        (worktree-only; pure --staged unstaging is allowed)
+# git restore <path…>       (worktree-only; pure --staged unstaging is allowed)
 for _seg in "${SEGMENTS[@]}"; do
   echo "$_seg" | grep -qE '^git\b' || continue
   echo "$_seg" | grep -qE '\brestore\b' || continue

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -585,6 +585,34 @@ if seg_match git '\bclean\b.*(-[a-zA-Z]*f|--force)'; then
   exit 2
 fi
 
+# git switch with force/discard-changes — throws away local modifications
+# during branch switching. Reflog can't recover uncommitted edits.
+# Matches `-f`, `--force`, and `--discard-changes` as standalone tokens.
+# `--force-create` is intentionally NOT matched: it forces branch CREATION
+# over an existing branch name, which doesn't touch the worktree state.
+# The `(\s|$)` suffix on `--force` is what distinguishes it from
+# `--force-create` (the latter is followed by `-`, not whitespace/EOL).
+if seg_match git '\bswitch\b.*\s(-f|--force|--discard-changes)(\s|$)'; then
+  echo "BLOCKED (Lean guardrail): git switch with --force / --discard-changes / -f discards uncommitted edits during branch switching. Commit or checkpoint first." >&2
+  exit 2
+fi
+
+# git checkout -f|--force <branch-like-token>  — hard-block. Force
+# branch checkout discards uncommitted edits across the whole worktree
+# (same effective blast radius as `reset --hard`). Heuristic: branch-like
+# means the following token has no path indicators (no `/`, `.`, `:`),
+# i.e. matches `[A-Za-z0-9_][A-Za-z0-9_-]*`. Path-scoped force-restore
+# (`-f file.lean`, `-f docs/`) falls through to the soft-gate below.
+# Whole-worktree pathspecs (`-f .`, `-f :/`) were already caught by the
+# whole-worktree hard-block above. Branch names containing `/` or `.`
+# (e.g. `release/v1.0`) are deliberately treated as path-like and
+# soft-gated rather than hard-blocked — the heuristic prefers fewer
+# false-positive hard-blocks over branch-name exhaustiveness.
+if seg_match git '\bcheckout\b\s+(-f|--force)\s+[A-Za-z0-9_][A-Za-z0-9_-]*(\s|$)'; then
+  echo "BLOCKED (Lean guardrail): git checkout -f / --force <branch> discards uncommitted edits across the whole worktree during branch switching. Commit or checkpoint first." >&2
+  exit 2
+fi
+
 # ---------------------------------------------------------------------------
 # Destructive ops: path-scoped (SOFT-GATE via DESTRUCTIVE_POLICY)
 # ---------------------------------------------------------------------------
@@ -630,6 +658,19 @@ fi
 # stripped and are detected normally.
 if seg_match git '\bcheckout\b.*\s(--ours|--theirs|--conflict[=[:space:]])\b'; then
   _check_destructive_op "git checkout <restore-flag>" "restores the named path(s) from the merge-conflict side, discarding uncommitted edits"
+fi
+
+# git checkout -f|--force <path-like-token>
+# Path-scoped force-restore. Branch-like `-f <branch>` was hard-blocked
+# above; whole-worktree `-f .` was hard-blocked even earlier. What's
+# left is the case where `-f` is followed by a token containing a path
+# indicator (`/`, `.`, `:`) — e.g. `-f file.lean`, `-f docs/`,
+# `-f release/v1.0`. Soft-gated rather than hard-blocked because the
+# blast radius is the named path; reflog still can't recover the edits
+# but the operator can opt in via DESTRUCTIVE_POLICY=allow or the
+# bypass token.
+if seg_match git '\bcheckout\b\s+(-f|--force)\s+\S*[/.:]\S*'; then
+  _check_destructive_op "git checkout -f <path>" "force-restores the named path, discarding uncommitted edits"
 fi
 
 # git checkout ./file or git checkout :/file or git checkout ../path

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -660,14 +660,37 @@ if seg_match git '\bcheckout\b.*\s--\s'; then
 fi
 
 # git checkout <tree-ish> <path…>   (no `--` separator; restore from tree-ish)
-# Matches forms like `git checkout HEAD file.lean` or
-# `git checkout main src/foo.lean`. First positional must not start
-# with `-` (so `-b newbranch` doesn't match) and the second positional
-# must also be a non-flag token. Whole-worktree pathspec variants
-# above already short-circuited, so this only catches bounded paths.
-if seg_match git '\bcheckout\b\s+[^-\s]\S*\s+[^-\s]\S*'; then
-  _check_destructive_op "git checkout <tree-ish> <path>" "restores the named path(s) from the tree-ish, discarding uncommitted edits"
-fi
+# Matches forms like `git checkout HEAD file.lean`,
+# `git checkout main src/foo.lean`, `git checkout -q HEAD file.lean`,
+# `git checkout --quiet HEAD a.lean b.lean`. Per-segment loop so
+# non-destructive flag prefixes (`-q`, `--quiet`, etc.) can interleave
+# with the positionals without forcing the regex to anchor `\S` to
+# `\s+` immediately after `checkout`.
+#
+# Explicit skip list for branch-creation / detach flags (`-b`, `-B`,
+# `--orphan`, `--detach`): those forms take a branch name as their
+# next argument, not a tree-ish + path, and they aren't path-restore.
+# `-f` / `--force` is also skipped — the force-mode loop above already
+# applies the (stricter) classification for that case.
+#
+# Whole-worktree pathspec variants were hard-blocked earlier, so this
+# only catches bounded paths.
+for _seg in "${SEGMENTS[@]}"; do
+  echo "$_seg" | grep -qE '^git\b' || continue
+  echo "$_seg" | grep -qE '\bcheckout\b' || continue
+  # Branch-creation / detach forms — not path-restore.
+  if echo "$_seg" | grep -qE '\s(-b|-B|--orphan|--detach)(\s|$)'; then
+    continue
+  fi
+  # Force mode handled by the dedicated loop above (stricter classification).
+  if echo "$_seg" | grep -qE '\s(-f|--force)(\s|$)'; then
+    continue
+  fi
+  # Two non-flag positionals with optional flag interleaving.
+  if echo "$_seg" | grep -qE '\bcheckout\b\s+(-\S+\s+)*[^-\s]\S*\s+(-\S+\s+)*[^-\s]\S*'; then
+    _check_destructive_op "git checkout <tree-ish> <path>" "restores the named path(s) from the tree-ish, discarding uncommitted edits"
+  fi
+done
 
 # git checkout {--ours|--theirs|--conflict=…} <path…>
 # Merge-conflict resolution flags that take pathspecs. With a path
@@ -705,7 +728,9 @@ fi
 # `:/` standalone) already short-circuited via the hard-block, so the
 # `[^\s]+` suffix only excludes the bare prefix without forbidding
 # dotfile-style paths.
-if seg_match git '\bcheckout\b\s+(\.{1,2}/|:/?)[^\s]+'; then
+# Optional flag prefix (`\s+(-\S+\s+)*`) so `git checkout -q ./file.lean`,
+# `git checkout --quiet :/foo.lean`, etc. soft-gate too.
+if seg_match git '\bcheckout\b\s+(-\S+\s+)*(\.{1,2}/|:/?)[^\s]+'; then
   _check_destructive_op "git checkout <path>" "restores the named path from index, discarding uncommitted edits"
 fi
 

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -597,21 +597,52 @@ if seg_match git '\bswitch\b.*\s(-f|--force|--discard-changes)(\s|$)'; then
   exit 2
 fi
 
-# git checkout -f|--force <branch-like-token>  — hard-block. Force
-# branch checkout discards uncommitted edits across the whole worktree
-# (same effective blast radius as `reset --hard`). Heuristic: branch-like
-# means the following token has no path indicators (no `/`, `.`, `:`),
-# i.e. matches `[A-Za-z0-9_][A-Za-z0-9_-]*`. Path-scoped force-restore
-# (`-f file.lean`, `-f docs/`) falls through to the soft-gate below.
-# Whole-worktree pathspecs (`-f .`, `-f :/`) were already caught by the
-# whole-worktree hard-block above. Branch names containing `/` or `.`
-# (e.g. `release/v1.0`) are deliberately treated as path-like and
-# soft-gated rather than hard-blocked — the heuristic prefers fewer
-# false-positive hard-blocks over branch-name exhaustiveness.
-if seg_match git '\bcheckout\b\s+(-f|--force)\s+[A-Za-z0-9_][A-Za-z0-9_-]*(\s|$)'; then
-  echo "BLOCKED (Lean guardrail): git checkout -f / --force <branch> discards uncommitted edits across the whole worktree during branch switching. Commit or checkpoint first." >&2
-  exit 2
-fi
+# git checkout -f|--force — force-mode checkout. Order-insensitive
+# loop so `-f` may appear anywhere in the option run (e.g.
+# `git checkout -q -f main`, `--quiet --force main`, `-f --detach HEAD`,
+# `-f -B tmp main` all hit the same branches as `-f main`).
+#
+# Three outcomes based on which positionals appear in the segment:
+#
+#   (a) `--` separator present → explicit path-restore form; defer to
+#       the general `--` soft-gate below.
+#   (b) Path-like positional present (token contains `/`, `.`, or `:`,
+#       and isn't a whole-worktree pathspec — those were hard-blocked
+#       earlier) → soft-gate as a path-scoped force-restore.
+#   (c) Branch/ref-like positional present (token in `[A-Za-z0-9_@]
+#       [A-Za-z0-9_@~^{}-]*` or the standalone `-` "previous branch"
+#       shorthand — covers `main`, `HEAD`, `HEAD~3`, `HEAD@{1}`,
+#       `@{-1}`, `@`, `-`) → hard-block: force branch checkout
+#       discards uncommitted edits across the whole worktree (same
+#       blast radius as `reset --hard`).
+#   (d) Neither path-like nor branch/ref-like (e.g. bare `-f` or
+#       `-f --quiet` with no positional) → fall through; git would
+#       likely error anyway.
+#
+# Heuristic note: branch names containing `/` or `.` (e.g.
+# `release/v1.0`) are deliberately classified as path-like and
+# soft-gated. The trade-off prefers fewer false-positive hard-blocks
+# over ref-name exhaustiveness; operators can still opt in via
+# DESTRUCTIVE_POLICY=allow or the bypass token.
+for _seg in "${SEGMENTS[@]}"; do
+  echo "$_seg" | grep -qE '^git\b' || continue
+  echo "$_seg" | grep -qE '\bcheckout\b' || continue
+  echo "$_seg" | grep -qE '\s(-f|--force)(\s|$)' || continue
+  # (a) `--` separator: defer to general soft-gate.
+  if echo "$_seg" | grep -qE '\s--(\s|$)'; then
+    continue
+  fi
+  # (b) Path-like positional present: soft-gate as path-scoped restore.
+  if echo "$_seg" | grep -qE '(^|\s)[^-\s]\S*[/.:]\S*(\s|$)'; then
+    _check_destructive_op "git checkout -f <path>" "force-restores the named path, discarding uncommitted edits"
+    continue
+  fi
+  # (c) Branch/ref-like positional present: hard-block.
+  if echo "$_seg" | grep -qE '\s([A-Za-z0-9_@][A-Za-z0-9_@~^{}-]*|-)(\s|$)'; then
+    echo "BLOCKED (Lean guardrail): git checkout -f / --force <branch-or-ref> discards uncommitted edits across the whole worktree during branch switching. Commit or checkpoint first." >&2
+    exit 2
+  fi
+done
 
 # ---------------------------------------------------------------------------
 # Destructive ops: path-scoped (SOFT-GATE via DESTRUCTIVE_POLICY)
@@ -660,18 +691,10 @@ if seg_match git '\bcheckout\b.*\s(--ours|--theirs|-2|-3|--conflict[=[:space:]])
   _check_destructive_op "git checkout <restore-flag>" "restores the named path(s) from the merge-conflict side, discarding uncommitted edits"
 fi
 
-# git checkout -f|--force <path-like-token>
-# Path-scoped force-restore. Branch-like `-f <branch>` was hard-blocked
-# above; whole-worktree `-f .` was hard-blocked even earlier. What's
-# left is the case where `-f` is followed by a token containing a path
-# indicator (`/`, `.`, `:`) — e.g. `-f file.lean`, `-f docs/`,
-# `-f release/v1.0`. Soft-gated rather than hard-blocked because the
-# blast radius is the named path; reflog still can't recover the edits
-# but the operator can opt in via DESTRUCTIVE_POLICY=allow or the
-# bypass token.
-if seg_match git '\bcheckout\b\s+(-f|--force)\s+\S*[/.:]\S*'; then
-  _check_destructive_op "git checkout -f <path>" "force-restores the named path, discarding uncommitted edits"
-fi
+# Path-scoped `git checkout -f <path>` was handled by the force-mode
+# loop above (outcome (b)) so its policy gate fires before this point.
+# Falling through here means the `--` form took outcome (a) and will be
+# matched by the general `--` soft-gate (already above).
 
 # git checkout ./file or git checkout :/file or git checkout ../path
 # Single positional with an explicit path prefix. Distinguishes

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -70,18 +70,52 @@ fi
 #          FOO="a b" LEAN4_GUARDRAILS_BYPASS=1 git push ...
 # Rejects: echo LEAN4_GUARDRAILS_BYPASS=1 && git push ... (token after a command word)
 #          FOO="LEAN4_GUARDRAILS_BYPASS=1" git push ...  (token inside quoted value)
-# Applies to collaboration ops only (push, amend, pr create), not destructive ops.
+# Applies to soft-gated ops (collaboration + single-file destructive); the
+# whole-worktree destructive ops (reset --hard, clean -f, checkout .,
+# restore .) remain non-bypassable regardless.
 # Never exits early — all destructive checks run first; bypass resolves at end.
 BYPASS=0
 
-# Collaboration policy: ask (default) | allow | block
-# - ask:   require human confirmation; block unless one-shot bypass token present
-# - allow: permit collaboration ops without bypass token
-# - block: block collaboration ops even with bypass token
+# Three-tier git operation policy:
+#
+#   1. ALLOW (implicit)         — status, diff, log, show, branch, add,
+#                                 commit, stash push, switch <branch>,
+#                                 restore --staged <path>, etc. No gate.
+#
+#   2. SOFT-GATE (this section) — policy-controlled, bypass-token-able.
+#                                 Two independent vars cover the two
+#                                 risk categories:
+#                                   COLLAB_POLICY: push, amend, pr create
+#                                     (affects shared state, reversible
+#                                     via force-push / amend back / PR close)
+#                                   DESTRUCTIVE_POLICY: checkout -- <path>,
+#                                     restore <path>
+#                                     (single-file local data loss; smaller
+#                                     blast radius than whole-worktree wipes)
+#
+#   3. HARD-BLOCK (below)       — non-bypassable, no policy override.
+#                                 reset --hard, clean -f/-fd/-fdx,
+#                                 checkout ., restore ., checkout -- .
+#                                 The blast radius is unbounded and
+#                                 git reflog can't recover uncommitted
+#                                 edits (and can't recover untracked
+#                                 files via clean -f at all).
+#
+# Each soft-gate policy independently accepts ask | allow | block:
+#   ask:   require human confirmation via one-shot bypass token (default)
+#   allow: permit without bypass token (user explicitly opted in)
+#   block: block even with bypass token (extra paranoia)
+
 COLLAB_POLICY="${LEAN4_GUARDRAILS_COLLAB_POLICY:-ask}"
 case "$COLLAB_POLICY" in
   ask|allow|block) ;;
   *) COLLAB_POLICY="ask" ;;
+esac
+
+DESTRUCTIVE_POLICY="${LEAN4_GUARDRAILS_DESTRUCTIVE_POLICY:-ask}"
+case "$DESTRUCTIVE_POLICY" in
+  ask|allow|block) ;;
+  *) DESTRUCTIVE_POLICY="ask" ;;
 esac
 
 # --- Segment-based command parsing ---
@@ -376,12 +410,36 @@ _check_collab_op() {
   case "$COLLAB_POLICY" in
     allow) return 0 ;;
     block)
-      echo "BLOCKED (Lean guardrail): $label - $msg [policy=block]" >&2
+      echo "BLOCKED (Lean guardrail): $label - $msg [collab_policy=block]" >&2
       exit 2
       ;;
     *)  # ask (default): confirmation-gated; bypass is the one-time confirmed rerun path
       if [[ $BYPASS -ne 1 ]]; then
-        echo "BLOCKED (Lean guardrail): $label - $msg [policy=ask, confirm then rerun]" >&2
+        echo "BLOCKED (Lean guardrail): $label - $msg [collab_policy=ask, confirm then rerun]" >&2
+        echo "  To proceed once, prefix with: LEAN4_GUARDRAILS_BYPASS=1" >&2
+        exit 2
+      fi
+      ;;
+  esac
+}
+
+# Destructive-op policy enforcement (single-file blast radius).
+# Same shape as _check_collab_op but governed by DESTRUCTIVE_POLICY.
+# Used by the soft-gated cases below. Whole-worktree destructive ops
+# (reset --hard, clean -f, checkout ., restore .) bypass this helper
+# and exit 2 unconditionally — see the dedicated block further down.
+# $1 = short label, $2 = user-facing message suffix
+_check_destructive_op() {
+  local label="$1" msg="$2"
+  case "$DESTRUCTIVE_POLICY" in
+    allow) return 0 ;;
+    block)
+      echo "BLOCKED (Lean guardrail): $label - $msg [destructive_policy=block]" >&2
+      exit 2
+      ;;
+    *)  # ask (default): confirmation-gated; bypass token allows one-shot
+      if [[ $BYPASS -ne 1 ]]; then
+        echo "BLOCKED (Lean guardrail): $label - $msg [destructive_policy=ask, confirm then rerun]" >&2
         echo "  To proceed once, prefix with: LEAN4_GUARDRAILS_BYPASS=1" >&2
         exit 2
       fi
@@ -406,45 +464,75 @@ if seg_match gh '\bpr\b.*\bcreate\b'; then
   _check_collab_op "gh pr create" "review first, then create PR manually"
 fi
 
-# --- Destructive ops (never bypassable) ---
+# ---------------------------------------------------------------------------
+# Destructive ops: whole-worktree (HARD-BLOCK — non-bypassable)
+# ---------------------------------------------------------------------------
+# These wipe state across the whole worktree (or untracked files); reflog
+# can't recover uncommitted edits and `clean -f` can't recover untracked
+# files at all. No policy override; bypass token does not apply. The
+# whole-worktree variants run BEFORE the soft-gated single-file variants
+# below so a broad-blast pattern can't accidentally fall through into
+# ask/allow territory.
 
-# Block destructive checkout (discards uncommitted changes)
-# Allows: git checkout <branch>, git checkout -b <branch>
-# Blocks: git checkout -- <path>, git checkout .
-if seg_match git '\bcheckout\b.*\s--\s'; then
-  echo "BLOCKED (Lean guardrail): destructive git checkout. Commit or checkpoint first." >&2
+# git checkout .            (whole-worktree revert)
+# git checkout -- .         (same semantics: -- with . as the path)
+# Note: this must precede the soft-gated `checkout -- <path>` check.
+if seg_match git '\bcheckout\b\s+(--\s+)?\.(\s|$)'; then
+  echo "BLOCKED (Lean guardrail): whole-worktree git checkout discards all changes. Commit or checkpoint first." >&2
   exit 2
 fi
-if seg_match git '\bcheckout\b\s+\.(\s|$)'; then
-  echo "BLOCKED (Lean guardrail): git checkout . discards changes. Commit or checkpoint first." >&2
-  exit 2
-fi
 
-# Block git restore (worktree changes only, allow pure unstaging)
-# Blocks: git restore <path>, git restore --source=..., git restore --staged --worktree
-# Allows: git restore --staged <path> (without --worktree)
+# git restore .             (whole-worktree restore)
+# git restore --staged --worktree  (still hard-block: combined restore is whole-worktree-ish)
 for _seg in "${SEGMENTS[@]}"; do
   echo "$_seg" | grep -qE '^git\b' || continue
   echo "$_seg" | grep -qE '\brestore\b' || continue
-  if echo "$_seg" | grep -qE -- '--staged\b' && ! echo "$_seg" | grep -qE -- '--worktree\b'; then
-    continue  # allowed - pure unstaging
+  if echo "$_seg" | grep -qE '\brestore\b.*\s\.(\s|$)'; then
+    echo "BLOCKED (Lean guardrail): git restore . discards all worktree changes. Commit or checkpoint first." >&2
+    exit 2
   fi
-  echo "BLOCKED (Lean guardrail): git restore discards changes. Commit or checkpoint first." >&2
-  exit 2
+  if echo "$_seg" | grep -qE -- '--staged\b' && echo "$_seg" | grep -qE -- '--worktree\b'; then
+    echo "BLOCKED (Lean guardrail): git restore --staged --worktree resets both index and worktree. Commit or checkpoint first." >&2
+    exit 2
+  fi
 done
 
-# Block git reset --hard (discards commits and changes)
+# git reset --hard
 if seg_match git '\breset\b.*--hard\b'; then
   echo "BLOCKED (Lean guardrail): git reset --hard. Commit or checkpoint first." >&2
   exit 2
 fi
 
-# Block git clean with -f/--force anywhere (deletes untracked files)
+# git clean with -f/--force anywhere (deletes untracked files; not recoverable)
 # Matches: -f, -fd, -fx, -nfd, --force, etc.
 if seg_match git '\bclean\b.*(-[a-zA-Z]*f|--force)'; then
   echo "BLOCKED (Lean guardrail): git clean deletes untracked files. Commit or checkpoint first." >&2
   exit 2
 fi
+
+# ---------------------------------------------------------------------------
+# Destructive ops: single-file (SOFT-GATE via DESTRUCTIVE_POLICY)
+# ---------------------------------------------------------------------------
+# Bounded blast radius (the named paths only). Still loses uncommitted
+# edits — reflog won't help — so default mode is `ask` (block unless
+# bypass token), but the operator can opt into `allow` or paranoia-mode
+# `block` via LEAN4_GUARDRAILS_DESTRUCTIVE_POLICY. The whole-worktree
+# variants above have already short-circuited.
+
+# git checkout -- <path>    (single or multiple specific paths)
+if seg_match git '\bcheckout\b.*\s--\s'; then
+  _check_destructive_op "git checkout --" "discards uncommitted edits in the named path(s)"
+fi
+
+# git restore <path>        (worktree-only; pure --staged unstaging is allowed)
+for _seg in "${SEGMENTS[@]}"; do
+  echo "$_seg" | grep -qE '^git\b' || continue
+  echo "$_seg" | grep -qE '\brestore\b' || continue
+  if echo "$_seg" | grep -qE -- '--staged\b' && ! echo "$_seg" | grep -qE -- '--worktree\b'; then
+    continue  # pure unstaging — always allowed
+  fi
+  _check_destructive_op "git restore" "discards uncommitted edits in the named path(s)"
+done
 
 # All checks passed — resolve deferred bypass or allow normally
 exit 0

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -426,6 +426,26 @@ _check_collab_op() {
   esac
 }
 
+# Classify git restore flag presence (long + short forms) into two
+# integers passed back via the global _restore_staged / _restore_worktree.
+# Long forms: --staged / --worktree. Short forms: -S / -W, including
+# bundled short flags like -SW, -WS, -qS (git docs document the short
+# aliases and bundling). Detection runs over the raw segment text and
+# uses a `(^|\s)` boundary so substrings like `--no-staged` don't
+# false-match the staged check.
+_classify_restore_flags() {
+  local s="$1"
+  _restore_staged=0
+  _restore_worktree=0
+  if echo "$s" | grep -qE -- '(^|[[:space:]])--staged([[:space:]]|=|$)'; then _restore_staged=1; fi
+  if echo "$s" | grep -qE -- '(^|[[:space:]])--worktree([[:space:]]|=|$)'; then _restore_worktree=1; fi
+  # Short flag bundles: `-` (not preceded by alphanumeric) + sequence of
+  # letters that contains S or W. Excludes long-form `--…` by requiring
+  # the char after `-` to be a letter (not `-`).
+  if echo "$s" | grep -qE -- '(^|[[:space:]])-[A-Za-z]*S[A-Za-z]*([[:space:]]|$)'; then _restore_staged=1; fi
+  if echo "$s" | grep -qE -- '(^|[[:space:]])-[A-Za-z]*W[A-Za-z]*([[:space:]]|$)'; then _restore_worktree=1; fi
+}
+
 # Destructive-op policy enforcement (path-scoped blast radius).
 # Same shape as _check_collab_op but governed by DESTRUCTIVE_POLICY.
 # Used by the soft-gated cases below — operations that name an
@@ -512,21 +532,25 @@ fi
 #   git restore ./                 (same)
 #   git restore :/                 (top-of-repo pathspec)
 #   git restore --staged --worktree …  (restores both index and worktree)
-# But: pure `--staged` (no `--worktree`) is unstaging only — index-bounded,
-# recoverable, never touches worktree. ALWAYS allowed regardless of path,
-# so the unstaging exemption MUST be checked first, otherwise commands
-# like `git restore --staged .` (legitimate "unstage everything") would
-# be hard-blocked incorrectly.
+#   git restore -SW <path>         (short form of --staged --worktree)
+#   git restore --staged -W <path> (mixed long/short combined restore)
+# But: pure `--staged` (or `-S`) without `--worktree` (or `-W`) is
+# unstaging only — index-bounded, recoverable, never touches worktree.
+# ALWAYS allowed regardless of path, so the unstaging exemption MUST
+# be checked first, otherwise commands like `git restore --staged .`
+# (legitimate "unstage everything") would be hard-blocked incorrectly.
+# Flag detection covers long and short forms via _classify_restore_flags.
 for _seg in "${SEGMENTS[@]}"; do
   echo "$_seg" | grep -qE '^git\b' || continue
   echo "$_seg" | grep -qE '\brestore\b' || continue
+  _classify_restore_flags "$_seg"
   # Pure unstaging — always allowed, must come first.
-  if echo "$_seg" | grep -qE -- '--staged\b' && ! echo "$_seg" | grep -qE -- '--worktree\b'; then
+  if [[ $_restore_staged -eq 1 && $_restore_worktree -eq 0 ]]; then
     continue
   fi
-  # Combined --staged --worktree — restores worktree too, so destructive.
-  if echo "$_seg" | grep -qE -- '--staged\b' && echo "$_seg" | grep -qE -- '--worktree\b'; then
-    echo "BLOCKED (Lean guardrail): git restore --staged --worktree resets both index and worktree. Commit or checkpoint first." >&2
+  # Combined staged+worktree (any flag combo) — restores worktree too.
+  if [[ $_restore_staged -eq 1 && $_restore_worktree -eq 1 ]]; then
+    echo "BLOCKED (Lean guardrail): git restore --staged --worktree (or -SW) resets both index and worktree. Commit or checkpoint first." >&2
     exit 2
   fi
   # Whole-worktree pathspec — `.`, `./`, `:/`, `:(top)`.
@@ -574,11 +598,12 @@ if seg_match git '\bcheckout\b\s+[^-\s]\S*\s+[^-\s]\S*'; then
   _check_destructive_op "git checkout <tree-ish> <path>" "restores the named path(s) from the tree-ish, discarding uncommitted edits"
 fi
 
-# git restore <path…>       (worktree-only; pure --staged unstaging is allowed)
+# git restore <path…>       (worktree-only; pure --staged/-S unstaging is allowed)
 for _seg in "${SEGMENTS[@]}"; do
   echo "$_seg" | grep -qE '^git\b' || continue
   echo "$_seg" | grep -qE '\brestore\b' || continue
-  if echo "$_seg" | grep -qE -- '--staged\b' && ! echo "$_seg" | grep -qE -- '--worktree\b'; then
+  _classify_restore_flags "$_seg"
+  if [[ $_restore_staged -eq 1 && $_restore_worktree -eq 0 ]]; then
     continue  # pure unstaging — always allowed
   fi
   _check_destructive_op "git restore" "discards uncommitted edits in the named path(s)"

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -178,6 +178,8 @@ run_test_destructive_policy "unset: checkout --quiet HEAD file (block=ask)" "" "
 run_test_destructive_policy "allow: checkout -q HEAD file"                  allow "git checkout -q HEAD file.lean"                    0
 run_test_destructive_policy "allow: checkout --quiet HEAD file"             allow "git checkout --quiet HEAD file.lean"               0
 run_test_destructive_policy "bypass: checkout -q HEAD file"                 "" "LEAN4_GUARDRAILS_BYPASS=1 git checkout -q HEAD file.lean" 0
+# Flag interleaving between tree-ish and path — pins the documented behavior.
+run_test_destructive_policy "unset: checkout HEAD -q file (block=ask)"      "" "git checkout HEAD -q file.lean"                         2
 # Non-force flag prefix before explicit-prefix path — same soft-gate.
 run_test_destructive_policy "unset: checkout -q ./file (block=ask)"         "" "git checkout -q ./file.lean"                            2
 run_test_destructive_policy "allow: checkout --quiet :/foo.lean"            allow "git checkout --quiet :/foo.lean"                   0

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -202,6 +202,20 @@ run_test_destructive_policy "allow: restore directory"                      allo
 run_test_destructive_policy "block: restore file (still block)"             block "git restore file.lean"                              2
 run_test_destructive_policy "block: bypass restore file (still block)"      block "LEAN4_GUARDRAILS_BYPASS=1 git restore file.lean"    2
 
+# Short flag aliases: -S = --staged, -W = --worktree.
+# Pure unstaging via -S (or any bundle containing S but not W) is allowed.
+run_test_destructive_policy "unset: restore -S file (allow always)"         "" "git restore -S file.lean"                                0
+run_test_destructive_policy "block: restore -S file (allow always)"         block "git restore -S file.lean"                            0
+run_test_destructive_policy "block: restore -S . (allow always)"            block "git restore -S ."                                    0
+# Combined index+worktree via -SW or mixed long/short → hard-block
+run_test_destructive_policy "git restore -SW file (always block)"           allow "git restore -SW file.lean"                           2
+run_test_destructive_policy "git restore -WS file (always block)"           allow "git restore -WS file.lean"                           2
+run_test_destructive_policy "git restore --staged -W file (always block)"   allow "git restore --staged -W file.lean"                   2
+run_test_destructive_policy "git restore -S --worktree file (always block)" allow "git restore -S --worktree file.lean"                 2
+# Worktree-only via -W alone is path-scoped destructive → soft-gate
+run_test_destructive_policy "allow: restore -W file"                        allow "git restore -W file.lean"                            0
+run_test_destructive_policy "unset: restore -W file (block=ask)"            "" "git restore -W file.lean"                                2
+
 echo ""
 echo "-- Hard-block: whole-worktree variants stay non-bypassable --"
 # These must block regardless of DESTRUCTIVE_POLICY value or bypass token.

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -182,6 +182,26 @@ run_test_destructive_policy "allow: switch to ref by name"                  ""  
 run_test_destructive_policy "allow: checkout -b newbranch"                  ""    "git checkout -b newbranch"                         0
 run_test_destructive_policy "allow: checkout -b newbranch start-point"      ""    "git checkout -b newbranch main"                    0
 
+# Option-prefixed checkout pathspec forms (merge-conflict resolution flags
+# + force flag). These are restore-mode operations gated by the
+# destructive policy.
+run_test_destructive_policy "unset: checkout --ours file (block=ask)"       "" "git checkout --ours file.lean"                          2
+run_test_destructive_policy "unset: checkout --theirs file (block=ask)"     "" "git checkout --theirs file.lean"                        2
+# Note: -m is not covered — see _strip_optvals limitation comment in guardrails.sh
+run_test_destructive_policy "allow: checkout --ours file"                   allow "git checkout --ours file.lean"                      0
+run_test_destructive_policy "allow: checkout --theirs src/foo.lean"         allow "git checkout --theirs src/foo.lean"                  0
+run_test_destructive_policy "bypass: checkout --ours file"                  "" "LEAN4_GUARDRAILS_BYPASS=1 git checkout --ours file.lean" 0
+run_test_destructive_policy "block: checkout --ours file (still block)"     block "git checkout --ours file.lean"                       2
+
+# Single positional with explicit path prefix (./, :/, ../)
+# Distinguishes obvious path arguments from branch names.
+run_test_destructive_policy "unset: checkout ./file (block=ask)"            "" "git checkout ./file.lean"                                2
+run_test_destructive_policy "unset: checkout :/file (block=ask)"            "" "git checkout :/file.lean"                                2
+run_test_destructive_policy "unset: checkout ../file (block=ask)"           "" "git checkout ../file.lean"                               2
+run_test_destructive_policy "allow: checkout ./file"                        allow "git checkout ./file.lean"                            0
+run_test_destructive_policy "bypass: checkout ./file"                       "" "LEAN4_GUARDRAILS_BYPASS=1 git checkout ./file.lean"      0
+run_test_destructive_policy "block: checkout ./file (still block)"          block "git checkout ./file.lean"                            2
+
 echo ""
 echo "-- Destructive policy: path-scoped git restore <path…> --"
 # Default: same shape
@@ -233,6 +253,15 @@ run_test_destructive_policy "git checkout HEAD -- ./          (always block)" al
 run_test_destructive_policy "git checkout HEAD .              (always block)" allow "git checkout HEAD ."                               2
 run_test_destructive_policy "git checkout HEAD ./             (always block)" allow "git checkout HEAD ./"                              2
 run_test_destructive_policy "git checkout main :/             (always block)" allow "git checkout main :/"                              2
+# Option-prefixed whole-worktree pathspec variants — all hard-block.
+run_test_destructive_policy "git checkout -f .                (always block)" allow "git checkout -f ."                                 2
+run_test_destructive_policy "git checkout --force ./          (always block)" allow "git checkout --force ./"                           2
+run_test_destructive_policy "git checkout --ours .            (always block)" allow "git checkout --ours ."                             2
+run_test_destructive_policy "git checkout --theirs :/         (always block)" allow "git checkout --theirs :/"                          2
+# Note: -m is not covered — see _strip_optvals limitation comment in guardrails.sh
+# --pathspec-from-file always hard-blocks (paths hidden in a file)
+run_test_destructive_policy "git checkout --pathspec-from-file (always block)" allow "git checkout --pathspec-from-file=paths.txt"      2
+run_test_destructive_policy "git checkout HEAD --pathspec-from-file (always block)" allow "git checkout HEAD --pathspec-from-file=paths.txt" 2
 run_test_destructive_policy "git restore .                    (always block)" allow "git restore ."                                     2
 run_test_destructive_policy "git restore ./                   (always block)" allow "git restore ./"                                    2
 run_test_destructive_policy "git restore :/                   (always block)" allow "git restore :/"                                    2
@@ -245,6 +274,9 @@ run_test_destructive_policy "bypass git checkout .            (still block)" all
 run_test_destructive_policy "bypass git checkout -- .         (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout -- ."       2
 run_test_destructive_policy "bypass git checkout HEAD -- .    (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout HEAD -- ."  2
 run_test_destructive_policy "bypass git checkout HEAD .       (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout HEAD ."     2
+run_test_destructive_policy "bypass git checkout -f .         (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout -f ."       2
+run_test_destructive_policy "bypass git checkout --ours .     (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout --ours ."   2
+run_test_destructive_policy "bypass git checkout --pathspec-from-file (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout --pathspec-from-file=paths.txt" 2
 run_test_destructive_policy "bypass git restore ./            (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git restore ./"           2
 run_test_destructive_policy "bypass git reset --hard          (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git reset --hard"        2
 run_test_destructive_policy "bypass git clean -fd             (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git clean -fd"           2

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -180,6 +180,15 @@ run_test_destructive_policy "allow: checkout --quiet HEAD file"             allo
 run_test_destructive_policy "bypass: checkout -q HEAD file"                 "" "LEAN4_GUARDRAILS_BYPASS=1 git checkout -q HEAD file.lean" 0
 # Flag interleaving between tree-ish and path — pins the documented behavior.
 run_test_destructive_policy "unset: checkout HEAD -q file (block=ask)"      "" "git checkout HEAD -q file.lean"                         2
+# Pathspec-oriented flags: single positional with one of these is
+# unambiguously path-restore (empirically confirmed to discard).
+run_test_destructive_policy "unset: checkout --ignore-skip-worktree-bits file" "" "git checkout --ignore-skip-worktree-bits file.lean"  2
+run_test_destructive_policy "unset: checkout --no-overlay file (block=ask)"  "" "git checkout --no-overlay file.lean"                    2
+run_test_destructive_policy "unset: checkout --overlay file (block=ask)"     "" "git checkout --overlay file.lean"                       2
+run_test_destructive_policy "unset: checkout --recurse-submodules file"      "" "git checkout --recurse-submodules file.lean"            2
+run_test_destructive_policy "allow: checkout --no-overlay file"              allow "git checkout --no-overlay file.lean"                 0
+run_test_destructive_policy "allow: checkout --ignore-skip-worktree-bits file" allow "git checkout --ignore-skip-worktree-bits file.lean" 0
+run_test_destructive_policy "bypass: checkout --no-overlay file"             "" "LEAN4_GUARDRAILS_BYPASS=1 git checkout --no-overlay file.lean" 0
 # Non-force flag prefix before explicit-prefix path — same soft-gate.
 run_test_destructive_policy "unset: checkout -q ./file (block=ask)"         "" "git checkout -q ./file.lean"                            2
 run_test_destructive_policy "allow: checkout --quiet :/foo.lean"            allow "git checkout --quiet :/foo.lean"                   0

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -165,6 +165,23 @@ run_test_destructive_policy "allow: checkout -- directory"                  allo
 run_test_destructive_policy "block: checkout -- file (still block)"         block "git checkout -- file.lean"                       2
 run_test_destructive_policy "block: bypass checkout -- file (still block)"  block "LEAN4_GUARDRAILS_BYPASS=1 git checkout -- file.lean" 2
 
+# git checkout <tree-ish> <path…>  (restore-from-tree-ish form, no `--`)
+# Default (ask): blocks without bypass, allows with bypass.
+run_test_destructive_policy "unset: checkout HEAD file (block=ask)"         "" "git checkout HEAD file.lean"                          2
+run_test_destructive_policy "unset: bypass checkout HEAD file (allow=ask)"  "" "LEAN4_GUARDRAILS_BYPASS=1 git checkout HEAD file.lean" 0
+# allow: any tree-ish + bounded path passes
+run_test_destructive_policy "allow: checkout HEAD file"                     allow "git checkout HEAD file.lean"                      0
+run_test_destructive_policy "allow: checkout main file"                     allow "git checkout main src/foo.lean"                   0
+run_test_destructive_policy "allow: checkout HEAD~1 file"                   allow "git checkout HEAD~1 file.lean"                    0
+# block: even bypass token doesn't help
+run_test_destructive_policy "block: checkout HEAD file (still block)"       block "git checkout HEAD file.lean"                      2
+# Branch switching with a single arg is still allowed (not the restore form)
+run_test_destructive_policy "allow: switch to branch by name"               ""    "git checkout main"                                 0
+run_test_destructive_policy "allow: switch to ref by name"                  ""    "git checkout origin/main"                          0
+# -b/-B newbranch creates a branch; not restore, not gated
+run_test_destructive_policy "allow: checkout -b newbranch"                  ""    "git checkout -b newbranch"                         0
+run_test_destructive_policy "allow: checkout -b newbranch start-point"      ""    "git checkout -b newbranch main"                    0
+
 echo ""
 echo "-- Destructive policy: path-scoped git restore <path…> --"
 # Default: same shape
@@ -199,6 +216,9 @@ run_test_destructive_policy "git checkout -- :/               (always block)" al
 run_test_destructive_policy "git checkout -- :(top)           (always block)" allow "git checkout -- :(top)"                            2
 run_test_destructive_policy "git checkout HEAD -- .           (always block)" allow "git checkout HEAD -- ."                            2
 run_test_destructive_policy "git checkout HEAD -- ./          (always block)" allow "git checkout HEAD -- ./"                           2
+run_test_destructive_policy "git checkout HEAD .              (always block)" allow "git checkout HEAD ."                               2
+run_test_destructive_policy "git checkout HEAD ./             (always block)" allow "git checkout HEAD ./"                              2
+run_test_destructive_policy "git checkout main :/             (always block)" allow "git checkout main :/"                              2
 run_test_destructive_policy "git restore .                    (always block)" allow "git restore ."                                     2
 run_test_destructive_policy "git restore ./                   (always block)" allow "git restore ./"                                    2
 run_test_destructive_policy "git restore :/                   (always block)" allow "git restore :/"                                    2
@@ -210,6 +230,7 @@ run_test_destructive_policy "git clean --force                (always block)" al
 run_test_destructive_policy "bypass git checkout .            (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout ."          2
 run_test_destructive_policy "bypass git checkout -- .         (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout -- ."       2
 run_test_destructive_policy "bypass git checkout HEAD -- .    (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout HEAD -- ."  2
+run_test_destructive_policy "bypass git checkout HEAD .       (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout HEAD ."     2
 run_test_destructive_policy "bypass git restore ./            (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git restore ./"           2
 run_test_destructive_policy "bypass git reset --hard          (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git reset --hard"        2
 run_test_destructive_policy "bypass git clean -fd             (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git clean -fd"           2

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -187,6 +187,12 @@ run_test_destructive_policy "allow: checkout -b newbranch start-point"      ""  
 # destructive policy.
 run_test_destructive_policy "unset: checkout --ours file (block=ask)"       "" "git checkout --ours file.lean"                          2
 run_test_destructive_policy "unset: checkout --theirs file (block=ask)"     "" "git checkout --theirs file.lean"                        2
+# --conflict=<style> takes a value; the regex must accept `--conflict=merge`,
+# `--conflict=zdiff3`, etc., not just bare `--conflict`.
+run_test_destructive_policy "unset: checkout --conflict=merge file (block=ask)" "" "git checkout --conflict=merge file.lean"            2
+run_test_destructive_policy "unset: checkout --conflict=zdiff3 file (block=ask)" "" "git checkout --conflict=zdiff3 file.lean"          2
+run_test_destructive_policy "allow: checkout --conflict=merge file"         allow "git checkout --conflict=merge file.lean"            0
+run_test_destructive_policy "allow: checkout --conflict=zdiff3 file"        allow "git checkout --conflict=zdiff3 file.lean"           0
 # -2 / -3 are short aliases for --ours / --theirs (same conflict-resolution semantics).
 run_test_destructive_policy "unset: checkout -2 file (block=ask)"           "" "git checkout -2 file.lean"                              2
 run_test_destructive_policy "unset: checkout -3 file (block=ask)"           "" "git checkout -3 file.lean"                              2

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -45,6 +45,26 @@ run_test_policy() {
   fi
 }
 
+# Run a test with a specific destructive policy (single-file destructive ops).
+# $1=desc  $2=policy value (ask|allow|block|"" for unset)  $3=command  $4=expected exit
+run_test_destructive_policy() {
+  local desc="$1" policy="$2" cmd="$3" expected="$4" actual
+  actual=0
+  local policy_env=()
+  if [[ -n "$policy" ]]; then
+    policy_env=(LEAN4_GUARDRAILS_DESTRUCTIVE_POLICY="$policy")
+  fi
+  echo "{\"tool_input\":{\"command\":$(printf '%s' "$cmd" | jq -Rs .)}}" \
+    | env LEAN4_GUARDRAILS_FORCE=1 "${policy_env[@]}" bash "$HOOK" >/dev/null 2>&1 || actual=$?
+  if [[ "$actual" -eq "$expected" ]]; then
+    echo "  PASS: $desc"
+    (( ++PASS ))
+  else
+    echo "  FAIL: $desc (expected exit $expected, got $actual)"
+    (( ++FAIL ))
+  fi
+}
+
 echo "=== guardrails.sh regression tests ==="
 echo ""
 
@@ -166,6 +186,60 @@ run_test_policy "invalid: yolo push (block=ask)"        yolo "git push origin ma
 run_test_policy "invalid: yolo bypass push (allow=ask)" yolo "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"   0
 run_test_policy "unset: plain push (block=ask)"         ""   "git push origin main"           2
 run_test_policy "unset: bypass push (allow=ask)"        ""   "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"   0
+
+echo ""
+echo "-- Destructive policy: single-file checkout -- <path> --"
+# Default (unset = ask): blocks without bypass, allows with bypass
+run_test_destructive_policy "unset: checkout -- file (block=ask)"           "" "git checkout -- file.lean"                            2
+run_test_destructive_policy "unset: bypass checkout -- file (allow=ask)"    "" "LEAN4_GUARDRAILS_BYPASS=1 git checkout -- file.lean"  0
+# allow: passes without bypass
+run_test_destructive_policy "allow: checkout -- file"                       allow "git checkout -- file.lean"                       0
+run_test_destructive_policy "allow: checkout -- multi-file"                 allow "git checkout -- a.lean b.lean"                    0
+# block: blocks even with bypass token
+run_test_destructive_policy "block: checkout -- file (still block)"         block "git checkout -- file.lean"                       2
+run_test_destructive_policy "block: bypass checkout -- file (still block)"  block "LEAN4_GUARDRAILS_BYPASS=1 git checkout -- file.lean" 2
+
+echo ""
+echo "-- Destructive policy: single-file git restore <path> --"
+# Default: same shape
+run_test_destructive_policy "unset: restore file (block=ask)"               "" "git restore file.lean"                                  2
+run_test_destructive_policy "unset: bypass restore file (allow=ask)"        "" "LEAN4_GUARDRAILS_BYPASS=1 git restore file.lean"        0
+# Pure unstaging — always allowed regardless of policy
+run_test_destructive_policy "unset: restore --staged file (allow always)"   "" "git restore --staged file.lean"                         0
+run_test_destructive_policy "block: restore --staged file (allow always)"   block "git restore --staged file.lean"                     0
+# allow
+run_test_destructive_policy "allow: restore file"                           allow "git restore file.lean"                              0
+# block: even bypass token doesn't help
+run_test_destructive_policy "block: restore file (still block)"             block "git restore file.lean"                              2
+run_test_destructive_policy "block: bypass restore file (still block)"      block "LEAN4_GUARDRAILS_BYPASS=1 git restore file.lean"    2
+
+echo ""
+echo "-- Hard-block: whole-worktree variants stay non-bypassable --"
+# These must block regardless of DESTRUCTIVE_POLICY value or bypass token.
+run_test_destructive_policy "git checkout .       (always block)"           allow "git checkout ."                                    2
+run_test_destructive_policy "git checkout -- .    (always block, new)"      allow "git checkout -- ."                                 2
+run_test_destructive_policy "git restore .        (always block, new)"      allow "git restore ."                                     2
+run_test_destructive_policy "git restore --staged --worktree (always block)" allow "git restore --staged --worktree file.lean"        2
+run_test_destructive_policy "git reset --hard    (always block)"            allow "git reset --hard"                                  2
+run_test_destructive_policy "git clean -fd       (always block)"            allow "git clean -fd"                                     2
+run_test_destructive_policy "git clean --force   (always block)"            allow "git clean --force"                                 2
+# Even with bypass token, whole-worktree ops must stay blocked.
+run_test_destructive_policy "bypass git checkout .     (still block)"       allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout ."          2
+run_test_destructive_policy "bypass git checkout -- .  (still block)"       allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout -- ."       2
+run_test_destructive_policy "bypass git reset --hard   (still block)"       allow "LEAN4_GUARDRAILS_BYPASS=1 git reset --hard"        2
+run_test_destructive_policy "bypass git clean -fd      (still block)"       allow "LEAN4_GUARDRAILS_BYPASS=1 git clean -fd"           2
+
+echo ""
+echo "-- Policy independence: COLLAB and DESTRUCTIVE govern separately --"
+# DESTRUCTIVE_POLICY=allow doesn't unblock collab ops; COLLAB_POLICY=allow doesn't unblock destructive ops.
+run_test_destructive_policy "allow: git push (still block — collab governs)" allow "git push origin main"                              2
+run_test_policy "allow: checkout -- file (still block — destructive governs)" allow "git checkout -- file.lean"                       2
+run_test_policy "allow: restore file (still block — destructive governs)"    allow "git restore file.lean"                            2
+
+echo ""
+echo "-- Invalid destructive policy values fall back to ask --"
+run_test_destructive_policy "invalid: yolo plain checkout -- (block=ask)"  yolo "git checkout -- file.lean"                            2
+run_test_destructive_policy "invalid: yolo bypass checkout -- (allow=ask)" yolo "LEAN4_GUARDRAILS_BYPASS=1 git checkout -- file.lean" 0
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -214,20 +214,42 @@ run_test_destructive_policy "block: restore file (still block)"             bloc
 run_test_destructive_policy "block: bypass restore file (still block)"      block "LEAN4_GUARDRAILS_BYPASS=1 git restore file.lean"    2
 
 echo ""
+echo "-- Pure unstaging is always allowed (including whole-index 'restore --staged .') --"
+# git restore --staged <anything> (without --worktree) only touches the index.
+# Recoverable via re-add. Must NOT be hard-blocked even with the broad `.`
+# pathspec — previously was a regression.
+run_test_destructive_policy "unset: restore --staged . (allow always)"   "" "git restore --staged ."         0
+run_test_destructive_policy "block: restore --staged . (allow always)"   block "git restore --staged ."     0
+run_test_destructive_policy "unset: restore --staged ./ (allow always)"  "" "git restore --staged ./"        0
+
+echo ""
 echo "-- Hard-block: whole-worktree variants stay non-bypassable --"
 # These must block regardless of DESTRUCTIVE_POLICY value or bypass token.
-run_test_destructive_policy "git checkout .       (always block)"           allow "git checkout ."                                    2
-run_test_destructive_policy "git checkout -- .    (always block, new)"      allow "git checkout -- ."                                 2
-run_test_destructive_policy "git restore .        (always block, new)"      allow "git restore ."                                     2
-run_test_destructive_policy "git restore --staged --worktree (always block)" allow "git restore --staged --worktree file.lean"        2
-run_test_destructive_policy "git reset --hard    (always block)"            allow "git reset --hard"                                  2
-run_test_destructive_policy "git clean -fd       (always block)"            allow "git clean -fd"                                     2
-run_test_destructive_policy "git clean --force   (always block)"            allow "git clean --force"                                 2
+# Coverage includes the broader pathspec variants: `.`, `./`, `:/`,
+# `:(top)`, the `checkout HEAD -- .` form (ref before `--`), and
+# combined `--staged --worktree` restores.
+run_test_destructive_policy "git checkout .                   (always block)" allow "git checkout ."                                    2
+run_test_destructive_policy "git checkout ./                  (always block)" allow "git checkout ./"                                   2
+run_test_destructive_policy "git checkout -- .                (always block)" allow "git checkout -- ."                                 2
+run_test_destructive_policy "git checkout -- ./               (always block)" allow "git checkout -- ./"                                2
+run_test_destructive_policy "git checkout -- :/               (always block)" allow "git checkout -- :/"                                2
+run_test_destructive_policy "git checkout -- :(top)           (always block)" allow "git checkout -- :(top)"                            2
+run_test_destructive_policy "git checkout HEAD -- .           (always block)" allow "git checkout HEAD -- ."                            2
+run_test_destructive_policy "git checkout HEAD -- ./          (always block)" allow "git checkout HEAD -- ./"                           2
+run_test_destructive_policy "git restore .                    (always block)" allow "git restore ."                                     2
+run_test_destructive_policy "git restore ./                   (always block)" allow "git restore ./"                                    2
+run_test_destructive_policy "git restore :/                   (always block)" allow "git restore :/"                                    2
+run_test_destructive_policy "git restore --staged --worktree  (always block)" allow "git restore --staged --worktree file.lean"        2
+run_test_destructive_policy "git reset --hard                 (always block)" allow "git reset --hard"                                  2
+run_test_destructive_policy "git clean -fd                    (always block)" allow "git clean -fd"                                     2
+run_test_destructive_policy "git clean --force                (always block)" allow "git clean --force"                                 2
 # Even with bypass token, whole-worktree ops must stay blocked.
-run_test_destructive_policy "bypass git checkout .     (still block)"       allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout ."          2
-run_test_destructive_policy "bypass git checkout -- .  (still block)"       allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout -- ."       2
-run_test_destructive_policy "bypass git reset --hard   (still block)"       allow "LEAN4_GUARDRAILS_BYPASS=1 git reset --hard"        2
-run_test_destructive_policy "bypass git clean -fd      (still block)"       allow "LEAN4_GUARDRAILS_BYPASS=1 git clean -fd"           2
+run_test_destructive_policy "bypass git checkout .            (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout ."          2
+run_test_destructive_policy "bypass git checkout -- .         (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout -- ."       2
+run_test_destructive_policy "bypass git checkout HEAD -- .    (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout HEAD -- ."  2
+run_test_destructive_policy "bypass git restore ./            (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git restore ./"           2
+run_test_destructive_policy "bypass git reset --hard          (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git reset --hard"        2
+run_test_destructive_policy "bypass git clean -fd             (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git clean -fd"           2
 
 echo ""
 echo "-- Policy independence: COLLAB and DESTRUCTIVE govern separately --"

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -189,6 +189,16 @@ run_test_destructive_policy "unset: checkout --recurse-submodules file"      "" 
 run_test_destructive_policy "allow: checkout --no-overlay file"              allow "git checkout --no-overlay file.lean"                 0
 run_test_destructive_policy "allow: checkout --ignore-skip-worktree-bits file" allow "git checkout --ignore-skip-worktree-bits file.lean" 0
 run_test_destructive_policy "bypass: checkout --no-overlay file"             "" "LEAN4_GUARDRAILS_BYPASS=1 git checkout --no-overlay file.lean" 0
+# -p / --patch is interactive but pipeable (yes y | git checkout -p file
+# discards the file). Soft-gate regardless of TTY.
+run_test_destructive_policy "unset: checkout -p file (block=ask)"            "" "git checkout -p file.lean"                              2
+run_test_destructive_policy "unset: checkout --patch file (block=ask)"       "" "git checkout --patch file.lean"                         2
+run_test_destructive_policy "allow: checkout -p file"                        allow "git checkout -p file.lean"                          0
+run_test_destructive_policy "allow: checkout --patch file"                   allow "git checkout --patch file.lean"                     0
+run_test_destructive_policy "bypass: checkout -p file"                       "" "LEAN4_GUARDRAILS_BYPASS=1 git checkout -p file.lean"   0
+# Patch with no positional — still soft-gate (whole-worktree interactive sweep).
+run_test_destructive_policy "unset: checkout -p (no path, block=ask)"        "" "git checkout -p"                                        2
+run_test_destructive_policy "unset: checkout --patch (no path, block=ask)"   "" "git checkout --patch"                                   2
 # Non-force flag prefix before explicit-prefix path — same soft-gate.
 run_test_destructive_policy "unset: checkout -q ./file (block=ask)"         "" "git checkout -q ./file.lean"                            2
 run_test_destructive_policy "allow: checkout --quiet :/foo.lean"            allow "git checkout --quiet :/foo.lean"                   0

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -202,6 +202,14 @@ run_test_destructive_policy "allow: checkout ./file"                        allo
 run_test_destructive_policy "bypass: checkout ./file"                       "" "LEAN4_GUARDRAILS_BYPASS=1 git checkout ./file.lean"      0
 run_test_destructive_policy "block: checkout ./file (still block)"          block "git checkout ./file.lean"                            2
 
+# Dotfile path-prefix forms (e.g., ./.env, ./.github/...) — same gating
+# as non-dotfile path-prefix forms.
+run_test_destructive_policy "unset: checkout ./.env (block=ask)"            "" "git checkout ./.env"                                     2
+run_test_destructive_policy "unset: checkout :/.env (block=ask)"            "" "git checkout :/.env"                                     2
+run_test_destructive_policy "unset: checkout ../.env (block=ask)"           "" "git checkout ../.env"                                    2
+run_test_destructive_policy "allow: checkout ./.env"                        allow "git checkout ./.env"                                  0
+run_test_destructive_policy "allow: checkout ./.github path"                allow "git checkout ./.github/workflows/lint.yml"            0
+
 echo ""
 echo "-- Destructive policy: path-scoped git restore <path…> --"
 # Default: same shape

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -196,9 +196,18 @@ run_test_destructive_policy "unset: checkout --patch file (block=ask)"       "" 
 run_test_destructive_policy "allow: checkout -p file"                        allow "git checkout -p file.lean"                          0
 run_test_destructive_policy "allow: checkout --patch file"                   allow "git checkout --patch file.lean"                     0
 run_test_destructive_policy "bypass: checkout -p file"                       "" "LEAN4_GUARDRAILS_BYPASS=1 git checkout -p file.lean"   0
-# Patch with no positional — still soft-gate (whole-worktree interactive sweep).
-run_test_destructive_policy "unset: checkout -p (no path, block=ask)"        "" "git checkout -p"                                        2
-run_test_destructive_policy "unset: checkout --patch (no path, block=ask)"   "" "git checkout --patch"                                   2
+# Patch with no path positional — TIER-1 hard-block (whole-worktree
+# interactive sweep; pipes like `yes y | …` bypass interactivity).
+# Empirically verified: both forms wipe every dirty file in the worktree.
+run_test_destructive_policy "git checkout -p              (always block, no path)" allow "git checkout -p"                                2
+run_test_destructive_policy "git checkout --patch         (always block, no path)" allow "git checkout --patch"                           2
+run_test_destructive_policy "git checkout -p HEAD         (always block, no pathspec)" allow "git checkout -p HEAD"                       2
+run_test_destructive_policy "git checkout --patch HEAD    (always block, no pathspec)" allow "git checkout --patch HEAD"                  2
+run_test_destructive_policy "bypass git checkout -p       (still block, no path)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout -p"      2
+run_test_destructive_policy "bypass git checkout --patch  (still block, no path)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout --patch" 2
+run_test_destructive_policy "bypass git checkout -p HEAD  (still block)"         allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout -p HEAD"  2
+# Negative control: -p WITH a path positional still soft-gates (path-scoped).
+run_test_destructive_policy "allow: checkout -p HEAD file"                       allow "git checkout -p HEAD file.lean"                  0
 # Non-force flag prefix before explicit-prefix path — same soft-gate.
 run_test_destructive_policy "unset: checkout -q ./file (block=ask)"         "" "git checkout -q ./file.lean"                            2
 run_test_destructive_policy "allow: checkout --quiet :/foo.lean"            allow "git checkout --quiet :/foo.lean"                   0

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -172,6 +172,22 @@ run_test_destructive_policy "unset: bypass checkout HEAD file (allow=ask)"  "" "
 # allow: any tree-ish + bounded path passes
 run_test_destructive_policy "allow: checkout HEAD file"                     allow "git checkout HEAD file.lean"                      0
 run_test_destructive_policy "allow: checkout main file"                     allow "git checkout main src/foo.lean"                   0
+# Non-force flag prefix before tree-ish + path — same soft-gate.
+run_test_destructive_policy "unset: checkout -q HEAD file (block=ask)"      "" "git checkout -q HEAD file.lean"                         2
+run_test_destructive_policy "unset: checkout --quiet HEAD file (block=ask)" "" "git checkout --quiet HEAD file.lean"                    2
+run_test_destructive_policy "allow: checkout -q HEAD file"                  allow "git checkout -q HEAD file.lean"                    0
+run_test_destructive_policy "allow: checkout --quiet HEAD file"             allow "git checkout --quiet HEAD file.lean"               0
+run_test_destructive_policy "bypass: checkout -q HEAD file"                 "" "LEAN4_GUARDRAILS_BYPASS=1 git checkout -q HEAD file.lean" 0
+# Non-force flag prefix before explicit-prefix path — same soft-gate.
+run_test_destructive_policy "unset: checkout -q ./file (block=ask)"         "" "git checkout -q ./file.lean"                            2
+run_test_destructive_policy "allow: checkout --quiet :/foo.lean"            allow "git checkout --quiet :/foo.lean"                   0
+# Negative controls: branch creation/detach flags must not soft-gate
+# (those forms aren't path-restore).
+run_test_destructive_policy "allow: git checkout -b newbranch"              "" "git checkout -b newbranch"                              0
+run_test_destructive_policy "allow: git checkout -b newbranch main"         "" "git checkout -b newbranch main"                         0
+run_test_destructive_policy "allow: git checkout -B existing main"          "" "git checkout -B existing main"                          0
+run_test_destructive_policy "allow: git checkout --orphan newroot"          "" "git checkout --orphan newroot"                          0
+run_test_destructive_policy "allow: git checkout --detach main"             "" "git checkout --detach main"                             0
 run_test_destructive_policy "allow: checkout HEAD~1 file"                   allow "git checkout HEAD~1 file.lean"                    0
 # block: even bypass token doesn't help
 run_test_destructive_policy "block: checkout HEAD file (still block)"       block "git checkout HEAD file.lean"                      2

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -45,7 +45,7 @@ run_test_policy() {
   fi
 }
 
-# Run a test with a specific destructive policy (single-file destructive ops).
+# Run a test with a specific destructive policy (path-scoped destructive ops).
 # $1=desc  $2=policy value (ask|allow|block|"" for unset)  $3=command  $4=expected exit
 run_test_destructive_policy() {
   local desc="$1" policy="$2" cmd="$3" expected="$4" actual
@@ -153,74 +153,37 @@ run_test "FOO=\$(cmd) BYPASS=1 git push (allow)"       'FOO=$(echo "x y") LEAN4_
 run_test "FOO=\"BYPASS=1\" git push (block)"            'FOO="LEAN4_GUARDRAILS_BYPASS=1" git push origin main'        2
 
 echo ""
-echo "-- Collaboration policy: ask mode --"
-run_test_policy "ask: git push (block)"                 ask "git push origin main"            2
-run_test_policy "ask: git commit --amend (block)"       ask "git commit --amend"              2
-run_test_policy "ask: gh pr create (block)"             ask "gh pr create --title test"       2
-run_test_policy "ask: bypass git push (allow)"          ask "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"   0
-run_test_policy "ask: bypass git commit --amend (allow)" ask "LEAN4_GUARDRAILS_BYPASS=1 git commit --amend"    0
-run_test_policy "ask: bypass gh pr create (allow)"      ask "LEAN4_GUARDRAILS_BYPASS=1 gh pr create --title t" 0
-
-echo ""
-echo "-- Collaboration policy: allow mode --"
-run_test_policy "allow: git push (allow)"               allow "git push origin main"          0
-run_test_policy "allow: git commit --amend (allow)"     allow "git commit --amend"            0
-run_test_policy "allow: gh pr create (allow)"           allow "gh pr create --title test"     0
-run_test_policy "allow: reset --hard (still block)"     allow "git reset --hard"              2
-run_test_policy "allow: clean -f (still block)"         allow "git clean -f"                  2
-run_test_policy "allow: checkout -- (still block)"      allow "git checkout -- file.txt"      2
-
-echo ""
-echo "-- Collaboration policy: block mode --"
-run_test_policy "block: git push (block)"               block "git push origin main"          2
-run_test_policy "block: git commit --amend (block)"     block "git commit --amend"            2
-run_test_policy "block: gh pr create (block)"           block "gh pr create --title test"     2
-run_test_policy "block: bypass git push (still block)"  block "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"   2
-run_test_policy "block: bypass amend (still block)"     block "LEAN4_GUARDRAILS_BYPASS=1 git commit --amend"     2
-run_test_policy "block: bypass pr create (still block)" block "LEAN4_GUARDRAILS_BYPASS=1 gh pr create --title t" 2
-run_test_policy "block: reset --hard (still block)"     block "git reset --hard"              2
-
-echo ""
-echo "-- Collaboration policy: invalid/default --"
-run_test_policy "invalid: yolo push (block=ask)"        yolo "git push origin main"           2
-run_test_policy "invalid: yolo bypass push (allow=ask)" yolo "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"   0
-run_test_policy "unset: plain push (block=ask)"         ""   "git push origin main"           2
-run_test_policy "unset: bypass push (allow=ask)"        ""   "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"   0
-
-echo ""
-echo "-- Destructive policy: single-file checkout -- <path> --"
+echo "-- Destructive policy: path-scoped checkout -- <path…> --"
 # Default (unset = ask): blocks without bypass, allows with bypass
 run_test_destructive_policy "unset: checkout -- file (block=ask)"           "" "git checkout -- file.lean"                            2
 run_test_destructive_policy "unset: bypass checkout -- file (allow=ask)"    "" "LEAN4_GUARDRAILS_BYPASS=1 git checkout -- file.lean"  0
-# allow: passes without bypass
+# allow: passes without bypass; covers multi-file and directory pathsets too
 run_test_destructive_policy "allow: checkout -- file"                       allow "git checkout -- file.lean"                       0
 run_test_destructive_policy "allow: checkout -- multi-file"                 allow "git checkout -- a.lean b.lean"                    0
+run_test_destructive_policy "allow: checkout -- directory"                  allow "git checkout -- src/"                             0
 # block: blocks even with bypass token
 run_test_destructive_policy "block: checkout -- file (still block)"         block "git checkout -- file.lean"                       2
 run_test_destructive_policy "block: bypass checkout -- file (still block)"  block "LEAN4_GUARDRAILS_BYPASS=1 git checkout -- file.lean" 2
 
 echo ""
-echo "-- Destructive policy: single-file git restore <path> --"
+echo "-- Destructive policy: path-scoped git restore <path…> --"
 # Default: same shape
 run_test_destructive_policy "unset: restore file (block=ask)"               "" "git restore file.lean"                                  2
 run_test_destructive_policy "unset: bypass restore file (allow=ask)"        "" "LEAN4_GUARDRAILS_BYPASS=1 git restore file.lean"        0
-# Pure unstaging — always allowed regardless of policy
+# Pure unstaging — always allowed regardless of policy (any pathspec,
+# including the whole-index `--staged .` form — pure unstaging is
+# index-only and recoverable).
 run_test_destructive_policy "unset: restore --staged file (allow always)"   "" "git restore --staged file.lean"                         0
 run_test_destructive_policy "block: restore --staged file (allow always)"   block "git restore --staged file.lean"                     0
-# allow
+run_test_destructive_policy "unset: restore --staged . (allow always)"      "" "git restore --staged ."                                 0
+run_test_destructive_policy "block: restore --staged . (allow always)"      block "git restore --staged ."                             0
+run_test_destructive_policy "unset: restore --staged ./ (allow always)"     "" "git restore --staged ./"                                0
+# allow: any path-scoped restore
 run_test_destructive_policy "allow: restore file"                           allow "git restore file.lean"                              0
+run_test_destructive_policy "allow: restore directory"                      allow "git restore src/"                                   0
 # block: even bypass token doesn't help
 run_test_destructive_policy "block: restore file (still block)"             block "git restore file.lean"                              2
 run_test_destructive_policy "block: bypass restore file (still block)"      block "LEAN4_GUARDRAILS_BYPASS=1 git restore file.lean"    2
-
-echo ""
-echo "-- Pure unstaging is always allowed (including whole-index 'restore --staged .') --"
-# git restore --staged <anything> (without --worktree) only touches the index.
-# Recoverable via re-add. Must NOT be hard-blocked even with the broad `.`
-# pathspec — previously was a regression.
-run_test_destructive_policy "unset: restore --staged . (allow always)"   "" "git restore --staged ."         0
-run_test_destructive_policy "block: restore --staged . (allow always)"   block "git restore --staged ."     0
-run_test_destructive_policy "unset: restore --staged ./ (allow always)"  "" "git restore --staged ./"        0
 
 echo ""
 echo "-- Hard-block: whole-worktree variants stay non-bypassable --"
@@ -262,6 +225,41 @@ echo ""
 echo "-- Invalid destructive policy values fall back to ask --"
 run_test_destructive_policy "invalid: yolo plain checkout -- (block=ask)"  yolo "git checkout -- file.lean"                            2
 run_test_destructive_policy "invalid: yolo bypass checkout -- (allow=ask)" yolo "LEAN4_GUARDRAILS_BYPASS=1 git checkout -- file.lean" 0
+
+echo ""
+echo "-- Collaboration policy: ask mode --"
+run_test_policy "ask: git push (block)"                 ask "git push origin main"            2
+run_test_policy "ask: git commit --amend (block)"       ask "git commit --amend"              2
+run_test_policy "ask: gh pr create (block)"             ask "gh pr create --title test"       2
+run_test_policy "ask: bypass git push (allow)"          ask "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"   0
+run_test_policy "ask: bypass git commit --amend (allow)" ask "LEAN4_GUARDRAILS_BYPASS=1 git commit --amend"    0
+run_test_policy "ask: bypass gh pr create (allow)"      ask "LEAN4_GUARDRAILS_BYPASS=1 gh pr create --title t" 0
+
+echo ""
+echo "-- Collaboration policy: allow mode --"
+run_test_policy "allow: git push (allow)"               allow "git push origin main"          0
+run_test_policy "allow: git commit --amend (allow)"     allow "git commit --amend"            0
+run_test_policy "allow: gh pr create (allow)"           allow "gh pr create --title test"     0
+run_test_policy "allow: reset --hard (still block)"     allow "git reset --hard"              2
+run_test_policy "allow: clean -f (still block)"         allow "git clean -f"                  2
+run_test_policy "allow: checkout -- (still block)"      allow "git checkout -- file.txt"      2
+
+echo ""
+echo "-- Collaboration policy: block mode --"
+run_test_policy "block: git push (block)"               block "git push origin main"          2
+run_test_policy "block: git commit --amend (block)"     block "git commit --amend"            2
+run_test_policy "block: gh pr create (block)"           block "gh pr create --title test"     2
+run_test_policy "block: bypass git push (still block)"  block "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"   2
+run_test_policy "block: bypass amend (still block)"     block "LEAN4_GUARDRAILS_BYPASS=1 git commit --amend"     2
+run_test_policy "block: bypass pr create (still block)" block "LEAN4_GUARDRAILS_BYPASS=1 gh pr create --title t" 2
+run_test_policy "block: reset --hard (still block)"     block "git reset --hard"              2
+
+echo ""
+echo "-- Collaboration policy: invalid/default --"
+run_test_policy "invalid: yolo push (block=ask)"        yolo "git push origin main"           2
+run_test_policy "invalid: yolo bypass push (allow=ask)" yolo "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"   0
+run_test_policy "unset: plain push (block=ask)"         ""   "git push origin main"           2
+run_test_policy "unset: bypass push (allow=ask)"        ""   "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"   0
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -210,6 +210,32 @@ run_test_destructive_policy "unset: checkout ../.env (block=ask)"           "" "
 run_test_destructive_policy "allow: checkout ./.env"                        allow "git checkout ./.env"                                  0
 run_test_destructive_policy "allow: checkout ./.github path"                allow "git checkout ./.github/workflows/lint.yml"            0
 
+# Force-mode checkout / switch — branch-like vs path-like.
+# Branch-like (no path indicators) is hard-blocked because force branch
+# checkout discards uncommitted edits across the whole worktree.
+run_test_destructive_policy "git checkout -f main             (always block)" allow "git checkout -f main"                              2
+run_test_destructive_policy "git checkout --force main        (always block)" allow "git checkout --force main"                        2
+run_test_destructive_policy "git checkout -f feature_x        (always block)" allow "git checkout -f feature_x"                        2
+run_test_destructive_policy "bypass git checkout -f main      (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout -f main"   2
+# git switch in force/discard-changes mode — always hard-block.
+run_test_destructive_policy "git switch -f main               (always block)" allow "git switch -f main"                               2
+run_test_destructive_policy "git switch --force main          (always block)" allow "git switch --force main"                         2
+run_test_destructive_policy "git switch --discard-changes main (always block)" allow "git switch --discard-changes main"               2
+run_test_destructive_policy "bypass git switch -f main        (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git switch -f main"     2
+# Path-like -f forms — soft-gate (path-scoped).
+run_test_destructive_policy "unset: checkout -f file (block=ask)"           "" "git checkout -f file.lean"                              2
+run_test_destructive_policy "unset: checkout -f docs/ (block=ask)"          "" "git checkout -f docs/"                                  2
+run_test_destructive_policy "allow: checkout -f file"                       allow "git checkout -f file.lean"                          0
+run_test_destructive_policy "allow: checkout --force file"                  allow "git checkout --force file.lean"                     0
+run_test_destructive_policy "bypass: checkout -f file"                      "" "LEAN4_GUARDRAILS_BYPASS=1 git checkout -f file.lean"   0
+run_test_destructive_policy "block: checkout -f file (still block)"         block "git checkout -f file.lean"                          2
+# Negative: git switch --force-create (creates branch over existing; doesn't touch worktree)
+# should NOT match the switch-force hard-block.
+run_test_destructive_policy "allow: git switch --force-create new" "" "git switch --force-create new-branch" 0
+# Negative: regular branch switching stays allowed.
+run_test_destructive_policy "allow: git switch main" "" "git switch main" 0
+run_test_destructive_policy "allow: git checkout main" "" "git checkout main" 0
+
 echo ""
 echo "-- Destructive policy: path-scoped git restore <path…> --"
 # Default: same shape

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -187,6 +187,12 @@ run_test_destructive_policy "allow: checkout -b newbranch start-point"      ""  
 # destructive policy.
 run_test_destructive_policy "unset: checkout --ours file (block=ask)"       "" "git checkout --ours file.lean"                          2
 run_test_destructive_policy "unset: checkout --theirs file (block=ask)"     "" "git checkout --theirs file.lean"                        2
+# -2 / -3 are short aliases for --ours / --theirs (same conflict-resolution semantics).
+run_test_destructive_policy "unset: checkout -2 file (block=ask)"           "" "git checkout -2 file.lean"                              2
+run_test_destructive_policy "unset: checkout -3 file (block=ask)"           "" "git checkout -3 file.lean"                              2
+run_test_destructive_policy "allow: checkout -2 file"                       allow "git checkout -2 file.lean"                          0
+run_test_destructive_policy "allow: checkout -3 file"                       allow "git checkout -3 file.lean"                          0
+run_test_destructive_policy "bypass: checkout -2 file"                      "" "LEAN4_GUARDRAILS_BYPASS=1 git checkout -2 file.lean"   0
 # Note: -m is not covered — see _strip_optvals limitation comment in guardrails.sh
 run_test_destructive_policy "allow: checkout --ours file"                   allow "git checkout --ours file.lean"                      0
 run_test_destructive_policy "allow: checkout --theirs src/foo.lean"         allow "git checkout --theirs src/foo.lean"                  0

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -266,6 +266,11 @@ run_test_destructive_policy "git restore .                    (always block)" al
 run_test_destructive_policy "git restore ./                   (always block)" allow "git restore ./"                                    2
 run_test_destructive_policy "git restore :/                   (always block)" allow "git restore :/"                                    2
 run_test_destructive_policy "git restore --staged --worktree  (always block)" allow "git restore --staged --worktree file.lean"        2
+run_test_destructive_policy "git restore --pathspec-from-file (always block)" allow "git restore --pathspec-from-file=paths.txt"        2
+run_test_destructive_policy "git restore --worktree --pathspec-from-file (always block)" allow "git restore --worktree --pathspec-from-file=paths.txt" 2
+# Pure-unstaging --staged --pathspec-from-file remains allowed (index-only).
+run_test_destructive_policy "restore --staged --pathspec-from-file (allow always)" block "git restore --staged --pathspec-from-file=paths.txt" 0
+run_test_destructive_policy "restore -S --pathspec-from-file (allow always)" block "git restore -S --pathspec-from-file=paths.txt" 0
 run_test_destructive_policy "git reset --hard                 (always block)" allow "git reset --hard"                                  2
 run_test_destructive_policy "git clean -fd                    (always block)" allow "git clean -fd"                                     2
 run_test_destructive_policy "git clean --force                (always block)" allow "git clean --force"                                 2
@@ -277,6 +282,7 @@ run_test_destructive_policy "bypass git checkout HEAD .       (still block)" all
 run_test_destructive_policy "bypass git checkout -f .         (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout -f ."       2
 run_test_destructive_policy "bypass git checkout --ours .     (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout --ours ."   2
 run_test_destructive_policy "bypass git checkout --pathspec-from-file (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout --pathspec-from-file=paths.txt" 2
+run_test_destructive_policy "bypass git restore --pathspec-from-file (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git restore --pathspec-from-file=paths.txt" 2
 run_test_destructive_policy "bypass git restore ./            (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git restore ./"           2
 run_test_destructive_policy "bypass git reset --hard          (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git reset --hard"        2
 run_test_destructive_policy "bypass git clean -fd             (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git clean -fd"           2

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -249,9 +249,14 @@ run_test_destructive_policy "git checkout -f -B tmp main      (always block)" al
 run_test_destructive_policy 'git checkout -f @{-1}           (always block)' allow 'git checkout -f @{-1}'                              2
 run_test_destructive_policy "git checkout --force @{-1}      (always block)" allow 'git checkout --force @{-1}'                         2
 run_test_destructive_policy "git checkout -f -                (always block)" allow "git checkout -f -"                                 2
+run_test_destructive_policy "git checkout --force -            (always block)" allow "git checkout --force -"                            2
 run_test_destructive_policy "git checkout -f @                (always block)" allow "git checkout -f @"                                 2
 run_test_destructive_policy "git checkout -f HEAD~3           (always block)" allow "git checkout -f HEAD~3"                            2
 run_test_destructive_policy 'git checkout -f HEAD@{1}        (always block)' allow 'git checkout -f HEAD@{1}'                           2
+# Bypass token does not override ref-shorthand force hard-blocks (Layer 1
+# confirmed these discard the dirty worktree; tier-1 stays absolute).
+run_test_destructive_policy 'bypass git checkout -f @{-1}    (still block)' allow 'LEAN4_GUARDRAILS_BYPASS=1 git checkout -f @{-1}'      2
+run_test_destructive_policy "bypass git checkout -f -         (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git checkout -f -"        2
 # Force checkout with path-like and option interleaving: soft-gate.
 run_test_destructive_policy "unset: checkout -q -f file (block=ask)"        "" "git checkout -q -f file.lean"                            2
 run_test_destructive_policy "allow: checkout -q -f file"                    allow "git checkout -q -f file.lean"                       0
@@ -259,6 +264,10 @@ run_test_destructive_policy "allow: checkout --quiet --force file"          allo
 # Force checkout with explicit `--` separator: defers to general -- soft-gate.
 run_test_destructive_policy "allow: checkout -f -- file"                    allow "git checkout -f -- file.lean"                       0
 run_test_destructive_policy "unset: checkout -f -- file (block=ask)"        "" "git checkout -f -- file.lean"                           2
+# Force restore with explicit ./ path prefix — soft-gate (path-scoped).
+run_test_destructive_policy "unset: checkout -f ./file (block=ask)"         "" "git checkout -f ./file.lean"                              2
+run_test_destructive_policy "allow: checkout -f ./file"                     allow "git checkout -f ./file.lean"                        0
+run_test_destructive_policy "bypass: checkout -f ./file"                    "" "LEAN4_GUARDRAILS_BYPASS=1 git checkout -f ./file.lean" 0
 # Path-like -f forms — soft-gate (path-scoped).
 run_test_destructive_policy "unset: checkout -f file (block=ask)"           "" "git checkout -f file.lean"                              2
 run_test_destructive_policy "unset: checkout -f docs/ (block=ask)"          "" "git checkout -f docs/"                                  2
@@ -272,6 +281,10 @@ run_test_destructive_policy "allow: git switch --force-create new" "" "git switc
 # Negative: regular branch switching stays allowed.
 run_test_destructive_policy "allow: git switch main" "" "git switch main" 0
 run_test_destructive_policy "allow: git checkout main" "" "git checkout main" 0
+# `git checkout -` (bare dash, no force) is "switch to previous branch"; git
+# itself refuses the operation if the worktree is dirty, so it never destroys
+# data. Stays in the implicit-allow tier — Layer 1 confirmed PRESERVED.
+run_test_destructive_policy "allow: git checkout -" "" "git checkout -" 0
 
 echo ""
 echo "-- Destructive policy: path-scoped git restore <path…> --"

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -228,6 +228,25 @@ run_test_destructive_policy "git switch -f main               (always block)" al
 run_test_destructive_policy "git switch --force main          (always block)" allow "git switch --force main"                         2
 run_test_destructive_policy "git switch --discard-changes main (always block)" allow "git switch --discard-changes main"               2
 run_test_destructive_policy "bypass git switch -f main        (still block)" allow "LEAN4_GUARDRAILS_BYPASS=1 git switch -f main"     2
+# Force checkout with options interleaved before/after -f: same hard-block.
+run_test_destructive_policy "git checkout -q -f main          (always block)" allow "git checkout -q -f main"                           2
+run_test_destructive_policy "git checkout --quiet --force main (always block)" allow "git checkout --quiet --force main"                 2
+run_test_destructive_policy "git checkout -f --detach HEAD    (always block)" allow "git checkout -f --detach HEAD"                     2
+run_test_destructive_policy "git checkout -f -B tmp main      (always block)" allow "git checkout -f -B tmp main"                       2
+# Force checkout with git ref shorthand forms — branch/ref-switch hard-block.
+run_test_destructive_policy 'git checkout -f @{-1}           (always block)' allow 'git checkout -f @{-1}'                              2
+run_test_destructive_policy "git checkout --force @{-1}      (always block)" allow 'git checkout --force @{-1}'                         2
+run_test_destructive_policy "git checkout -f -                (always block)" allow "git checkout -f -"                                 2
+run_test_destructive_policy "git checkout -f @                (always block)" allow "git checkout -f @"                                 2
+run_test_destructive_policy "git checkout -f HEAD~3           (always block)" allow "git checkout -f HEAD~3"                            2
+run_test_destructive_policy 'git checkout -f HEAD@{1}        (always block)' allow 'git checkout -f HEAD@{1}'                           2
+# Force checkout with path-like and option interleaving: soft-gate.
+run_test_destructive_policy "unset: checkout -q -f file (block=ask)"        "" "git checkout -q -f file.lean"                            2
+run_test_destructive_policy "allow: checkout -q -f file"                    allow "git checkout -q -f file.lean"                       0
+run_test_destructive_policy "allow: checkout --quiet --force file"          allow "git checkout --quiet --force file.lean"             0
+# Force checkout with explicit `--` separator: defers to general -- soft-gate.
+run_test_destructive_policy "allow: checkout -f -- file"                    allow "git checkout -f -- file.lean"                       0
+run_test_destructive_policy "unset: checkout -f -- file (block=ask)"        "" "git checkout -f -- file.lean"                           2
 # Path-like -f forms — soft-gate (path-scoped).
 run_test_destructive_policy "unset: checkout -f file (block=ask)"           "" "git checkout -f file.lean"                              2
 run_test_destructive_policy "unset: checkout -f docs/ (block=ask)"          "" "git checkout -f docs/"                                  2

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -187,6 +187,12 @@ run_test_destructive_policy "allow: checkout -b newbranch start-point"      ""  
 # destructive policy.
 run_test_destructive_policy "unset: checkout --ours file (block=ask)"       "" "git checkout --ours file.lean"                          2
 run_test_destructive_policy "unset: checkout --theirs file (block=ask)"     "" "git checkout --theirs file.lean"                        2
+# --merge is the long form of -m. Unlike short -m (which _strip_optvals
+# removes pre-emptively to support `git commit -m "msg"`), the long
+# form survives normalization and IS gated here.
+run_test_destructive_policy "unset: checkout --merge file (block=ask)"      "" "git checkout --merge file.lean"                         2
+run_test_destructive_policy "allow: checkout --merge file"                  allow "git checkout --merge file.lean"                     0
+run_test_destructive_policy "bypass: checkout --merge file"                 "" "LEAN4_GUARDRAILS_BYPASS=1 git checkout --merge file.lean" 0
 # --conflict=<style> takes a value; the regex must accept `--conflict=merge`,
 # `--conflict=zdiff3`, etc., not just bare `--conflict`.
 run_test_destructive_policy "unset: checkout --conflict=merge file (block=ask)" "" "git checkout --conflict=merge file.lean"            2


### PR DESCRIPTION
## Summary

Restructures `plugins/lean4/hooks/guardrails.sh`'s git-op policy from two tiers (collab soft-gate + destructive hard-block) to three explicit tiers, with **path-scoped** `git checkout`/`git restore` operations moving from absolute hard-block to a new policy-controlled soft-gate (`LEAN4_GUARDRAILS_DESTRUCTIVE_POLICY=ask|allow|block`, default `ask`).

Branched off `main` directly — independent of PR #130 (the wrapper PR). The two PRs touch disjoint `test_guardrails.sh` regions (this PR's destructive-policy tests are inserted before the collab-policy section; PR #130 appends stderr-suppression tests at the end), so they merge in either order without conflict.

## Three tiers

| Tier | Behavior | Operations |
|---|---|---|
| **ALLOW** (implicit) | no gate, no warning | `git status`, `diff`, `log`, `show`, `branch`, `add`, `commit`, `stash push`, `switch <branch>` (without `-f`/`--force`/`--discard-changes`), `switch --force-create <name>`, `checkout <branch>`, `restore --staged <path>` (pure unstaging, any pathspec including `.`; including `-S --pathspec-from-file=…`) |
| **SOFT-GATE** (policy-controlled, bypass-able) | `LEAN4_GUARDRAILS_COLLAB_POLICY` (ask\|allow\|block, default ask): `git push`, `gh pr create`, `git commit --amend`. **`LEAN4_GUARDRAILS_DESTRUCTIVE_POLICY` (new, ask\|allow\|block, default ask): `git checkout -- <path…>`, `git checkout <tree-ish> <path…>`, `git checkout [-q\|--quiet] <tree-ish> <path…>` (flag prefix/interleaving OK), `git checkout {--ours,--theirs,-2,-3,--merge,--conflict=…} <path…>`, `git checkout {--ignore-skip-worktree-bits,--no-overlay,--overlay,--recurse-submodules,-p,--patch} [<path>]`, `git checkout -f\|--force <path-like>` (option order doesn't matter), `git checkout [-q\|--quiet] ./<path>` / `:/<path>` / `../<path>` (incl. dotfiles), `git restore <path…>` (any short or long worktree flags) — path-scoped, including multi-file and directory pathsets.** | `LEAN4_GUARDRAILS_BYPASS=1` prefix opts into a one-shot allow for both |
| **HARD-BLOCK** (absolute, no bypass) | unbounded blast radius; reflog can't recover uncommitted edits, `clean -f` can't recover untracked files at all, force-branch-switch discards across the whole worktree, opaque pathspec files could hide whole-worktree wipes | `git reset --hard`, `git clean -f`/`-fd`/`-fdx`/`--force`, `git checkout .`/`./`/`-- .`/`-- ./`/`-- :/`/`-- :(top)`/`HEAD -- .`/`HEAD -- ./`/`-f .`/`--ours .`/`--theirs :/`, `git checkout --pathspec-from-file=…`, `git checkout -f\|--force <branch-or-ref>` (incl. ref shorthand `@{-1}`, `-`, `@`, `HEAD~3`, `HEAD@{1}`; option order doesn't matter), `git restore .`/`./`/`:/`, `git restore --staged --worktree` (incl. `-SW`/`-S -W` combos), `git restore --pathspec-from-file=…` (non-staged), `git checkout -p`/`--patch` with no path (interactive whole-worktree sweep, bypassable by piped stdin), `git switch -f\|--force\|--discard-changes <anything>` |

## Twenty-six commits

1–10. Original three-tier restructure + first round of review fixups. See commits `4953281` through `986f91e` for the buildup: three-tier env-var + helper + restructure, initial tier-boundary tests, broaden whole-worktree pathspec detection, rename "single-file" → "path-scoped", README/MIGRATION docs, `checkout <tree-ish> <path>` without `--`, `restore` short flags `-S`/`-W`/`-SW`, README "Blocked" → "Guarded", comment typo fix, option-prefixed checkout pathspec forms (`-f .`, `--ours <path>`, `--pathspec-from-file`, `./<path>`).

11. **`fix(guardrails)`** (`e3142a1`) — Parallel hard-block for `git restore --pathspec-from-file=…` (the previous round only blocked the checkout variant). Ordered after the pure-unstaging exemption so `git restore --staged --pathspec-from-file=…` (index-only) remains allowed.
12. **`fix(guardrails)`** (`9955679`) — Explicit-path-prefix regex caught `./file.lean` but rejected `./.env`, `./.github/...`, `:/.env`, `../.env` because of a `[^\s.]` first-char exclusion. Replaced with `[^\s]+`; the hard-block already short-circuits the bare-prefix case.
13. **`fix(guardrails)`** (`c124b05`) — Force-mode branch checkout/switch (`git checkout -f main`, `--force main`, `git switch -f main`, `git switch --discard-changes main`) silently passed through implicit-allow because the guardrail had no specific recognition. All four discard uncommitted edits across the whole worktree (same blast radius as `reset --hard`). Now hard-blocked. Path-like `-f <path>` soft-gates instead. `--force-create` is intentionally not matched (forces branch creation over existing name, doesn't touch worktree).
14. **`fix(guardrails)`** (`998bb09`) — `-2` / `-3` short aliases for `--ours` / `--theirs` (conflict-resolution stage flags). Added to the soft-gate alternation; `_strip_optvals` leaves them intact (digit-based, not letter-based). Also tightened the trailing boundary from `\b` to `(\s|$)` so the alternation doesn't accidentally match longer tokens like `--ours-foo`.
15. **`docs(readme)`** (`81ad87e`) — Expand the "Destructive policy" subsection to enumerate the path-scoped forms (was still describing only `checkout -- <path>` and `restore <path>`). Extend the tier-3 hard-block bullet to include the new opaque-pathspec and force-branch variants.
16. **`fix(guardrails)`** (`24f0117`) — Force-mode checkout detection refactored from a single seg_match regex into a per-segment loop so option ordering no longer matters: `git checkout -q -f main`, `--quiet --force main`, `-f --detach HEAD`, `-f -B tmp main` all hit the same branches as `-f main`. Also handles git ref shorthand forms — `@{-1}`, `-` (synonym for `@{-1}`), `@`, `HEAD~3`, `HEAD@{1}` — that previously bypassed the `[A-Za-z0-9_]`-anchored branch-like regex. The `-f <path>` soft-gate is folded into the same loop.
17. **`fix(guardrails)`** (`f6c50ba`) — `--conflict=<style>` was effectively unreachable: the regex `--conflict[=[:space:]]` followed by `(\s|$)` required whitespace immediately after `=`, so `--conflict=merge file.lean` (the only valid form) never matched. Replaced with `--conflict(=\S+)?` to optionally consume the value before the boundary.
18. **`fix(guardrails)`** (`3f1f1bd`) — `--merge <path>` (long form of `-m`) added to the soft-gate alternation. Short `-m` remains deferred (documented in-source: `_strip_optvals` strips it for `git commit -m "msg"` false-positive avoidance), but `--merge` survives normalization (`_strip_optvals` only handles `--(message|file|body|title)` long flags).
19. **`test(guardrails)`** (`430b27a`) — Durable probes from a separate two-layer empirical audit: temp-repo verification of which checkout/switch forms actually discard a dirty worktree, then hook classification confirmed for each. Adds 7 reviewer-flagged probes (`--force -`, bypass-still-blocks for `-f @{-1}` / `-f -`, `-f ./file.lean` ask/allow/bypass, bare `git checkout -`). Empirical audit details posted as a PR comment; full probe scripts kept ad hoc.
20. **`fix(guardrails)`** (`32ce96b`) — `<tree-ish> <path>` soft-gate refactored from a single seg_match (anchored to `\bcheckout\b\s+[^-\s]`) into a per-segment loop, so non-destructive flag prefixes like `-q` / `--quiet` no longer bypass the gate: `git checkout -q HEAD file.lean`, `git checkout --quiet HEAD file.lean`, `git checkout HEAD -q file.lean` are now caught. Branch-creation / detach flags (`-b`, `-B`, `--orphan`, `--detach`) are explicitly skipped so they stay in implicit-allow. The explicit-path-prefix soft-gate gets the same flag-prefix widening. Bare-single-positional `git checkout -q file.lean` remains in implicit-allow as a deliberate trade-off (branch/path ambiguity). Same class of bug as the force-mode ordering issue in commit 16.
21. **`test(guardrails)`** (`fa4127a`) — Permanent regression probe for the `tree-ish + flag-interleaving` claim documented in commit 20 (`git checkout HEAD -q file.lean`): the commit supported it; this commit pins it.
22. **`fix(guardrails)`** (`bd45022`) — Closes the last single-positional gap. Bare `git checkout file.lean` stays in implicit-allow because of branch/path ambiguity, but when checkout is invoked with a pathspec-oriented flag the operation is unambiguously path-restore: `git checkout --ignore-skip-worktree-bits file.lean`, `--no-overlay file.lean`, `--overlay file.lean`, `--recurse-submodules file.lean`. Empirically verified (temp-repo probe) that all four discard a dirty worktree file when paired with a path positional. Soft-gates via `DESTRUCTIVE_POLICY`. `--recurse-submodules` is also valid with branch switching, where git itself refuses a dirty switch without `-f`; the conservative trade-off is an extra confirmation prompt before a likely-noop rather than a silent destructive false-negative for the path-restore form.
23. **`fix(guardrails)`** (`39e885e`) — `-p` / `--patch` (interactive hunk-selection variant of file-restore) added to the pathspec-oriented flag alternation. Interactive y/n is some protection but isn't absolute — empirically verified that `yes y | git checkout -p f` and `yes y | git checkout --patch f` both DISCARD the dirty file. Soft-gates regardless of TTY since the hook can't see the shell's stdin configuration. Bare `git checkout -p` (no path, interactive whole-worktree sweep) is also soft-gated.
24. **`release`** (`4a1fcdb`) — Bumps `plugin.json` + `marketplace.json` from 4.4.10 → 4.4.11 with the corresponding `CHANGELOG.md` entry summarizing the three-tier policy restructure.
25. **`fix(guardrails)`** (`ba0cef9`) — Moves no-path `git checkout -p` / `--patch` from tier-2 soft-gate to tier-1 hard-block. The previous round put it in the pathspec-oriented soft-gate alternation, but bare-form patch checkout is an interactive whole-worktree sweep with the same blast radius as `git checkout .`. Empirically verified: `yes y | git checkout -p` and `yes y | git checkout -p HEAD` both wipe every dirty file (interactive y/n isn't protection against piped stdin). Hard-block loop deferring to soft-gate only when a path-like positional is present, so `-p file.lean` and `-p HEAD file.lean` still soft-gate (path-scoped).
26. **`docs(readme)`** (`0471126`) — Brings the README's "Guarded during Lean project sessions" bullets and the "Destructive policy" subsection in line with current coverage. They were both missing forms added in commits 12, 18, 20, 22, 23, plus the new no-path patch hard-block from commit 25.

## Design choices

**Two separate env vars (`COLLAB_POLICY` + `DESTRUCTIVE_POLICY`)** rather than widening `COLLAB_POLICY` or renaming to `SOFT_GATE_POLICY`. The two categories have genuinely different risk semantics (collab affects shared state but is reversible; destructive affects local state and isn't). Mixing them under one var creates semantic confusion. Operators tune each axis independently.

**`[policy=…]` blocked-message tag disambiguates** `[collab_policy=…]` vs `[destructive_policy=…]` so reviewers/operators can tell at a glance which knob to twiddle.

**Path-scoped, not literally single-file.** `DESTRUCTIVE_POLICY=allow` permits any explicit pathset — one file, multiple files, a subdirectory, etc. Whole-worktree pathspecs (`.`, `./`, `:/`, `:(top)`) stay absolute. The blast radius is bounded by what the model names; that bound is what makes `ask`-by-default acceptable.

**Whole-worktree + force-branch variants stay absolute** — no bypass, no policy override. `reset --hard` / `clean -f` / `checkout .` / `restore .` / `checkout -f <branch>` / `switch -f <branch>` are fundamentally unrecoverable; the model should never legitimately need them.

**`--pathspec-from-file=…` hard-blocks rather than soft-gates** (both checkout and restore). The paths file is opaque to the guardrail and could contain `.` or `:/`. Conservative tier-1 placement; operators with a trusted paths file can pass paths explicitly on the command line. Pure-unstaging `--staged --pathspec-from-file=…` remains allowed since it's index-only.

**Force-mode branch detection uses a loop, not a single regex.** Option ordering would otherwise be load-bearing (`git checkout -q -f main` is the same as `git checkout -f main` in git's eyes, but a regex anchored to `checkout\s+-f` only catches the latter). The loop also accommodates git ref shorthand (`@{-1}`, `-`, `HEAD@{1}`, etc.) that doesn't fit `[A-Za-z0-9_]+`-style branch-like regex.

**Force-branch heuristic prefers fewer hard-blocks over branch-name exhaustiveness.** Branch names containing `/` or `.` (e.g. `release/v1.0`) are treated as path-like and soft-gated rather than hard-blocked. Operators can still opt in via `DESTRUCTIVE_POLICY=allow` or the bypass token.

## Test plan

- [x] All 75 pre-existing `test_guardrails.sh` cases still pass (backward-compatible in default mode).
- [x] **182 new tier-boundary probes** (75 → 257):
  - Path-scoped `checkout -- <path…>`, `checkout <tree-ish> <path…>`, `checkout {--ours,--theirs,-2,-3,--merge,--conflict[=value]} <path>`, `checkout -f <path-like>` (with option ordering variants), `checkout ./file`, `restore <path…>` (including `-S`/`-W` short flags and bundles) under ask/allow/block × bypass-or-not, plus multi-file and directory pathsets under `allow`.
  - Dotfile path-prefix forms (`./.env`, `./.github/...`, `:/.env`, `../.env`) gated identically to non-dotfile forms.
  - Pure unstaging (`restore --staged file`, `restore --staged .`, `restore -S file`, `restore --staged --pathspec-from-file=…`) always allowed regardless of policy.
  - Whole-worktree hard-block probes covering all the broader pathspec variants (`.`, `./`, `:/`, `:(top)`, `HEAD -- .`, `HEAD -- ./`, `-f .`, `--ours .`, `--theirs :/`) + `--staged --worktree` + `-SW` short-flag bundle.
  - `--pathspec-from-file=…` always hard-blocks for both checkout and restore (with and without preceding tree-ish; with bypass).
  - Force-mode branch hard-block: `git checkout -f|--force main`, `git switch -f|--force|--discard-changes main` (with bypass-still-blocks variants), option-ordering variants (`-q -f main`, `--quiet --force main`, `-f --detach HEAD`, `-f -B tmp main`), and git ref shorthand (`@{-1}`, `-`, `@`, `HEAD~3`, `HEAD@{1}`).
  - Force-mode path-like soft-gate including option-interleaving (`-q -f file.lean`, `--quiet --force file.lean`) and explicit `--` separator deferring to general soft-gate.
  - Negative: `git switch --force-create <name>`, plain `git switch main` / `git checkout main` stay allowed.
  - Policy independence (`DESTRUCTIVE_POLICY=allow` doesn't unblock collab; `COLLAB_POLICY=allow` doesn't unblock destructive).
  - Invalid value fallback to `ask`.
- [x] Full test matrix on Linux Bash 5.2.37 — no regressions in lint, smoke, cycle-tracker, validate-user-prompt, contracts, command_args, ruff, format, shellcheck.
- [x] `lint_runtime_portability.sh` passes on head `0471126` (9 shell + 12 Python files).
- [x] CI green on head `0471126`: `bash3-compat` (macOS) + `mypy` + `ruff` + `shellcheck`.

Result on `test_guardrails.sh`: **257 passed, 0 failed**.

## Out of scope

- The wrapper detector update from PR #130 — independent; either order merges cleanly.
- Short `-m <path>` coverage — `_strip_optvals` (shared with collab-op detection) strips `-m <value>` to prevent `git commit -m "git push"` from false-matching the push check. Catching short `-m` in checkout context requires splitting the normalization pipeline per-command; documented in-source and deferred. The long form `--merge` IS covered (commit 18), as are `--ours`/`--theirs`/`-2`/`-3`/`--conflict=…`.
- Bundled-flag forms like `-fb newbranch` (= `-f -b`). The `-f` detector matches standalone `-f`/`--force`, not letter bundles. Bundles are uncommon in practice and the bundled `-b` indicates branch CREATION (not destruction), so the false-negative window is narrow.
- Adding a `references/guardrail-policy.md` doc — the canonical references are the header comment block in `guardrails.sh` itself (now expanded to document the three tiers) and `test_guardrails.sh` as exhaustive canonical examples. The `plugins/lean4/README.md` Safety Guardrails section (updated here) is the user-facing summary.
