### PR TITLE
lint(docs): Check 8c — Python helpers must use ${LEAN4_PYTHON_BIN:-python3}

### DIFF
--- a/.github/workflows/bash3-compat.yml
+++ b/.github/workflows/bash3-compat.yml
@@ -23,5 +23,8 @@ jobs:
       - name: Self-test — lint catches all advertised policy violations
         run: /bin/bash plugins/lean4/tests/test_lint_runtime_portability.sh
 
+      - name: Self-test — lint_docs Check 8c (Python interpreter prefix, #135)
+        run: /bin/bash plugins/lean4/tests/test_lint_docs.sh
+
       - name: Runtime smoke — cycle_tracker.sh under /bin/bash
         run: /bin/bash plugins/lean4/tests/test_bash3_smoke.sh

--- a/plugins/lean4/skills/lean4/references/compiler-guided-repair.md
+++ b/plugins/lean4/skills/lean4/references/compiler-guided-repair.md
@@ -126,14 +126,14 @@ theorem foo (f g : α → ℝ) (hf : MemLp f (ENNReal.ofReal 2) μ) (h : f =ᵐ[
 ### 1. Compile → Extract Error
 ```bash
 lake env lean FILE.lean 2> errors.txt   # run from project root
-python3 $LEAN4_SCRIPTS/parse_lean_errors.py errors.txt > context.json
+${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/parse_lean_errors.py" errors.txt > context.json
 ```
 
 Extracts: error type, location, goal state, local context, code snippet
 
 ### 2. Try Solver Cascade (many simple cases, free!)
 ```bash
-python3 $LEAN4_SCRIPTS/solver_cascade.py context.json FILE.lean
+${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/solver_cascade.py" context.json FILE.lean
 ```
 
 Tries in order: `rfl → simp → ring → linarith → nlinarith → omega → exact? → apply? → grind → aesop`
@@ -520,12 +520,12 @@ Success improves over time as structured logging enables learning from repair at
 
 **Error parsing:**
 ```bash
-python3 $LEAN4_SCRIPTS/parse_lean_errors.py errors.txt
+${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/parse_lean_errors.py" errors.txt
 ```
 
 **Solver cascade:**
 ```bash
-python3 $LEAN4_SCRIPTS/solver_cascade.py context.json FILE.lean
+${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/solver_cascade.py" context.json FILE.lean
 ```
 
 **Via prove/autoprove:**

--- a/plugins/lean4/tests/test_lint_docs.sh
+++ b/plugins/lean4/tests/test_lint_docs.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Self-test for lint_docs.sh Check 8c (Python helper interpreter prefix,
+# closes #135). Verifies the check fires on a planted violation and
+# emits its clean-run OK line once the violation is removed.
+#
+# Pattern: plant a scratch .md file inside the real plugin tree, run
+# lint_docs.sh once with the fixture present (assert WARN fires for
+# the fixture), explicitly remove the fixture, run again (assert OK
+# line present, WARN absent). A trap on EXIT stays installed as a
+# backup cleanup.
+#
+# Unlike test_lint_runtime_portability.sh (which copies the lint into
+# a synthetic isolated tree), lint_docs.sh runs many checks that
+# require a fully-populated plugin tree (commands/, agents/, SKILL.md,
+# etc.). Building a minimal substitute is high-overhead; we use the
+# real tree and assert on output content. Critically the test does
+# NOT depend on lint_docs.sh exiting 0 — the linter may already exit
+# nonzero from inherited warnings on main (line-length flags, etc.)
+# unrelated to this check.
+#
+# Helpers invoke lint_docs.sh under $BASH_FOR_COMPAT (default /bin/bash)
+# so the self-test runs under macOS Bash 3.2 in CI. On hosts without
+# /bin/bash (e.g. NixOS) the test SKIPs gracefully.
+
+BASH_FOR_COMPAT="${BASH_FOR_COMPAT:-/bin/bash}"
+if [[ ! -x "$BASH_FOR_COMPAT" ]]; then
+  echo "SKIP: $BASH_FOR_COMPAT not found — cannot run lint self-test"
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LINT="$PLUGIN_ROOT/tools/lint_docs.sh"
+
+if [[ ! -x "$LINT" ]]; then
+  echo "FAIL: lint_docs.sh not found at $LINT"
+  exit 1
+fi
+
+# Unique fixture so the assertion regex can pinpoint it amid other warnings.
+FIXTURE_NAME="__lint_docs_test_fixture"
+SCRATCH="$PLUGIN_ROOT/skills/lean4/references/${FIXTURE_NAME}.md"
+
+# Backup cleanup in case the test aborts mid-stream.
+trap 'rm -f "$SCRATCH"' EXIT
+
+PASS=0
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# Probe 1 — fixture present: Check 8c MUST fire for the planted line.
+# ---------------------------------------------------------------------------
+cat > "$SCRATCH" <<EOF
+# Test fixture for lint_docs.sh Check 8c (#135 self-test)
+
+\`\`\`bash
+python3 "\$LEAN4_SCRIPTS/${FIXTURE_NAME}.py" --foo
+\`\`\`
+EOF
+
+# || true — lint_docs.sh may legitimately exit nonzero from inherited
+# warnings unrelated to Check 8c. We assert on output content, not exit.
+output1=$("$BASH_FOR_COMPAT" "$LINT" 2>&1 || true)
+
+if echo "$output1" | grep -qE "${FIXTURE_NAME}\.md:.*Python helper uses bare python3"; then
+  echo "  PASS: Probe 1 — Check 8c fires on planted fixture"
+  ((PASS++)) || true
+else
+  echo "  FAIL: Probe 1 — Check 8c did not flag the planted fixture"
+  echo "         expected: '${FIXTURE_NAME}.md:<line>: Python helper uses bare python3 — ...'"
+  echo "         relevant output:"
+  echo "$output1" | grep -E "(${FIXTURE_NAME}|Python helper interpreter)" | sed 's/^/           /' || true
+  ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
+# Explicit cleanup before Probe 2. Traps fire on EXIT only — not between
+# probes — so the fixture removal here must be explicit. The trap stays
+# installed as a safety net for the post-Probe-2 path.
+# ---------------------------------------------------------------------------
+rm -f "$SCRATCH"
+
+# ---------------------------------------------------------------------------
+# Probe 2 — fixture absent: Check 8c emits its OK line and no WARN.
+# Both conditions together prove Check 8c ran cleanly without depending
+# on lint_docs.sh's overall exit code.
+# ---------------------------------------------------------------------------
+output2=$("$BASH_FOR_COMPAT" "$LINT" 2>&1 || true)
+
+ok_line='✓ Python helper interpreter prefixes checked'
+warn_preamble='Python helper uses bare python3'
+
+probe2_ok=1
+if ! echo "$output2" | grep -qF "$ok_line"; then
+  echo "  FAIL: Probe 2 — expected OK line not found"
+  echo "         expected: '$ok_line'"
+  probe2_ok=0
+fi
+if echo "$output2" | grep -qF "$warn_preamble"; then
+  echo "  FAIL: Probe 2 — warning preamble unexpectedly present after fixture removal"
+  echo "         offending lines:"
+  echo "$output2" | grep -F "$warn_preamble" | sed 's/^/           /' || true
+  probe2_ok=0
+fi
+if [[ $probe2_ok -eq 1 ]]; then
+  echo "  PASS: Probe 2 — Check 8c clean on post-cleanup tree (OK line present, no WARN)"
+  ((PASS++)) || true
+else
+  ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== test_lint_docs.sh: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/plugins/lean4/tools/lint_docs.sh
+++ b/plugins/lean4/tools/lint_docs.sh
@@ -543,6 +543,52 @@ check_script_stderr_suppression() {
     ok "Lean script stderr suppression check done"
 }
 
+# Check 8c: Python helper invocations must use ${LEAN4_PYTHON_BIN:-python3}
+# rather than bare `python3`. The bootstrap hook persists LEAN4_PYTHON_BIN
+# (used by /lean4:disprove which requires Python 3.11+ for tomllib), so
+# docs that bypass it route the model around the operator's Python pin.
+# Closes issue #135.
+#
+# Regex anchors `python3` to a leading boundary (start of line, whitespace,
+# or a few shell metacharacters) so the `python3` inside parameter
+# expansion `${LEAN4_PYTHON_BIN:-python3}` does NOT match — its preceding
+# char is `-`, not in the boundary class.
+#
+# Skip rules (parallel to check_bare_scripts):
+#   - MIGRATION.md (historical doc)
+#   - lib/scripts/, tools/ (internals)
+#   - lines tagged with explicit anti-pattern markers so docs can still
+#     demonstrate the wrong form deliberately
+check_python_script_interpreters() {
+    log ""
+    log "Checking Python helper interpreter prefixes..."
+
+    local _pi_base _pi_line _pi_match _pi_trimmed _pi_found
+    _pi_found=0
+
+    while IFS= read -r file; do
+        _pi_base=$(basename "$file")
+        [[ "$_pi_base" == "MIGRATION.md" ]] && continue
+        case "$file" in
+            */lib/scripts/*|*/tools/*) continue ;;
+        esac
+
+        while IFS=: read -r _pi_line _pi_match; do
+            [[ -z "$_pi_line" ]] && continue
+            # Anti-pattern allow-list so deliberate bad examples don't trip.
+            if echo "$_pi_match" | grep -qiE '(Never|Do not|Wrong|Incorrect|anti.?pattern|forbidden|avoid)'; then
+                continue
+            fi
+            _pi_trimmed=$(echo "$_pi_match" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            warn "$_pi_base:$_pi_line: Python helper uses bare python3 — use \${LEAN4_PYTHON_BIN:-python3} prefix"
+            log "    matched: $_pi_trimmed"
+            _pi_found=1
+        done < <(grep -nE '(^|[[:space:]`;&|()])python3[[:space:]]+"?\$\{?LEAN4_SCRIPTS\}?/[A-Za-z0-9._/-]+\.py' "$file" 2>/dev/null || true)
+    done < <(find "$PLUGIN_ROOT" -name "*.md" -type f)
+
+    [[ $_pi_found -eq 0 ]] && ok "Python helper interpreter prefixes checked"
+}
+
 # Check 9: Deep-safety invariants in prove/autoprove/cycle-engine
 check_deep_safety() {
     log ""
@@ -1678,6 +1724,7 @@ check_stale_commands
 check_bare_scripts
 check_skill_omit_rule
 check_script_stderr_suppression
+check_python_script_interpreters
 check_deep_safety
 check_guardrail_docs
 check_guardrail_impl


### PR DESCRIPTION
## Summary

Closes #135. Adds `lint_docs.sh` Check 8c flagging docs that invoke Python helpers with bare `python3 "$LEAN4_SCRIPTS/<script>.py"` instead of the canonical `${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/<script>.py"`. The bootstrap hook persists `LEAN4_PYTHON_BIN` (used by `/lean4:disprove` which requires Python 3.11+ for `tomllib`), so docs that bypass it route the model around the operator's Python pin.

Off `feat/python-bin-lint` from `origin/main` (`ef04763`). Three focused commits, no version bump.

## Commits

1. **`lint(docs)`** (`7023ea0`) — new `check_python_script_interpreters` in `lint_docs.sh`, slotted as Check 8c (after the existing Check 8b stderr-suppression check, keeping 8 → 8a → 8b → 8c ordered). Regex anchors `python3` to a leading boundary so `${...:-python3}` inside parameter expansion correctly does NOT match. Skip rules mirror `check_bare_scripts` (MIGRATION.md, `lib/scripts/`, `tools/`, anti-pattern markers). Warning embeds the actual matched line under each `warn` for CI-diagnosability without rerunning.

2. **`docs(compiler-guided-repair)`** (`e258d17`) — fixes the 4 violations Check 8c flags on main today (`parse_lean_errors.py`/`solver_cascade.py` at lines 129, 136, 523, 528). Rewrites to `${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/<script>.py" ...` form with the path quoted. These are intentionally unwrapped internal scripts (not in #130's curated wrapper set), so wrapper form isn't an option here — env-var form with the bin override is the canonical invocation.

3. **`test(lint-docs)`** (`2ead975`) — new `plugins/lean4/tests/test_lint_docs.sh` self-test. Plants a uniquely-named scratch `.md` in the real plugin tree, runs `lint_docs.sh`, asserts the Check 8c warning matches the fixture path. Then explicit-rms the fixture (traps fire on EXIT only — not between probes), reruns, asserts the OK line is present AND the warning preamble is absent. Both probe runs use `|| true` so the test does NOT depend on `lint_docs.sh` exiting 0 (the linter may already exit nonzero from inherited warnings on main unrelated to Check 8c). Wired into `.github/workflows/bash3-compat.yml` as a new step under macOS `/bin/bash` 3.2. This is the first `lint_docs.sh` check to run in CI; the rest stays local/doctor-only, matching the #136 precedent.

## Test plan

- [x] **Negative sanity test (pre-fix):** before commit 2, `bash plugins/lean4/tools/lint_docs.sh` correctly flags all 4 `compiler-guided-repair.md` violations with diagnostic `matched: <full line>` context.
- [x] **Post-fix lint pass:** Check 8c emits `✓ Python helper interpreter prefixes checked`; no `python3 $LEAN4_SCRIPTS/...` warnings remain. (Other inherited warnings unrelated to this check are preexisting and out of scope; the verification target is the new check's output line, not full-suite green.)
- [x] **Self-test green:** `bash plugins/lean4/tests/test_lint_docs.sh` — 2 passed, 0 failed (Probe 1: plant fires Check 8c; Probe 2: post-cleanup tree returns to clean).
- [x] **No regression:** `bash plugins/lean4/tests/test_lint_runtime_portability.sh` unchanged, still passes.
- [ ] **CI:** macos-bash3 (now runs `test_lint_docs.sh` step) + mypy + ruff + shellcheck stay green.

## Out of scope

- "Shebang invocation" stretch check (distinguishing inline path references like `` `$LEAN4_SCRIPTS/foo.py` `` from actual invocations). Noisier; the issue's acceptance criteria are satisfied by the high-signal `python3 "$LEAN4_SCRIPTS/*.py"` check alone.
- Wiring the full `lint_docs.sh` into CI — only Check 8c is exercised via the self-test; the rest stays local/doctor-only.
- No version bump (per request).