### PR TITLE
docs(style): mathlib lambda + show conventions checklist + reference sweep

### DIFF
--- a/plugins/lean4/skills/lean4/SKILL.md
+++ b/plugins/lean4/skills/lean4/SKILL.md
@@ -17,6 +17,8 @@ Use this skill whenever you're editing Lean 4 proofs, debugging Lean builds, for
 
 **Use 100-character line width for Lean files.** Do not wrap lines at 80 characters — Lean and mathlib convention is 100. If a line fits within 100 characters, keep it on one line. See [mathlib-style](references/mathlib-style.md) for breaking strategies when lines exceed 100.
 
+**Mathlib style quick check.** For ordinary mathematical lambdas, write `fun x ↦ ...` (`\mapsto`), not `fun x => ...`. Use `=>` for `match`/`do` branches and metaprogramming callback idioms. Prefer `show P by tac` for tactic proofs; use `show P from term` only for term proofs. See [mathlib-style](references/mathlib-style.md).
+
 **Never change statements or add axioms without explicit permission.** Theorem/lemma statements, type signatures, and docstrings are off-limits unless the user requests changes. Inline comments may be adjusted; docstrings may not (they're part of the API). Custom axioms require explicit approval—if a proof seems to need one, stop and discuss. Exception: within synthesis wrappers (`/lean4:formalize`, `/lean4:autoformalize`), session-generated declarations may be redrafted under the outer-loop statement-safety rules; see cycle-engine.md.
 
 ## Commands

--- a/plugins/lean4/skills/lean4/references/compilation-errors.md
+++ b/plugins/lean4/skills/lean4/references/compilation-errors.md
@@ -419,14 +419,14 @@ but is expected to have type
 have h_sp_le : ∀ n a, (sp n a) ≤ φp a := by
   intro n a
   have := SimpleFunc.iSup_eapprox_apply
-    (fun a => ENNReal.ofReal (max (φ a) 0))  -- 'a' shadows!
+    (fun a ↦ ENNReal.ofReal (max (φ a) 0))  -- 'a' shadows!
     ... a  -- ERROR: which 'a'?
 
 -- ✅ CORRECT: Rename lambda variable or add type annotation
 have h_sp_le : ∀ n a, (sp n a) ≤ φp a := by
   intro n a
   have := SimpleFunc.iSup_eapprox_apply
-    (fun (x : α) => ENNReal.ofReal (max (φ x) 0))
+    (fun (x : α) ↦ ENNReal.ofReal (max (φ x) 0))
     ... a  -- ✓ Clear: outer 'a'
 ```
 
@@ -537,7 +537,7 @@ have := h1.atTop_add 1
 
 ```lean
 -- ✅ CORRECT: Pass a proof term
-have := h1.atTop_add (tendsto_const_nhds : Tendsto (fun _ => (1 : ℝ)) atTop (nhds 1))
+have := h1.atTop_add (tendsto_const_nhds : Tendsto (fun _ ↦ (1 : ℝ)) atTop (nhds 1))
 ```
 
 **Pattern:** Functions like `atTop_add` work on limits and need proof terms:
@@ -547,7 +547,7 @@ have := h1.atTop_add (tendsto_const_nhds : Tendsto (fun _ => (1 : ℝ)) atTop (n
 **Common fixes:**
 ```lean
 -- For constant functions
-tendsto_const_nhds : Tendsto (fun _ => c) filter (nhds c)
+tendsto_const_nhds : Tendsto (fun _ ↦ c) filter (nhds c)
 
 -- For simple expressions
 use lemmas like Filter.tendsto_id, Filter.tendsto_const_pure
@@ -605,25 +605,25 @@ tactic 'simp' failed
 
 **Example failure:**
 ```lean
-have h := integral_condExp (f := fun ω => μ[g|m] ω * ξ ω)
+have h := integral_condExp (f := fun ω ↦ μ[g|m] ω * ξ ω)
 -- h : ∫ (x : Ω), F x ∂μ = ∫ (x : Ω), μ[F|m] x ∂μ
 -- Goal: ∫ (ω : Ω), μ[g|m] ω * ξ ω ∂μ = ...
 
 simpa using h.symm  -- Error: binder x ≠ binder ω
 ```
 
-**Why it fails:** Lean doesn't automatically recognize that `fun x => F x` and `fun ω => F ω` are the same when comparing goal to hypothesis.
+**Why it fails:** Lean doesn't automatically recognize that `fun x ↦ F x` and `fun ω ↦ F ω` are the same when comparing goal to hypothesis.
 
 **Solution: Use `set ... with` pattern to name expression once**
 
 ```lean
 -- Name the integrand once and for all
-set F : Ω → ℝ := fun ω => μ[g | m] ω * ξ ω with hF
+set F : Ω → ℝ := fun ω ↦ μ[g | m] ω * ξ ω with hF
 
 -- Apply lemma to named function F
 have h_goal :
     ∫ (ω : Ω), μ[g | m] ω * ξ ω ∂μ
-  = ∫ (ω : Ω), μ[(fun ω => μ[g | m] ω * ξ ω) | m] ω ∂μ := by
+  = ∫ (ω : Ω), μ[(fun ω ↦ μ[g | m] ω * ξ ω) | m] ω ∂μ := by
   simpa [hF] using
     (MeasureTheory.integral_condExp (μ := μ) (m := m) (hm := hm) (f := F)).symm
 

--- a/plugins/lean4/skills/lean4/references/disprove-engine.md
+++ b/plugins/lean4/skills/lean4/references/disprove-engine.md
@@ -777,8 +777,8 @@ Pick whichever conjunct yields the smaller search; obtain `h : ¬ P` (or
 match:
 
 ```lean
-theorem T_counterexample (h : ¬ P) : ¬ (P ∧ Q) := fun ⟨hp, _⟩ => h hp
--- mirror with `fun ⟨_, hq⟩ => h hq` when disproving Q
+theorem T_counterexample (h : ¬ P) : ¬ (P ∧ Q) := fun ⟨hp, _⟩ ↦ h hp
+-- mirror with `fun ⟨_, hq⟩ ↦ h hq` when disproving Q
 ```
 
 **Shape 5 — `P ∨ Q` (disprove both disjuncts):**
@@ -788,7 +788,7 @@ Shape 1/2/7 recipes, then combine:
 
 ```lean
 theorem T_counterexample (hp : ¬ P) (hq : ¬ Q) : ¬ (P ∨ Q) :=
-  fun h => h.elim hp hq
+  fun h ↦ h.elim hp hq
 ```
 
 **Shape 6 — `a = b` or `a ≤ b` / arithmetic ineq:**

--- a/plugins/lean4/skills/lean4/references/domain-patterns.md
+++ b/plugins/lean4/skills/lean4/references/domain-patterns.md
@@ -184,11 +184,11 @@ def IsMartingale (X : ℕ → Ω → ℝ) (f : ℕ → MeasurableSpace Ω) : Pro
 ```lean
 -- Infinite product via Ionescu-Tulcea
 noncomputable def productMeasure (ν : Measure α) : Measure (ℕ → α) :=
-  Measure.pi (fun _ => ν)
+  Measure.pi (fun _ ↦ ν)
 
 lemma independent_of_product :
     ∀ n m, n ≠ m →
-    IndepFun (fun ω => ω n) (fun ω => ω m) (productMeasure ν) := by
+    IndepFun (fun ω ↦ ω n) (fun ω ↦ ω m) (productMeasure ν) := by
   sorry
 ```
 
@@ -220,13 +220,13 @@ end IntegrationHelpers
 ```lean
 -- ❌ Manual: verbose
 lemma measurable_projection {n : ℕ} :
-    Measurable (fun (x : ℕ → α) => fun (i : Fin n) => x i.val) := by
-  refine measurable_pi_lambda _ (fun i => ?_)
+    Measurable (fun (x : ℕ → α) ↦ fun (i : Fin n) ↦ x i.val) := by
+  refine measurable_pi_lambda _ (fun i ↦ ?_)
   exact measurable_pi_apply i.val
 
 -- ✅ Automated: clean
 lemma measurable_projection {n : ℕ} :
-    Measurable (fun (x : ℕ → α) => fun (i : Fin n) => x i.val) := by
+    Measurable (fun (x : ℕ → α) ↦ fun (i : Fin n) ↦ x i.val) := by
   measurability
 ```
 
@@ -242,7 +242,7 @@ lemma measurable_shiftSeq {d : ℕ} : Measurable (shiftSeq (β:=β) d) := by
 
 ```lean
 -- Use fun_prop with measurability discharger
-have h : Measurable (fun ω => fun i => X (k i) ω) := by
+have h : Measurable (fun ω ↦ fun i ↦ X (k i) ω) := by
   fun_prop (disch := measurability)
 ```
 
@@ -286,7 +286,7 @@ theorem deFinetti (μ : Measure Ω) (X : ℕ → Ω → α) : ...
 
 -- ✅ Used in body, not types
 def shiftedCylinder (n : ℕ) (F : Ω[α] → ℝ) : Ω[α] → ℝ :=
-  fun ω => F ((shift^[n]) ω)
+  fun ω ↦ F ((shift^[n]) ω)
 
 -- ✅ In return type
 lemma foo (n : ℕ) : Fin n → α := ...
@@ -300,13 +300,13 @@ When using `Measurable.const_mul` with sums, structure must match goal's parenth
 
 ```lean
 -- ❌ WRONG: constant inside each term
-have h : Measurable (fun ω => (1/(m:ℝ)) * ∑ k, f k ω) :=
-  Finset.measurable_sum _ (fun k _ => Measurable.const_mul ...)
+have h : Measurable (fun ω ↦ (1/(m:ℝ)) * ∑ k, f k ω) :=
+  Finset.measurable_sum _ (fun k _ ↦ Measurable.const_mul ...)
 -- Applies const_mul to EACH TERM - wrong variable binding!
 
 -- ✅ CORRECT: constant wraps entire sum
-have h : Measurable (fun ω => (1/(m:ℝ)) * ∑ k, f k ω) :=
-  Measurable.const_mul (Finset.measurable_sum _ (fun k _ => ...)) _
+have h : Measurable (fun ω ↦ (1/(m:ℝ)) * ∑ k, f k ω) :=
+  Measurable.const_mul (Finset.measurable_sum _ (fun k _ ↦ ...)) _
 -- const_mul wraps whole sum, matching goal structure
 ```
 
@@ -318,13 +318,13 @@ Bound expression in measurability hypothesis must match canonical form after `si
 
 ```lean
 -- ❌ WRONG: Definition uses 1/(m:ℝ) but goal has (m:ℝ)⁻¹ after simp
-have h_meas : Measurable (fun ω => 1/(m:ℝ) * ∑ i, f i ω) := ...
+have h_meas : Measurable (fun ω ↦ 1/(m:ℝ) * ∑ i, f i ω) := ...
 apply Integrable.of_bound h_meas.aestronglyMeasurable 1
 filter_upwards with ω; simp [Real.norm_eq_abs]
 -- Type mismatch: goal has (m:ℝ)⁻¹ but h_meas has 1/(m:ℝ)
 
 -- ✅ CORRECT: Use canonical form (m:ℝ)⁻¹ from start
-have h_meas : Measurable (fun ω => (m:ℝ)⁻¹ * ∑ i, f i ω) := ...
+have h_meas : Measurable (fun ω ↦ (m:ℝ)⁻¹ * ∑ i, f i ω) := ...
 apply Integrable.of_bound h_meas.aestronglyMeasurable 1
 filter_upwards with ω; simp [Real.norm_eq_abs]
 -- Matches exactly after simp!
@@ -380,7 +380,7 @@ lemma continuous_of_isOpen_preimage
 
 -- Using automation
 lemma continuous_comp_add :
-    Continuous (fun (p : ℝ × ℝ) => p.1 + p.2) := by
+    Continuous (fun (p : ℝ × ℝ) ↦ p.1 + p.2) := by
   continuity
 ```
 
@@ -623,9 +623,9 @@ instance : Ring MyType := {
 lemma quotient_ring_hom (I : Ideal R) : RingHom R (R ⧸ I) := by
   refine { toFun := Ideal.Quotient.mk I,
            map_one' := rfl,
-           map_mul' := fun x y => rfl,
+           map_mul' := fun x y ↦ rfl,
            map_zero' := rfl,
-           map_add' := fun x y => rfl }
+           map_add' := fun x y ↦ rfl }
 ```
 
 ### Pattern 3: Universal Properties

--- a/plugins/lean4/skills/lean4/references/mathlib-style.md
+++ b/plugins/lean4/skills/lean4/references/mathlib-style.md
@@ -221,10 +221,18 @@ theorem bar {μ : Measure Ω} (X : ℕ → Ω → α) : Statement
 
 -- ✅ GOOD: n used in body
 def baz (n : ℕ) (F : Ω[α] → ℝ) : Ω[α] → ℝ :=
-  fun ω => F ((shift^[n]) ω)
+  fun ω ↦ F ((shift^[n]) ω)
 ```
 
 See [domain-patterns.md](domain-patterns.md) for detailed implicit parameter conversion patterns.
+
+### 9. Style Conventions Generators Often Miss
+
+- **Lambdas:** use `fun x ↦ ...` (`\mapsto`), not `fun x => ...`.
+  Use `=>` for `match`/`do` branches and metaprogramming callback idioms.
+- **Short lambdas:** consider placeholder notation (`·`) when it is clearer.
+- **`show`:** prefer `show P by tac` for tactic proofs. Use
+  `show P from term` only when giving a proof term; avoid `show P from by tac`.
 
 ## Documentation Content Guidelines
 

--- a/plugins/lean4/skills/lean4/references/mathlib-style.md
+++ b/plugins/lean4/skills/lean4/references/mathlib-style.md
@@ -232,7 +232,11 @@ See [domain-patterns.md](domain-patterns.md) for detailed implicit parameter con
   Use `=>` for `match`/`do` branches and metaprogramming callback idioms.
 - **Short lambdas:** consider placeholder notation (`·`) when it is clearer.
 - **`show`:** prefer `show P by tac` for tactic proofs. Use
-  `show P from term` only when giving a proof term; avoid `show P from by tac`.
+  `show P from term` only when giving a proof term — `from` in front
+  of a tactic block is redundant. Examples:
+  - ❌ `show P from by simp`     — anti-pattern; `from` is redundant
+  - ✅ `show P by simp`           — tactic proof
+  - ✅ `show P from h.symm`       — term proof (`from` introduces the term)
 
 ## Documentation Content Guidelines
 

--- a/plugins/lean4/skills/lean4/references/measure-theory.md
+++ b/plugins/lean4/skills/lean4/references/measure-theory.md
@@ -77,7 +77,7 @@ let mW : MeasurableSpace Ω := MeasurableSpace.comap W m0
    - Easy: `set_integral_condexp` gives `∫_{s} μ[g|m] = ∫_{s} g` for s ∈ m
 
 4. **❌ Don't force product measurability**
-   - Fragile: `AEStronglyMeasurable (fun ω => f ω * g ω)`
+   - Fragile: `AEStronglyMeasurable (fun ω ↦ f ω * g ω)`
    - Robust: Rewrite to `indicator` and use `Integrable.indicator`
 
 5. **❌ Don't use `set` with `MeasurableSpace.comap ... inferInstance`**
@@ -244,7 +244,7 @@ theorem my_theorem ... := by
 
   -- ✅ STEP 2: NOW define sub-σ-algebras
   let mW  : MeasurableSpace Ω := MeasurableSpace.comap W m0
-  let mZW : MeasurableSpace Ω := MeasurableSpace.comap (fun ω => (Z ω, W ω)) m0
+  let mZW : MeasurableSpace Ω := MeasurableSpace.comap (fun ω ↦ (Z ω, W ω)) m0
 
   -- ✅ STEP 3: Work with sub-σ-algebras
   have hmW_le : mW ≤ m0 := hW.comap_le
@@ -316,7 +316,7 @@ have hmζ_le : MeasurableSpace.comap ζ mγ ≤ mΩ := by
 
 -- Use inlined comaps in all lemma applications
 have hCEη : μ[f | MeasurableSpace.comap η mγ] =ᵐ[μ]
-            (fun ω => ∫ y, f y ∂(condExpKernel μ (MeasurableSpace.comap η mγ) ω)) :=
+            (fun ω ↦ ∫ y, f y ∂(condExpKernel μ (MeasurableSpace.comap η mγ) ω)) :=
   condExp_ae_eq_integral_condExpKernel hmη_le hint
 ```
 
@@ -361,13 +361,13 @@ lemma setIntegral_condExp_eq (μ : Measure Ω) (m : MeasurableSpace Ω) (hm : m 
 
 ```lean
 -- Rewrite product to indicator
-have hMulAsInd : (fun ω => μ[f|mW] ω * gB ω) = (Z ⁻¹' B).indicator (μ[f|mW]) := by
+have hMulAsInd : (fun ω ↦ μ[f|mW] ω * gB ω) = (Z ⁻¹' B).indicator (μ[f|mW]) := by
   funext ω; by_cases hω : ω ∈ Z ⁻¹' B
   · simp [gB, hω, Set.indicator_of_mem, mul_one]
   · simp [gB, hω, Set.indicator_of_notMem, mul_zero]
 
 -- Integrability without product measurability
-have : Integrable (fun ω => μ[f|mW] ω * gB ω) μ := by
+have : Integrable (fun ω ↦ μ[f|mW] ω * gB ω) μ := by
   simpa [hMulAsInd] using (integrable_condexp).indicator (hB.preimage hZ)
 ```
 
@@ -381,7 +381,7 @@ have : Integrable (fun ω => μ[f|mW] ω * gB ω) μ := by
 -- From |f| ≤ R to ‖μ[f|m]‖ ≤ R a.e.
 have hbdd_f : ∀ᵐ ω ∂μ, |f ω| ≤ (1 : ℝ) := …
 have hbdd_f' : ∀ᵐ ω ∂μ, |f ω| ≤ ((1 : ℝ≥0) : ℝ) :=
-  hbdd_f.mono (fun ω h => by simpa [NNReal.coe_one] using h)
+  hbdd_f.mono (fun ω h ↦ by simpa [NNReal.coe_one] using h)
 have : ∀ᵐ ω ∂μ, ‖μ[f|m] ω‖ ≤ (1 : ℝ) := by
   simpa [Real.norm_eq_abs, NNReal.coe_one] using
     ae_bdd_condExp_of_ae_bdd (μ := μ) (m := m) (R := (1 : ℝ≥0)) (f := f) hbdd_f'
@@ -415,7 +415,7 @@ have hsm_ceAmb : StronglyMeasurable (μ[f|mW]) := hsm_ce.mono hmW_le
 -- Restricted:  ∫_{S} (Z⁻¹ B).indicator h = ∫_{S ∩ Z⁻¹ B} h
 
 -- Rewrite pattern (avoids fragile lemma names):
-have : (fun ω => h ω * indicator (Z⁻¹' B) 1 ω) = indicator (Z⁻¹' B) h := by
+have : (fun ω ↦ h ω * indicator (Z⁻¹' B) 1 ω) = indicator (Z⁻¹' B) h := by
   funext ω; by_cases hω : ω ∈ Z⁻¹' B
   · simp [hω, Set.indicator_of_mem, mul_one]
   · simp [hω, Set.indicator_of_notMem, mul_zero]
@@ -441,7 +441,7 @@ have h : μ[ψ | m] = ... -- Error: Instance synthesis confused!
 
 ```lean
 -- Explicit: condExpKernel takes μ and m as parameters
-μ[ψ | m] =ᵐ[μ] (fun ω => ∫ y, ψ y ∂(condExpKernel μ m ω))
+μ[ψ | m] =ᵐ[μ] (fun ω ↦ ∫ y, ψ y ∂(condExpKernel μ m ω))
 ```
 
 **Why kernel form is better for complex cases:**
@@ -457,7 +457,7 @@ have h : μ[ψ | m] = ... -- Error: Instance synthesis confused!
 ```lean
 -- ❌ DON'T: Reinvent condExpKernel
 axiom directingMeasure : Ω → Measure α
-axiom directingMeasure_measurable_eval : ∀ s, Measurable (fun ω => directingMeasure ω s)
+axiom directingMeasure_measurable_eval : ∀ s, Measurable (fun ω ↦ directingMeasure ω s)
 axiom directingMeasure_isProb : ∀ ω, IsProbabilityMeasure (directingMeasure ω)
 axiom directingMeasure_marginal : ...
 ```
@@ -490,7 +490,7 @@ have h : ∫ ω in s, φ ω * μ[ψ | m] ω ∂μ = ∫ ω in s, φ ω * V ω �
 **After (kernel, explicit):**
 ```lean
 -- Step 1: Convert scalar to kernel form
-have hCE : μ[ψ | m] =ᵐ[μ] (fun ω => ∫ y, ψ y ∂(condExpKernel μ m ω))
+have hCE : μ[ψ | m] =ᵐ[μ] (fun ω ↦ ∫ y, ψ y ∂(condExpKernel μ m ω))
 
 -- Step 2: Work with kernel form
 have h : ∫ ω in s, φ ω * (∫ y, ψ y ∂(condExpKernel μ m ω)) ∂μ = ...
@@ -517,10 +517,10 @@ have h : ∫ ω in s, φ ω * (∫ y, ψ y ∂(condExpKernel μ m ω)) ∂μ = .
 
 ```lean
 -- Conversion between forms
-condExp_ae_eq_integral_condExpKernel : μ[f | m] =ᵐ[μ] (fun ω => ∫ y, f y ∂(condExpKernel μ m ω))
+condExp_ae_eq_integral_condExpKernel : μ[f | m] =ᵐ[μ] (fun ω ↦ ∫ y, f y ∂(condExpKernel μ m ω))
 
 -- Kernel measurability
-Measurable.eval_condExpKernel : Measurable (fun ω => condExpKernel μ m ω s)
+Measurable.eval_condExpKernel : Measurable (fun ω ↦ condExpKernel μ m ω s)
 
 -- Markov kernel property
 IsMarkovKernel.condExpKernel : IsMarkovKernel (condExpKernel μ m)
@@ -555,7 +555,7 @@ condExpKernel μ (tailSigma X) : @Kernel Ω Ω (tailSigma X) inst
 Kernel.map (condExpKernel μ m) f  -- Type error!
 
 -- ✅ RIGHT: Evaluate kernel first, then map the resulting measure
-fun ω => (condExpKernel μ m ω).map f
+fun ω ↦ (condExpKernel μ m ω).map f
 ```
 
 **Lesson:** When your kernel changes measurable spaces (like `condExpKernel`), you can't use `Kernel.map`. Instead, evaluate the kernel at a point to get a `Measure`, then use `Measure.map`.
@@ -585,7 +585,7 @@ isProbabilityMeasure_map : IsProbabilityMeasure μ → AEMeasurable f μ →
 -- Want: Pushforward each μ_ω along f
 
 -- Correct approach
-fun ω => (μ_ω ω).map f
+fun ω ↦ (μ_ω ω).map f
 
 -- Search with lean_leanfinder:
 -- "Measure.map pushforward measurable function"
@@ -594,14 +594,14 @@ fun ω => (μ_ω ω).map f
 
 ### 3. Kernel Measurability Proofs
 
-**Pattern:** Proving `Measurable (fun ω => κ ω s)` where `κ : Kernel α β`.
+**Pattern:** Proving `Measurable (fun ω ↦ κ ω s)` where `κ : Kernel α β`.
 
 ```lean
 -- Step 1: Recognize this is kernel evaluation at a set
-have : (fun ω => κ ω s) = fun ω => Kernel.eval κ s ω
+have : (fun ω ↦ κ ω s) = fun ω ↦ Kernel.eval κ s ω
 
 -- Step 2: Use Kernel.measurable_coe
-have : Measurable (fun a => κ a s) := Kernel.measurable_coe κ hs
+have : Measurable (fun a ↦ κ a s) := Kernel.measurable_coe κ hs
   -- where hs : MeasurableSet s
 ```
 
@@ -611,7 +611,7 @@ have : Measurable (fun a => κ a s) := Kernel.measurable_coe κ hs
 
 **API lemmas:**
 ```lean
-Kernel.measurable_coe : MeasurableSet s → Measurable (fun a => κ a s)
+Kernel.measurable_coe : MeasurableSet s → Measurable (fun a ↦ κ a s)
 ```
 
 ### 4. condExpKernel API Gaps
@@ -654,7 +654,7 @@ lean_leanfinder(query="Markov kernel conditional expectation")
 -- Different forms (not all recognized by API)
 if x ∈ B then 1 else 0           -- if-then-else
 Set.indicator B 1                 -- Set.indicator
-Set.indicator B (fun _ => 1)      -- Function form
+Set.indicator B (fun _ ↦ 1)      -- Function form
 (B.indicator 1) ∘ f               -- Composed
 ```
 
@@ -663,7 +663,7 @@ Set.indicator B (fun _ => 1)      -- Function form
 **Pattern:**
 ```lean
 -- Normalize to canonical form first
-have : (fun x => if x ∈ B then 1 else 0) = B.indicator 1 := by
+have : (fun x ↦ if x ∈ B then 1 else 0) = B.indicator 1 := by
   funext x; by_cases hx : x ∈ B <;> simp [hx, Set.indicator]
 
 -- Now apply integration lemma

--- a/plugins/lean4/skills/lean4/references/performance-optimization.md
+++ b/plugins/lean4/skills/lean4/references/performance-optimization.md
@@ -75,7 +75,7 @@ When polymorphic goals like `eLpNorm` or `MemLp` contain complex function expres
 **Example that times out:**
 ```lean
 -- This hits 500k heartbeat limit during elaboration:
-have : eLpNorm (fun ω => blockAvg f X 0 n ω - blockAvg f X 0 n' ω) 2 μ < ⊤ := by
+have : eLpNorm (fun ω ↦ blockAvg f X 0 n ω - blockAvg f X 0 n' ω) 2 μ < ⊤ := by
   -- Lean unfolds blockAvg → (n:ℝ)⁻¹ * Finset.sum ...
   -- Then chases typeclass instances through every layer
   -- WHNF TIMEOUT!
@@ -84,7 +84,7 @@ have : eLpNorm (fun ω => blockAvg f X 0 n ω - blockAvg f X 0 n' ω) 2 μ < ⊤
 **Root cause:** The expansion of `blockAvg`:
 ```lean
 def blockAvg (f : α → ℝ) (X : ℕ → Ω → α) (m n : ℕ) (ω : Ω) : ℝ :=
-  (n : ℝ)⁻¹ * (Finset.range n).sum (fun k => f (X (m + k) ω))
+  (n : ℝ)⁻¹ * (Finset.range n).sum (fun k ↦ f (X (m + k) ω))
 ```
 
 becomes deeply nested when substituted into `eLpNorm`, triggering expensive typeclass synthesis.
@@ -98,7 +98,7 @@ becomes deeply nested when substituted into `eLpNorm`, triggering expensive type
     will *not* unfold during type-checking. -/
 @[irreducible]
 def blockAvgFrozen {Ω : Type*} (f : ℝ → ℝ) (X : ℕ → Ω → ℝ) (n : ℕ) : Ω → ℝ :=
-  fun ω => blockAvg f X 0 n ω
+  fun ω ↦ blockAvg f X 0 n ω
 ```
 
 **Key point:** `@[irreducible]` prevents definitional unfolding but allows `rw` for manual expansion.
@@ -128,7 +128,7 @@ lemma blockAvgFrozen_diff_memLp_two {Ω : Type*} [MeasurableSpace Ω] {μ : Meas
     (f : ℝ → ℝ) (X : ℕ → Ω → ℝ)
     (hf : Measurable f) (hX : ∀ i, Measurable (X i))
     (hf_bdd : ∀ x, |f x| ≤ 1) (n n' : ℕ) :
-    MemLp (fun ω => blockAvgFrozen f X n ω - blockAvgFrozen f X n' ω) (2 : ℝ≥0∞) μ := by
+    MemLp (fun ω ↦ blockAvgFrozen f X n ω - blockAvgFrozen f X n' ω) (2 : ℝ≥0∞) μ := by
   apply memLp_two_of_bounded (M := 2)
   · exact (blockAvgFrozen_measurable f X hf hX n).sub
       (blockAvgFrozen_measurable f X hf hX n')
@@ -150,8 +150,8 @@ have hblockAvg_memLp : ∀ n, n > 0 → MemLp (blockAvg f X 0 n) 2 μ := by
   intro n hn_pos
   apply memLp_two_of_bounded
   · -- Measurable: blockAvg is a finite sum of measurable functions
-    show Measurable (fun ω => (n : ℝ)⁻¹ * (Finset.range n).sum (fun k => f (X (0 + k) ω)))
-    exact Measurable.const_mul (Finset.measurable_sum _ fun k _ =>
+    show Measurable (fun ω ↦ (n : ℝ)⁻¹ * (Finset.range n).sum (fun k ↦ f (X (0 + k) ω)))
+    exact Measurable.const_mul (Finset.measurable_sum _ fun k _ ↦
       hf_meas.comp (hX_meas (0 + k))) _
   intro ω
   -- 20+ line calc proof
@@ -166,7 +166,7 @@ have hblockAvg_memLp : ∀ n, n > 0 → MemLp (blockAvg f X 0 n) 2 μ := by
   rw [h_eq]
   apply memLp_two_of_bounded (M := 1)
   · exact blockAvgFrozen_measurable f X hf_meas hX_meas n
-  exact fun ω => blockAvgFrozen_abs_le_one f X hf_bdd n ω
+  exact fun ω ↦ blockAvgFrozen_abs_le_one f X hf_bdd n ω
 ```
 
 ---
@@ -182,7 +182,7 @@ have hblockAvg_memLp : ∀ n, n > 0 → MemLp (blockAvg f X 0 n) 2 μ := by
 have : eLpNorm (blockAvg f X 0 n - blockAvg f X 0 n') 2 μ < ⊤
 
 -- ✅ GOOD: Explicit parameters (cheap)
-have : eLpNorm (fun ω => BA n ω - BA n' ω) (2 : ℝ≥0∞) (μ := μ) < ⊤
+have : eLpNorm (fun ω ↦ BA n ω - BA n' ω) (2 : ℝ≥0∞) (μ := μ) < ⊤
 ```
 
 **Why:** Explicit `(p := (2 : ℝ≥0∞))` and `(μ := μ)` prevent type class search through function body.
@@ -210,7 +210,7 @@ have : blockAvg f X 0 n = blockAvgFrozen f X n := by
 ```lean
 -- ❌ BAD: Recompute MemLp every time (expensive)
 intro n n'
-have : MemLp (fun ω => blockAvg f X 0 n ω - blockAvg f X 0 n' ω) 2 μ := by
+have : MemLp (fun ω ↦ blockAvg f X 0 n ω - blockAvg f X 0 n' ω) 2 μ := by
   apply memLp_two_of_bounded
   · -- 10 lines proving measurability
   intro ω
@@ -237,7 +237,7 @@ have hn  : eLpNorm (blockAvgFrozen f X n - blockAvgFrozen f X n') 2 μ < ⊤
 have hn' : MemLp (blockAvgFrozen f X n - blockAvgFrozen f X n') 2 μ
 
 -- ✅ GOOD: Bind once, reuse
-let diff := fun ω => blockAvgFrozen f X n ω - blockAvgFrozen f X n' ω
+let diff := fun ω ↦ blockAvgFrozen f X n ω - blockAvgFrozen f X n' ω
 have hn  : eLpNorm diff (2 : ℝ≥0∞) μ < ⊤
 have hn' : MemLp diff (2 : ℝ≥0∞) μ
 ```
@@ -501,12 +501,12 @@ If `@[irreducible]` still causes timeouts, consider:
 ```lean
 -- Instead of one complex frozen function:
 @[irreducible]
-def complexFrozen := fun ω => f (g (h (X ω)))
+def complexFrozen := fun ω ↦ f (g (h (X ω)))
 
 -- Split into parts:
-@[irreducible] def frozenH (X : Ω → α) : Ω → β := fun ω => h (X ω)
-@[irreducible] def frozenG (Y : Ω → β) : Ω → γ := fun ω => g (Y ω)
-@[irreducible] def frozenF (Z : Ω → γ) : Ω → ℝ := fun ω => f (Z ω)
+@[irreducible] def frozenH (X : Ω → α) : Ω → β := fun ω ↦ h (X ω)
+@[irreducible] def frozenG (Y : Ω → β) : Ω → γ := fun ω ↦ g (Y ω)
+@[irreducible] def frozenF (Z : Ω → γ) : Ω → ℝ := fun ω ↦ f (Z ω)
 
 -- Compose:
 def complexFrozen := frozenF (frozenG (frozenH X))

--- a/plugins/lean4/skills/lean4/references/proof-golfing-patterns.md
+++ b/plugins/lean4/skills/lean4/references/proof-golfing-patterns.md
@@ -67,12 +67,12 @@ When terms are definitionally equal, `rfl` suffices. Low risk - test with build,
 
 ```lean
 -- Before
-eq_empty_iff_forall_notMem.mpr (fun x hx => hU_sub_int hx)
+eq_empty_iff_forall_notMem.mpr (fun x hx ↦ hU_sub_int hx)
 -- After
 eq_empty_iff_forall_notMem.mpr hU_sub_int
 ```
 
-Pattern: `fun x => f x` is just `f`. Zero risk.
+Pattern: `fun x ↦ f x` is just `f`. Zero risk.
 
 ### Pattern 2C: Direct `.mpr`/`.mp` (Directness)
 
@@ -91,7 +91,7 @@ When `rwa` does trivial work, use direct term application. Zero risk.
 -- Before
 have h : ∀ i : Fin m, p (ι i) := by intro i; dsimp [p, ι]; exact i.isLt
 -- After
-have h : ∀ i : Fin m, p (ι i) := fun i => i.isLt
+have h : ∀ i : Fin m, p (ι i) := fun i ↦ i.isLt
 ```
 
 Convert `intro x; dsimp; exact term` to direct lambda. 75% reduction.
@@ -101,11 +101,11 @@ Convert `intro x; dsimp; exact term` to direct lambda. 75% reduction.
 ```lean
 -- Before
 lemma foo := by
-  let k' := fun i => (k i).val
+  let k' := fun i ↦ (k i).val
   have hk' : StrictMono k' := by ...
   exact hX m k' hk'
 -- After
-lemma foo := by exact hX m (fun i => (k i).val) (fun i j hij => ...)
+lemma foo := by exact hX m (fun i ↦ (k i).val) (fun i j hij ↦ ...)
 ```
 
 **⚠️ HIGH RISK:** 60-80% reduction but 93% false positive rate! MUST verify let used ≤2 times.
@@ -368,9 +368,9 @@ Skip explicit `exact` when simp makes goal trivial. 67% reduction.
 
 ```lean
 -- Before (linter warns)
-fun i j hij => proof_not_using_i_or_j
+fun i j hij ↦ proof_not_using_i_or_j
 -- After
-fun _ _ hij => proof_not_using_i_or_j
+fun _ _ hij ↦ proof_not_using_i_or_j
 ```
 
 Replace unused lambda parameters with `_`. Zero risk.

--- a/plugins/lean4/skills/lean4/references/proof-golfing.md
+++ b/plugins/lean4/skills/lean4/references/proof-golfing.md
@@ -26,7 +26,7 @@
 |---------|---------|------|
 | `by exact t` → `t` | 1 line | Zero |
 | `by rfl` → `rfl` | 1 line | Zero |
-| Eta-reduction `fun x => f x` → `f` | Tokens | Zero |
+| Eta-reduction `fun x ↦ f x` → `f` | Tokens | Zero |
 | `.mpr`/`.mp` over `rwa` for trivial | 1 line | Zero |
 | Dot notation `.rfl`/`.symm` | Tokens | Zero |
 | `apply f; exact h` → `exact f h` | 1 line | Zero |
@@ -73,7 +73,7 @@
 
 **Example - DON'T optimize:**
 ```lean
-let μ_map := Measure.map (fun ω i => X (k i) ω) μ  -- 20 tokens
+let μ_map := Measure.map (fun ω i ↦ X (k i) ω) μ  -- 20 tokens
 -- Used 7 times in proof
 -- Current: 20 + (2 × 7) = 34 tokens
 -- Inlined: 20 × 7 = 140 tokens (4× WORSE!)
@@ -297,7 +297,7 @@ Nat.add_lt_add_left hij k
 
 ```text
 ~1 token each:   let, have, exact, intro, by, fun
-~2 tokens each:  :=, =>, (fun x => ...), StrictMono
+~2 tokens each:  :=, =>, (fun x ↦ ...), StrictMono
 ~5-10 tokens:    let x : Type := definition
                  have h : Property := by proof
 ```

--- a/plugins/lean4/skills/lean4/references/proof-simplification.md
+++ b/plugins/lean4/skills/lean4/references/proof-simplification.md
@@ -100,7 +100,7 @@ apply Finset.induction_on s
 **After:**
 ```lean
 exact Finset.card_image_of_injective s hinj
--- or: Finset.sum_image fun x _ y _ h => hinj h
+-- or: Finset.sum_image fun x _ y _ h ↦ hinj h
 -- or: Finset.prod_image ...
 ```
 
@@ -125,7 +125,7 @@ rw [map_add, map_mul, map_one]
 ```lean
 ext x <;> simp
 -- or when simp needs guidance:
--- exact RingHom.ext fun x => by simp [h_comm]
+-- exact RingHom.ext fun x ↦ by simp [h_comm]
 ```
 
 `MonoidHom.ext`, `RingHom.ext`, `LinearMap.ext`, and `AlgHom.ext` reduce morphism equality to pointwise equality with the correct coercion context. Combined with `simp`, this eliminates manual `DFunLike.ext` + `map_*` chains.

--- a/plugins/lean4/skills/lean4/references/review-hook-schema.md
+++ b/plugins/lean4/skills/lean4/references/review-hook-schema.md
@@ -91,7 +91,7 @@ Output returned by hooks (via stdout):
       "severity": "hint",
       "category": "sorry",
       "message": "Try tendsto_atTop from Mathlib.Topology.Order.Basic",
-      "fix": "exact tendsto_atTop.mpr fun n => ⟨n, fun m hm => hm⟩"
+      "fix": "exact tendsto_atTop.mpr fun n ↦ ⟨n, fun m hm ↦ hm⟩"
     },
     {
       "file": "Core.lean",

--- a/plugins/lean4/skills/lean4/references/tactics-reference.md
+++ b/plugins/lean4/skills/lean4/references/tactics-reference.md
@@ -441,10 +441,10 @@ fun_prop (disch := simp)
 
 **Example - Measurability:**
 ```lean
--- Goal: Measurable (fun ω => fun j : Fin n => X (k j) ω)
+-- Goal: Measurable (fun ω ↦ fun j : Fin n ↦ X (k j) ω)
 -- Without disch: fun_prop generates subgoals you must solve manually
 -- With disch: automation solves them
-have h : Measurable (fun ω => fun j : Fin n => X (k j) ω) := by
+have h : Measurable (fun ω ↦ fun j : Fin n ↦ X (k j) ω) := by
   fun_prop (disch := measurability)
 ```
 
@@ -472,7 +472,7 @@ lemma measurable_shiftℤ : Measurable (shiftℤ (α := α)) := by
   measurability
 
 -- Now fun_prop can automatically use this when it encounters shiftℤ
-example : Measurable (fun ω => shiftℤ ω) := by
+example : Measurable (fun ω ↦ shiftℤ ω) := by
   fun_prop  -- Automatically finds and applies measurable_shiftℤ
 ```
 
@@ -484,11 +484,11 @@ example : Measurable (fun ω => shiftℤ ω) := by
 **Real example from practice:**
 ```lean
 -- Without @[fun_prop]: manual proof needed
-have h : Measurable (fun ω => f (ω (-1))) := by
+have h : Measurable (fun ω ↦ f (ω (-1))) := by
   exact hf_meas.comp (measurable_pi_apply (-1))
 
 -- With @[fun_prop] on component lemmas: automated
-have h : Measurable (fun ω => f (ω (-1))) := by
+have h : Measurable (fun ω ↦ f (ω (-1))) := by
   fun_prop (disch := measurability)
 ```
 

--- a/plugins/lean4/skills/lean4/references/verso-docs.md
+++ b/plugins/lean4/skills/lean4/references/verso-docs.md
@@ -32,7 +32,7 @@ Use these small transforms in sequence:
 
 - Wrap inline code in backticks and add a role:
   - `{name}``TensorLayout.transpose``
-  - `{lean}``fun x => x + 1``
+  - `{lean}``fun x ↦ x + 1``
   - `{lit}``x[i,j]``
 - Use `{given}` to declare variables, then reference with `{lean}`:
   - `{given}``n`` then `{lean}``#[n]``

--- a/plugins/lean4/tools/lint_docs.sh
+++ b/plugins/lean4/tools/lint_docs.sh
@@ -589,6 +589,62 @@ check_python_script_interpreters() {
     [[ $_pi_found -eq 0 ]] && ok "Python helper interpreter prefixes checked"
 }
 
+# Check 8d: Mathlib style quick checklist surfaced in SKILL.md +
+# mathlib-style.md (issue #133). Three substring invariants:
+#   1. SKILL.md mentions `fun x ↦` (always-loaded lambda reminder).
+#   2. mathlib-style.md has a section "Style Conventions Generators
+#      Often Miss".
+#   3. That section mentions both `fun x ↦` AND `show P by tac`.
+#
+# Scope: this guards the ALWAYS-LOADED CHECKLIST SURFACE only. It
+# does NOT police the broader reference-file sweep — that policing
+# would be too noisy (legitimate metaprogramming/callback `=>`
+# usages exist in references). For new `fun ... =>` introductions
+# in unrelated files, rely on review.
+#
+# Guard strength is local/doctor only (same caveat as Check 8a from
+# #136 and Check 8c from #138). lint_docs.sh is not invoked in CI;
+# the only lint_docs check exercised in CI is 8c via test_lint_docs.sh.
+check_mathlib_style_lambda_guidance() {
+    log ""
+    log "Checking mathlib style checklist surfaced (issue #133)..."
+
+    local _ml_skill _ml_ref _ml_section
+    _ml_skill="$PLUGIN_ROOT/skills/lean4/SKILL.md"
+    _ml_ref="$PLUGIN_ROOT/skills/lean4/references/mathlib-style.md"
+    if [[ ! -f "$_ml_skill" ]]; then
+        warn "SKILL.md not found at $_ml_skill (cannot check mathlib style checklist)"
+        return
+    fi
+    if [[ ! -f "$_ml_ref" ]]; then
+        warn "mathlib-style.md not found at $_ml_ref (cannot check mathlib style checklist)"
+        return
+    fi
+    # 1. SKILL.md must mention `fun x ↦`.
+    if ! grep -qF 'fun x ↦' "$_ml_skill"; then
+        warn "SKILL.md: missing mathlib lambda style reminder ('fun x ↦' not present — see issue #133 and references/mathlib-style.md)"
+        return
+    fi
+    # 2. mathlib-style.md must have the section heading.
+    if ! grep -qF 'Style Conventions Generators Often Miss' "$_ml_ref"; then
+        warn "mathlib-style.md: missing 'Style Conventions Generators Often Miss' section — see issue #133"
+        return
+    fi
+    # 3. That section must mention both `fun x ↦` and `show P by tac`.
+    _ml_section=$(awk '
+        /^### .*Style Conventions Generators Often Miss/ {p=1; next}
+        p && /^### / {exit}
+        p && /^## / {exit}
+        p {print}
+    ' "$_ml_ref")
+    if ! grep -qF 'fun x ↦' <<<"$_ml_section" \
+       || ! grep -qF 'show P by tac' <<<"$_ml_section"; then
+        warn "mathlib-style.md 'Style Conventions Generators Often Miss': must mention both 'fun x ↦' and 'show P by tac' — see issue #133"
+        return
+    fi
+    ok "Mathlib style lambda/show checklist surfaced in SKILL.md + mathlib-style.md"
+}
+
 # Check 9: Deep-safety invariants in prove/autoprove/cycle-engine
 check_deep_safety() {
     log ""
@@ -1725,6 +1781,7 @@ check_bare_scripts
 check_skill_omit_rule
 check_script_stderr_suppression
 check_python_script_interpreters
+check_mathlib_style_lambda_guidance
 check_deep_safety
 check_guardrail_docs
 check_guardrail_impl

--- a/plugins/lean4/tools/lint_docs.sh
+++ b/plugins/lean4/tools/lint_docs.sh
@@ -602,9 +602,11 @@ check_python_script_interpreters() {
 # usages exist in references). For new `fun ... =>` introductions
 # in unrelated files, rely on review.
 #
-# Guard strength is local/doctor only (same caveat as Check 8a from
-# #136 and Check 8c from #138). lint_docs.sh is not invoked in CI;
-# the only lint_docs check exercised in CI is 8c via test_lint_docs.sh.
+# Guard strength is local/doctor only, same as Check 8a from #136.
+# Unlike Check 8c from #138, this invariant has no dedicated CI
+# self-test; test_lint_docs.sh (added in #138) invokes lint_docs.sh
+# incidentally in CI, but it only asserts the Check 8c fixture
+# behavior.
 check_mathlib_style_lambda_guidance() {
     log ""
     log "Checking mathlib style checklist surfaced (issue #133)..."


### PR DESCRIPTION
## Summary

Closes #133. Surfaces two recurring review-only style failures in the always-loaded `SKILL.md`, fixes the stale "GOOD" example in `mathlib-style.md`, sweeps ~80 ordinary lambda hits across 11 reference files from `fun ... =>` to `fun ... ↦`, and adds a narrow regression guard mirroring the #136 / #138 pattern.

Off `feat/mathlib-style-checklist` from `origin/main` (post-#136 and #138 merged). Five focused commits, no version bump.

## Commits

1. **`docs(skill)`** (`dde498a`) — adds a "Mathlib style quick check" reminder to `SKILL.md` immediately after the existing 100-character line-width rule (which already cross-references `mathlib-style.md`). Body: `fun x ↦` for ordinary mathematical lambdas, `=>` for `match`/`do` branches and metaprogramming callback idioms; `show P by tac` for tactic proofs, `show P from term` for term proofs.

2. **`docs(mathlib-style)`** (`6801596`) — adds new `### 9. Style Conventions Generators Often Miss` section under "Essential Rules" with three bullets (lambdas, short-lambda placeholder `·`, `show`). Also fixes the stale `fun ω => F ((shift^[n]) ω)` example in `### 8. Implicit Parameters` (currently marked `-- ✅ GOOD`, which actively reinforces the wrong default).

3. **`docs(references)`** (`5b1ddcc`) — reference sweep across 11 files. Audit regenerated on this branch base before editing. Per-file: `compilation-errors.md` (8 — earlier audit's keep-list of 422/429/615 was wrong on review; 429 was marked `✅ CORRECT` but used `=>`, 422's wrongness was shadowing not the arrow, 615 is binder-mismatch prose), `measure-theory.md` (20), `domain-patterns.md` (16+4 nested follow-ups), `performance-optimization.md` (14+1), `proof-golfing-patterns.md` (7+1), `tactics-reference.md` (5+2), `proof-golfing.md` (3), `disprove-engine.md` (3), `proof-simplification.md` (2), `review-hook-schema.md` (1+1 nested JSON), `verso-docs.md` (1). Total ~80 line rewrites.

   **Files explicitly NOT touched** (all hits are (a)-class — MetaM/elaborator/callback contexts where `=>` is correct):
   - `lean4-custom-syntax.md` (7 hits: forallTelescope, lambdaTelescope, withLocalDecl, transform, findDeclM?, liftMetaTactic, liftMetaTactic1)
   - `grind-tactic.md` (1: dsimproc callback)
   - `compiler-internals.md` (1: PassInstaller closure)
   - `simp-reference.md` (1: simproc_decl elaborator)
   - `mathlib-style.md:123` (MetaM withLocalDeclD callback)

4. **`lint(docs)`** (`302aff1`) — new `check_mathlib_style_lambda_guidance` as Check 8d in `lint_docs.sh`. Three substring invariants: SKILL.md mentions `fun x ↦`, `mathlib-style.md` has the section heading, the section mentions both `fun x ↦` and `show P by tac`. Mirrors `check_skill_omit_rule` from #136 (awk section-slice, two substring asserts, single warn/ok per outcome). Source comment explicitly scopes the guard to the always-loaded checklist surface only — does NOT police the broader reference sweep (too noisy; broader lint deliberately out of scope).

5. **`docs(mathlib-style)`** (`2d9c117`) — replaces the flat prose mention of `show P from by tac` with a concrete ❌/✅ triple worked example so a generator has something mechanical to imitate (drop `from` when the body is a tactic block; keep `from` when the body is a proof term). Reviewer flagged the pattern as recurring in real proofs (spherepacking-adjacent work); a worked example is more useful than a sentence even though our docs had zero pre-existing hits.

## Test plan

- [x] **Post-sweep audit:**
  ```bash
  grep -RInE 'fun[[:space:]][^=]*=>' plugins/lean4 --include='*.md'
  grep -RInE '\bfrom[[:space:]]+by\b' plugins/lean4 --include='*.md'
  ```
  Returns only the 11 (a)-class lines + 1 (b)-class self-mention (`mathlib-style.md:231` documents the lambda anti-pattern). `from by` grep returns only `mathlib-style.md:237` (the ❌ worked-example marker from commit 5).
- [x] **Targeted lint pass:** Check 8d emits `✓ Mathlib style lambda/show checklist surfaced in SKILL.md + mathlib-style.md`. (Other inherited warnings unrelated to this check are preexisting and out of scope.)
- [x] **Negative test:** stripping the SKILL.md mention fires the SKILL.md warning; stripping the section heading from `mathlib-style.md` fires the section-missing warning; restoring both returns to green.
- [x] **No regression in self-test:** `bash plugins/lean4/tests/test_lint_docs.sh` unchanged (Check 8d has no self-test by design — matches #136 precedent where `check_skill_omit_rule` also has none).
- [x] **CI:** macos-bash3 + mypy + ruff + shellcheck stay green on the new head.

## Out of scope

- Broad lint banning `fun ... =>` everywhere (noisy; per direction). The narrow docs-surface invariant in Check 8d is sufficient.
- `show P from by tac` rewrites in references (audit found zero current docs hits; the rule is purely preventative — but commit 5 adds a concrete ❌/✅ worked example to the checklist itself so a generator has something to imitate).
- The (a) MetaM / do-block / callback hits in references (left intentionally — `=>` is correct in those contexts).
- A `test_lint_docs.sh` self-test for Check 8d (matches #136 precedent — Check 8a has none either; only Check 8c has self-test coverage).
- No version bump.
