### PR TITLE
docs(skill): teach the omit [Inst] in ordering rule + lint guard (#136)

### DIFF
--- a/plugins/lean4/skills/lean4/SKILL.md
+++ b/plugins/lean4/skills/lean4/SKILL.md
@@ -289,6 +289,20 @@ open scoped Topology MeasureTheory
 
 Order matters: provide outer structures before inner ones.
 
+`omit [Inst] in` removes an unused section instance from the following declaration.
+Place it **before the declaration docstring**; putting it between the docstring and
+`lemma`/`theorem` makes Lean parse it as a separate `omit` command.
+
+```lean
+variable {α : Type*} [MeasurableSpace α]
+
+omit [MeasurableSpace α] in
+/-- doc -/
+theorem foo : True := trivial
+```
+
+See [domain-patterns](references/domain-patterns.md#pattern-7-managing-section-variables-with-omit) for more.
+
 ## Automation Tactics
 
 Try in order (stop on first success):

--- a/plugins/lean4/tools/lint_docs.sh
+++ b/plugins/lean4/tools/lint_docs.sh
@@ -479,6 +479,41 @@ check_bare_scripts() {
     ok "Bare script check done"
 }
 
+# Check 8a: SKILL.md Type Class Patterns section must teach the
+# `omit [Inst] in` ordering rule (issue #136). Docs-surface invariant
+# only — locks in the always-loaded surface so future edits can't
+# strip the rule out and re-introduce the parse-error footgun.
+# NOT a Lean parse test; not CI-enforced (lint_docs.sh runs
+# locally / via /lean4:doctor).
+check_skill_omit_rule() {
+    log ""
+    log "Checking SKILL.md teaches omit [Inst] in ordering rule..."
+
+    local _so_skill _so_section
+    _so_skill="$PLUGIN_ROOT/skills/lean4/SKILL.md"
+    if [[ ! -f "$_so_skill" ]]; then
+        warn "SKILL.md not found at $_so_skill (cannot check omit rule)"
+        return
+    fi
+    # Slice the `## Type Class Patterns` section: from its heading to
+    # the next top-level heading.
+    _so_section=$(awk '
+        /^## Type Class Patterns/ {p=1; next}
+        p && /^## / {exit}
+        p {print}
+    ' "$_so_skill")
+    if [[ -z "$_so_section" ]]; then
+        warn "SKILL.md: '## Type Class Patterns' section not found — omit ordering rule cannot be asserted (see issue #136)"
+        return
+    fi
+    if ! grep -q 'omit \[' <<<"$_so_section" \
+       || ! grep -q 'before the declaration docstring' <<<"$_so_section"; then
+        warn "SKILL.md Type Class Patterns: omit ordering rule missing — see issue #136 and references/domain-patterns.md Pattern 7"
+        return
+    fi
+    ok "SKILL.md teaches the omit [Inst] in ordering rule"
+}
+
 # Check 8b: Lean script invocations must not suppress stderr
 check_script_stderr_suppression() {
     log ""
@@ -1641,6 +1676,7 @@ check_cross_refs
 check_reference_links
 check_stale_commands
 check_bare_scripts
+check_skill_omit_rule
 check_script_stderr_suppression
 check_deep_safety
 check_guardrail_docs


### PR DESCRIPTION
## Summary

Closes #136. Adds the `omit [Inst] in` ordering rule to the always-loaded `SKILL.md` Type Class Patterns section, plus a small `lint_docs.sh` regression guard so future edits don't strip it out.

The rule (`omit [Inst] in` must come **before the declaration docstring**, not between the docstring and `lemma`/`theorem`) already exists in the on-demand reference `references/domain-patterns.md` (Pattern 7), but the reference isn't loaded by default — models hit the parse-error footgun during normal `.lean` editing because the always-loaded surface doesn't surface it.

No version bump (per request); two focused commits.

## Commits

1. **`docs(skill)`** (`19f46a5`) — extends SKILL.md `## Type Class Patterns` with the rule + the minimal failure-report example from the issue (`variable [MeasurableSpace α]` + `omit [...] in` + docstring + `theorem foo : True := trivial`), and a cross-reference to `references/domain-patterns.md#pattern-7-managing-section-variables-with-omit`.
2. **`lint(docs)`** (`18ecc16`) — new `check_skill_omit_rule` in `lint_docs.sh`. Slices the Type Class Patterns section out of SKILL.md and asserts the slice contains both `omit [` and `before the declaration docstring`. Wired into the main linear sequence between `check_bare_scripts` and `check_script_stderr_suppression`. Source comment explicitly notes:
   - Docs-surface invariant only; **NOT** a Lean parse test.
   - **Not CI-enforced** (`lint_docs.sh` runs locally / via `/lean4:doctor`). A strictly CI-gated invariant would belong in `test_contracts.sh` or require wiring `lint_docs.sh` into a CI step — deferred.

## Test plan

- [x] **Targeted lint pass:** `bash plugins/lean4/tools/lint_docs.sh` — new `check_skill_omit_rule` emits `✓ SKILL.md teaches the omit [Inst] in ordering rule`. (Other inherited warnings on the target branch — line-length flags on `autoprove.md` / `formalize.md` / `learn.md`, the `SKILL.md mentions 'Claude'` flag — are preexisting and out of scope here.)
- [x] **Negative test:** stripping the rule's paragraph from SKILL.md fires `⚠️  SKILL.md Type Class Patterns: omit ordering rule missing — see issue #136 and references/domain-patterns.md Pattern 7`. Restoring returns the check to `✓`.
- [x] **Anchor check:** open the rendered `domain-patterns.md` on GitHub and confirm the new SKILL.md cross-reference resolves the `#pattern-7-managing-section-variables-with-omit` anchor (GitHub-flavored markdown should derive this from the heading text `### Pattern 7: Managing Section Variables with \`omit\``).