### PR TITLE
chore(guardrails): host mode + per-op collab policies; hard-block force/mirror/delete push

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Lean 4 theorem proving with guided + autonomous proving, LSP-first workflows, guardrails, and contribution helpers",
-    "version": "4.5.1"
+    "version": "4.5.2"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v4.5.2 (June 2026)
+
+Collab-policy redesign so the hook stops fighting Claude Code's native permission UX, plus three folded-in docs/lint hardening PRs that landed on `main` after v4.5.1 without their own version bump.
+
+### `guardrails.sh` collab-policy refactor (primary)
+
+- Adds a new `host` policy mode meaning "exit 0 — defer to Claude Code's native `Bash(...)` permission rule" so ordinary `git push` no longer requires the exit-2 + `LEAN4_GUARDRAILS_BYPASS=1` retry dance.
+- Splits the single `LEAN4_GUARDRAILS_COLLAB_POLICY` knob into three per-op env vars: `LEAN4_GUARDRAILS_PUSH_POLICY`, `LEAN4_GUARDRAILS_AMEND_POLICY`, `LEAN4_GUARDRAILS_PR_CREATE_POLICY`. Each accepts `host` | `ask` | `allow` | `block`; default is `host`.
+- **Back-compat preserved:** `LEAN4_GUARDRAILS_COLLAB_POLICY` continues to be honored as the fallback for any per-op policy that isn't explicitly set. Users who already configured `COLLAB_POLICY=allow` / `=block` / `=ask` in their settings keep the v4.5.1 semantics on the soft-gate path.
+- **Push variants now tier-3 hard-blocked, non-bypassable** (matching `git reset --hard` posture): `--force` / `-f`, `--force-with-lease[=…]`, `--mirror`, `--delete` / `-d`, legacy `<remote> :<ref>` ref-delete syntax. Each emits a distinct BLOCKED message naming the variant. Per-command escape hatch: `LEAN4_GUARDRAILS_DISABLE=1 git push --force …`. `--dry-run` and `git stash push` remain exempted from all push gates.
+- Recommended pairing in `.claude/settings.local.json`: `"permissions": { "ask": ["Bash(git push *)", "Bash(gh pr create *)", "Bash(git commit --amend *)"] }` — Claude Code's native "ask once, remember" UI then owns the consent, with the hook only intervening on the dangerous variants.
+- See [MIGRATION.md § V4.5.1 → V4.5.2](plugins/lean4/MIGRATION.md#v451--v452) for the migration walkthrough.
+
+### Folded-in PRs (previously merged without version bumps)
+
+Three previously-merged PRs landed on `main` after the v4.5.1 release without their own CHANGELOG entries (each was scoped "no version bump" at the time). They're folded into v4.5.2 here so future archeology against `git log` reads cleanly:
+
+- **#137 (closes #136): `docs(skill): teach the omit [Inst] in ordering rule + lint guard`** — the always-loaded `SKILL.md` Type Class Patterns section now teaches that `omit [Inst] in` must appear **before** the declaration docstring (placing it between docstring and `lemma`/`theorem` is a parse error). Plus a new `lint_docs.sh` Check 8a (`check_skill_omit_rule`) regression guard.
+- **#138 (closes #135): `lint(docs): Check 8c — Python helpers must use ${LEAN4_PYTHON_BIN:-python3}`** — new Check 8c in `lint_docs.sh` flags bare `python3 "$LEAN4_SCRIPTS/<script>.py"` invocations and requires the `${LEAN4_PYTHON_BIN:-python3}` prefix so docs respect the operator's Python pin. Fixes 4 stale `compiler-guided-repair.md` invocations and ships `tests/test_lint_docs.sh` (a plant-in-real-tree self-test) wired into the `bash3-compat` CI workflow.
+- **#139 (closes #133): `docs(style): mathlib lambda + show conventions checklist + reference sweep`** — `SKILL.md` mathlib style quick-check (use `fun x ↦` for ordinary lambdas, reserve `=>` for `match`/`do` branches and metaprogramming callbacks; prefer `show P by tac` over `show P from by tac`). New `### 9. Style Conventions Generators Often Miss` section in `mathlib-style.md` with concrete ❌/✅ worked examples. ~80-line `fun ... =>` → `↦` sweep across 11 reference files (callback/elaborator contexts intentionally left alone). Plus `lint_docs.sh` Check 8d (`check_mathlib_style_lambda_guidance`) regression guard on the always-loaded checklist surface.
+
 ## v4.5.1 (June 2026)
 
 Adds prefixed `bin/` wrappers for model-facing scripts (closes #117). Claude Code's plugin loader appends `plugins/lean4/bin/` to the Bash tool's `PATH`, so wrappers like `lean4-skills-cycle-tracker` resolve as bare commands and become statically allowlistable as `Bash(lean4-skills-cycle-tracker:*)` — eliminating the per-invocation permission prompts that issue #117 reported on every `$LEAN4_SCRIPTS/...` call.

--- a/plugins/lean4/.claude-plugin/plugin.json
+++ b/plugins/lean4/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lean4",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "Unified Lean 4 plugin (draft, formalize, autoformalize, prove, autoprove, disprove, checkpoint, review, refactor, golf, learn, doctor) — LSP-first, scripts fallback",
   "author": {"name": "Cameron Freer", "email": "cameronfreer@gmail.com"}
 }

--- a/plugins/lean4/MIGRATION.md
+++ b/plugins/lean4/MIGRATION.md
@@ -244,13 +244,22 @@ without any prompt):
 {
   "permissions": {
     "ask": [
+      "Bash(git push)",
       "Bash(git push *)",
+      "Bash(gh pr create)",
       "Bash(gh pr create *)",
+      "Bash(git commit --amend)",
       "Bash(git commit --amend *)"
     ]
   }
 }
 ```
+
+Per Claude Code's permission docs, `Bash(<cmd> *)` only matches
+commands that start with `<cmd> ` (a space before `*` is required),
+so `Bash(git push *)` catches `git push origin main` but **not bare
+`git push`**. List both the exact form (`Bash(git push)`) and the
+prefix form (`Bash(git push *)`) so either invocation prompts.
 
 Claude Code then handles "ask once, remember" via its native
 permission UI — typically a per-session approval that doesn't

--- a/plugins/lean4/MIGRATION.md
+++ b/plugins/lean4/MIGRATION.md
@@ -214,6 +214,14 @@ You can also mix: set `COLLAB_POLICY=ask` (everything blocks until
 bypass) but `LEAN4_GUARDRAILS_PUSH_POLICY=host` (only push delegates
 to Claude Code). Per-op vars always win for the op they cover.
 
+**Typo-safety:** an unset per-op var resolves to `host` (or the
+legacy `COLLAB_POLICY` value if you set one) via the fallback chain
+above. But an **explicitly invalid** value — e.g.
+`LEAN4_GUARDRAILS_PUSH_POLICY=alow` (typo of `allow`) — falls back
+to `ask`, not `host`. A typo shouldn't silently relax the plugin
+guardrail; the operation blocks until bypass so you notice and
+fix the value.
+
 ### Push variants hard-blocked (new tier-3, non-bypassable)
 
 Six push form families that previously fell through the soft-gate

--- a/plugins/lean4/MIGRATION.md
+++ b/plugins/lean4/MIGRATION.md
@@ -178,6 +178,80 @@ Both `lib/scripts/` and `scripts/` (compat alias) resolve to the same directory.
 
 Run `/lean4:doctor` for full diagnostics.
 
+## V4.5.1 → V4.5.2
+
+**Collab policy split + `host` mode default.** The single
+`LEAN4_GUARDRAILS_COLLAB_POLICY` knob is replaced by three per-op
+policies, each with a new `host` value that defers to Claude Code's
+native `Bash(...)` permission rule (`allow`/`ask`/`deny`). The default
+for each per-op policy is `host`, which stops the hook from blocking
+ordinary `git push` with `exit 2` + bypass-token retries — Claude
+Code's permission layer handles consent natively (including
+"ask once, remember" UX).
+
+### Env var changes
+
+| Old (v4.5.1) | New (v4.5.2+) |
+|---|---|
+| `LEAN4_GUARDRAILS_COLLAB_POLICY=ask` (default) | Per-op default: `host` (each of PUSH/AMEND/PR_CREATE) |
+| Single knob for push + amend + pr-create | `LEAN4_GUARDRAILS_PUSH_POLICY`, `LEAN4_GUARDRAILS_AMEND_POLICY`, `LEAN4_GUARDRAILS_PR_CREATE_POLICY` (each `host` \| `ask` \| `allow` \| `block`) |
+
+### Back-compat: no action needed if you set `COLLAB_POLICY`
+
+The legacy `LEAN4_GUARDRAILS_COLLAB_POLICY` var is honored as the
+fallback for any per-op policy you haven't explicitly set. So:
+
+- If you set `COLLAB_POLICY=allow` in your settings, all three
+  ops continue to soft-gate with `allow` semantics (unchanged).
+- If you set `COLLAB_POLICY=block`, same (unchanged).
+- If you set `COLLAB_POLICY=ask` explicitly, push/amend/pr-create
+  continue to block-until-bypass (unchanged).
+- If you didn't set `COLLAB_POLICY` and relied on its `ask` default,
+  **your default is now `host`**. To preserve the old behavior,
+  add `LEAN4_GUARDRAILS_COLLAB_POLICY=ask` to your settings.
+
+You can also mix: set `COLLAB_POLICY=ask` (everything blocks until
+bypass) but `LEAN4_GUARDRAILS_PUSH_POLICY=host` (only push delegates
+to Claude Code). Per-op vars always win for the op they cover.
+
+### Push variants hard-blocked (new tier-3, non-bypassable)
+
+Five push forms that previously fell through the soft-gate are now
+hard-blocked regardless of `PUSH_POLICY` — same posture as
+`git reset --hard`:
+
+- `git push --force` / `-f`
+- `git push --force-with-lease[=<ref>]`
+- `git push --mirror`
+- `git push --delete` / `-d <ref>`
+- `git push <remote> :<ref>` (legacy ref-delete syntax)
+
+Escape hatch: `LEAN4_GUARDRAILS_DISABLE=1 git push --force ...` for
+the specific command. `--dry-run` and `git stash push` remain
+exempted from all push gates (unchanged).
+
+### Recommended `.claude/settings.local.json`
+
+With `host` as the default, you'll want to tell Claude Code to
+`ask` before push and pr-create (otherwise the model could push
+without any prompt):
+
+```json
+{
+  "permissions": {
+    "ask": [
+      "Bash(git push *)",
+      "Bash(gh pr create *)",
+      "Bash(git commit --amend *)"
+    ]
+  }
+}
+```
+
+Claude Code then handles "ask once, remember" via its native
+permission UI — typically a per-session approval that doesn't
+re-prompt on subsequent invocations.
+
 ## V4.4.0 → V4.4.1
 
 **Proof-editing agents renamed** to drop the `lean4-` prefix, fixing the dispatch name stutter.

--- a/plugins/lean4/MIGRATION.md
+++ b/plugins/lean4/MIGRATION.md
@@ -216,19 +216,23 @@ to Claude Code). Per-op vars always win for the op they cover.
 
 ### Push variants hard-blocked (new tier-3, non-bypassable)
 
-Five push forms that previously fell through the soft-gate are now
-hard-blocked regardless of `PUSH_POLICY` — same posture as
+Six push form families that previously fell through the soft-gate
+are now hard-blocked regardless of `PUSH_POLICY` — same posture as
 `git reset --hard`:
 
-- `git push --force` / `-f`
+- `git push --force` / `-f`, plus bundled short-flag runs containing `f` (`-fu`, `-uf`, `-vfu`, `-fnq`)
 - `git push --force-with-lease[=<ref>]`
 - `git push --mirror`
-- `git push --delete` / `-d <ref>`
+- `git push --delete <ref>` / `-d <ref>`, plus bundled short-flag runs containing `d` (`-dn`, `-nd`, `-vd`)
 - `git push <remote> :<ref>` (legacy ref-delete syntax)
+- `git push <remote> +<refspec>` (leading-`+` force-refspec — e.g. `+HEAD:main`, `+main`, `+src:dst`)
 
 Escape hatch: `LEAN4_GUARDRAILS_DISABLE=1 git push --force ...` for
-the specific command. `--dry-run` and `git stash push` remain
-exempted from all push gates (unchanged).
+the specific command. `--dry-run` (long form) and `git stash push`
+remain exempted from all push gates (unchanged). The bundled short
+form `-n` inside a `-fn` / `-dn` etc. run does **not** exempt — the
+bundled-force-with-dry-run signals force intent. Use the long forms
+(`git push --force --dry-run`) for an actual dry-run-force.
 
 ### Recommended `.claude/settings.local.json`
 

--- a/plugins/lean4/README.md
+++ b/plugins/lean4/README.md
@@ -252,13 +252,16 @@ Invalid values fall back to `host`.
 
 **Push variants hard-blocked (tier 3, non-bypassable):** the following push forms rewrite shared history, delete refs, or replicate-and-delete all refs, and are blocked regardless of `PUSH_POLICY` — same posture as `git reset --hard`:
 
-- `git push --force` / `-f`
+- `git push --force` / `-f`, plus any bundled short-flag run containing `f` (e.g. `git push -fu origin main`, `-uf`, `-vfu`, `-fnq`)
 - `git push --force-with-lease[=<ref>]`
 - `git push --mirror`
-- `git push --delete` / `-d <ref>`
+- `git push --delete <ref>` / `-d <ref>`, plus any bundled short-flag run containing `d` (e.g. `git push -dn origin feat`, `-nd`, `-vd`)
 - `git push <remote> :<ref>` (legacy delete-ref syntax)
+- `git push <remote> +<refspec>` (leading-`+` force-refspec; e.g. `+HEAD:main`, `+main`, `+src:dst`)
 
 Escape hatch for these: `LEAN4_GUARDRAILS_DISABLE=1 git push --force ...` for the specific command.
+
+Note on bundled `-n`: the long form `--dry-run` exempts every push hard-block check (back-compat with v4.5.1), but the bundled short form `-n` inside a `-fn` / `-dn` etc. run does **not** exempt — bundled-force-with-dry-run signals force intent the hook flags regardless. To dry-run a force, use `git push --force --dry-run` (long forms).
 
 **Destructive policy (`LEAN4_GUARDRAILS_DESTRUCTIVE_POLICY`):**
 

--- a/plugins/lean4/README.md
+++ b/plugins/lean4/README.md
@@ -208,8 +208,11 @@ Guarded during Lean project sessions (policy/tier details below):
 |----------|--------|
 | `LEAN4_GUARDRAILS_DISABLE=1` | Skip all guardrails regardless of context |
 | `LEAN4_GUARDRAILS_FORCE=1` | Enforce guardrails even outside Lean projects |
-| `LEAN4_GUARDRAILS_COLLAB_POLICY` | Collaboration op policy: `ask` (default), `allow`, `block` |
+| `LEAN4_GUARDRAILS_PUSH_POLICY` | `git push` policy: `host` (default), `ask`, `allow`, `block` |
+| `LEAN4_GUARDRAILS_AMEND_POLICY` | `git commit --amend` policy: `host` (default), `ask`, `allow`, `block` |
+| `LEAN4_GUARDRAILS_PR_CREATE_POLICY` | `gh pr create` policy: `host` (default), `ask`, `allow`, `block` |
 | `LEAN4_GUARDRAILS_DESTRUCTIVE_POLICY` | Path-scoped destructive op policy: `ask` (default), `allow`, `block` |
+| `LEAN4_GUARDRAILS_COLLAB_POLICY` | **Legacy** fallback for any unset per-op collab policy above (pre-v4.5.2 single-knob var, kept for back-compat) |
 
 `LEAN4_GUARDRAILS_DISABLE` overrides everything. `LEAN4_GUARDRAILS_FORCE` controls whether guardrails activate outside Lean projects.
 
@@ -219,15 +222,43 @@ Git operations fall into **three tiers**:
 2. **Soft-gate** (policy-controlled, bypass-able): collaboration ops + path-scoped destructive ops. See subsections below.
 3. **Hard-block** (absolute, never bypassable): `git reset --hard`, `git clean -f`/`-fd`/`-fdx`, plus the whole-worktree, opaque-pathspec, force-branch, and interactive-sweep variants — `git checkout .`/`./`/`-- .`/`-- ./`/`-- :/`/`HEAD -- .`/`-f .`/`--ours .`/`--theirs :/`, `git checkout --pathspec-from-file=…`, `git checkout -f|--force <branch-or-ref>` (incl. ref shorthand `@{-1}`, `-`, `@`, `HEAD~3`, `HEAD@{1}`), `git checkout -p`/`--patch` with no path positional (interactive whole-worktree sweep, bypassable by piped stdin), `git restore .`/`./`/`:/`, `git restore --staged --worktree` (incl. `-SW` short-flag bundle), `git restore --pathspec-from-file=…` (non-staged), `git switch -f|--force|--discard-changes <anything>`. These wipe state across the whole worktree (or untracked files), discard uncommitted edits during branch switching, sweep modified files interactively from an opaque stdin source, or accept opaque path lists the guardrail can't inspect; reflog can't recover uncommitted edits and `clean -f` can't recover untracked files at all.
 
-**Collaboration policy (`LEAN4_GUARDRAILS_COLLAB_POLICY`):**
+**Collaboration policies (per-op, v4.5.2+):**
 
-Controls how collaboration ops (`git push`, `git commit --amend`, `gh pr create`) — operations that affect shared state — are handled:
+Three independent env vars, one per collaboration op — `LEAN4_GUARDRAILS_PUSH_POLICY`, `LEAN4_GUARDRAILS_AMEND_POLICY`, `LEAN4_GUARDRAILS_PR_CREATE_POLICY` — each accepting:
 
-- **`ask`** (default) — block unless a one-shot bypass token is present. The hook is non-interactive; in `ask` mode the assistant asks you yes/no, then reruns the command with the bypass token once.
-- **`allow`** — permit collaboration ops without a bypass token.
-- **`block`** — block collaboration ops unconditionally, even with a bypass token.
+- **`host`** (default) — exit 0; let Claude Code's native `Bash(...)` permission rule ask the user. This stops the hook from fighting Claude Code's own "ask once, remember" UX with exit-2 + bypass-token retries. Recommended pairing in `.claude/settings.local.json`:
 
-Invalid values fall back to `ask`.
+  ```json
+  {
+    "permissions": {
+      "ask": [
+        "Bash(git push *)",
+        "Bash(gh pr create *)",
+        "Bash(git commit --amend *)"
+      ]
+    }
+  }
+  ```
+
+  Claude Code will then prompt once per command (or per session, depending on the user's "remember" choice), and the hook stays out of the way.
+
+- **`ask`** — block unless a one-shot bypass token is present. The hook is non-interactive; in `ask` mode the assistant asks you yes/no, then reruns the command with `LEAN4_GUARDRAILS_BYPASS=1` once. This is the pre-v4.5.2 default behavior.
+- **`allow`** — permit the op without a bypass token.
+- **`block`** — block the op unconditionally, even with a bypass token.
+
+Invalid values fall back to `host`.
+
+**Back-compat:** the legacy `LEAN4_GUARDRAILS_COLLAB_POLICY` var (pre-v4.5.2, single knob for all three ops) is honored as the fallback for any per-op policy that isn't explicitly set. So users who set `COLLAB_POLICY=allow` or `COLLAB_POLICY=block` in their settings keep their existing soft-gate semantics on all three ops; users who don't set it get the new `host` default on each. Setting both `COLLAB_POLICY` and a per-op var means the per-op var wins for that op.
+
+**Push variants hard-blocked (tier 3, non-bypassable):** the following push forms rewrite shared history, delete refs, or replicate-and-delete all refs, and are blocked regardless of `PUSH_POLICY` — same posture as `git reset --hard`:
+
+- `git push --force` / `-f`
+- `git push --force-with-lease[=<ref>]`
+- `git push --mirror`
+- `git push --delete` / `-d <ref>`
+- `git push <remote> :<ref>` (legacy delete-ref syntax)
+
+Escape hatch for these: `LEAN4_GUARDRAILS_DISABLE=1 git push --force ...` for the specific command.
 
 **Destructive policy (`LEAN4_GUARDRAILS_DESTRUCTIVE_POLICY`):**
 
@@ -249,7 +280,7 @@ Controls how **path-scoped** destructive ops are handled. The covered forms (eac
 
 Invalid values fall back to `ask`. Whole-worktree destructive variants (tier 3 above) are independent of this policy and **always block** regardless of its value or the bypass token.
 
-The two policies are independent: `DESTRUCTIVE_POLICY=allow` does not unblock collab ops, and `COLLAB_POLICY=allow` does not unblock path-scoped destructive ops.
+The collab and destructive policies are independent: `DESTRUCTIVE_POLICY=allow` does not unblock collab ops, and any of the collab `*_POLICY=allow` settings (or legacy `COLLAB_POLICY=allow`) do not unblock path-scoped destructive ops.
 
 **One-shot bypass (soft-gated ops):**
 
@@ -295,7 +326,10 @@ Optional user overrides (not set by bootstrap):
 |----------|---------|
 | `LEAN4_GUARDRAILS_DISABLE` | Skip all guardrails (set to `1`) |
 | `LEAN4_GUARDRAILS_FORCE` | Force guardrails outside Lean projects (set to `1`) |
-| `LEAN4_GUARDRAILS_COLLAB_POLICY` | Collaboration op policy: `ask`, `allow`, `block` |
+| `LEAN4_GUARDRAILS_PUSH_POLICY` | `git push` policy: `host` (default), `ask`, `allow`, `block` |
+| `LEAN4_GUARDRAILS_AMEND_POLICY` | `git commit --amend` policy: `host` (default), `ask`, `allow`, `block` |
+| `LEAN4_GUARDRAILS_PR_CREATE_POLICY` | `gh pr create` policy: `host` (default), `ask`, `allow`, `block` |
+| `LEAN4_GUARDRAILS_COLLAB_POLICY` | Legacy fallback for unset per-op collab policies (kept for back-compat) |
 
 **Script troubleshooting:**
 ```bash

--- a/plugins/lean4/README.md
+++ b/plugins/lean4/README.md
@@ -232,21 +232,24 @@ Three independent env vars, one per collaboration op — `LEAN4_GUARDRAILS_PUSH_
   {
     "permissions": {
       "ask": [
+        "Bash(git push)",
         "Bash(git push *)",
+        "Bash(gh pr create)",
         "Bash(gh pr create *)",
+        "Bash(git commit --amend)",
         "Bash(git commit --amend *)"
       ]
     }
   }
   ```
 
-  Claude Code will then prompt once per command (or per session, depending on the user's "remember" choice), and the hook stays out of the way.
+  Per Claude Code's permission docs, `Bash(<cmd> *)` matches commands starting with `<cmd> ` (note the trailing space before `*` is required by the matcher). That covers `git push origin main` but **not bare `git push`** — the exact-form rule `Bash(<cmd>)` catches the no-args case. Both are listed above so either form is asked. Claude Code will then prompt once per command (or per session, depending on the user's "remember" choice), and the hook stays out of the way.
 
 - **`ask`** — block unless a one-shot bypass token is present. The hook is non-interactive; in `ask` mode the assistant asks you yes/no, then reruns the command with `LEAN4_GUARDRAILS_BYPASS=1` once. This is the pre-v4.5.2 default behavior.
 - **`allow`** — permit the op without a bypass token.
 - **`block`** — block the op unconditionally, even with a bypass token.
 
-Invalid values fall back to `host`.
+**Unset** vars resolve to `host` via the back-compat fallback chain (legacy `COLLAB_POLICY` is checked first; if it's also unset, `host` wins). **Explicit invalid values** (typos like `alow`, `bock`, `yolo`) fall back to `ask` — typos shouldn't silently relax the plugin-level guardrail.
 
 **Back-compat:** the legacy `LEAN4_GUARDRAILS_COLLAB_POLICY` var (pre-v4.5.2, single knob for all three ops) is honored as the fallback for any per-op policy that isn't explicitly set. So users who set `COLLAB_POLICY=allow` or `COLLAB_POLICY=block` in their settings keep their existing soft-gate semantics on all three ops; users who don't set it get the new `host` default on each. Setting both `COLLAB_POLICY` and a per-op var means the per-op var wins for that op.
 

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -137,16 +137,16 @@ PUSH_POLICY="${LEAN4_GUARDRAILS_PUSH_POLICY:-${COLLAB_POLICY:-host}}"
 PR_CREATE_POLICY="${LEAN4_GUARDRAILS_PR_CREATE_POLICY:-${COLLAB_POLICY:-host}}"
 AMEND_POLICY="${LEAN4_GUARDRAILS_AMEND_POLICY:-${COLLAB_POLICY:-host}}"
 # Validate each; invalid → fall back to `host` (the friendly default).
-# Bash 3.2 doesn't support `${!_p}`-style indirect assignment universally,
-# so use eval to write back the validated value.
+# ${!_p} indirect expansion works on Bash 3.2+. Writing back the
+# validated value still uses eval since indirect *assignment* via the
+# same name isn't supported by `${!_p}=...` on Bash 3.2.
 for _p in PUSH_POLICY PR_CREATE_POLICY AMEND_POLICY; do
-  eval "_val=\$$_p"
-  case "$_val" in
+  case "${!_p}" in
     host|ask|allow|block) ;;
     *) eval "$_p=host" ;;
   esac
 done
-unset _p _val
+unset _p
 
 DESTRUCTIVE_POLICY="${LEAN4_GUARDRAILS_DESTRUCTIVE_POLICY:-ask}"
 case "$DESTRUCTIVE_POLICY" in

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -530,9 +530,18 @@ _check_destructive_op() {
 # via the seg_match exemption arg.
 _push_exempt='\bstash\b.*\bpush\b|--dry-run\b'
 
-# `--force` / `-f` (plain force-push; rewrites remote history)
-if seg_match git '\bpush\b.*\s(-f|--force)(\s|$)' "$_push_exempt"; then
-  echo "BLOCKED (Lean guardrail): git push --force / -f rewrites shared history. Non-bypassable. Escape hatch: LEAN4_GUARDRAILS_DISABLE=1 for this command." >&2
+# `--force` / `-f`, bundled `-...f...` (plain force-push; rewrites remote history).
+# Bundle detection: a single-dash short-option run containing `f` anywhere
+# (e.g. `-fu`, `-uf`, `-vfu`, `-fnq`). The `--force-with-lease` long form is
+# handled separately below; the bundle regex won't match it because the
+# single-dash class `[A-Za-z]*` excludes `-`.
+#
+# Bundled `-n` (short for --dry-run) is intentionally NOT exempted here:
+# if you want a dry-run force-push, use the long forms (--force --dry-run)
+# which the existing --dry-run exemption catches. The bundled-short form
+# signals force intent the hook flags regardless.
+if seg_match git '\bpush\b.*\s(--force|-[A-Za-z]*f[A-Za-z]*)(\s|$)' "$_push_exempt"; then
+  echo "BLOCKED (Lean guardrail): git push --force / -f / bundled -f short-flag (e.g. -fu, -uf) rewrites shared history. Non-bypassable. Escape hatch: LEAN4_GUARDRAILS_DISABLE=1 for this command." >&2
   exit 2
 fi
 
@@ -548,9 +557,13 @@ if seg_match git '\bpush\b.*\s--mirror(\s|$)' "$_push_exempt"; then
   exit 2
 fi
 
-# `--delete` / `-d` (delete remote ref)
-if seg_match git '\bpush\b.*\s(--delete|-d)(\s|$)' "$_push_exempt"; then
-  echo "BLOCKED (Lean guardrail): git push --delete / -d removes a remote ref. Non-bypassable. Escape hatch: LEAN4_GUARDRAILS_DISABLE=1 for this command." >&2
+# `--delete` / `-d`, bundled `-...d...` (delete remote ref). Same bundle
+# detection shape as force above: a single-dash short-option run containing
+# `d` anywhere (e.g. `-dn`, `-nd`, `-vd`). `--delete-this-extension` (some
+# hypothetical future long flag) won't false-match because the bundle regex
+# is single-dash.
+if seg_match git '\bpush\b.*\s(--delete|-[A-Za-z]*d[A-Za-z]*)(\s|$)' "$_push_exempt"; then
+  echo "BLOCKED (Lean guardrail): git push --delete / -d / bundled -d short-flag (e.g. -dn, -nd) removes a remote ref. Non-bypassable. Escape hatch: LEAN4_GUARDRAILS_DISABLE=1 for this command." >&2
   exit 2
 fi
 
@@ -560,6 +573,16 @@ fi
 # pathspec separator in other tokens.
 if seg_match git '\bpush\b.*\s:[A-Za-z0-9_./-]+(\s|$)' "$_push_exempt"; then
   echo "BLOCKED (Lean guardrail): git push <remote> :<ref> (legacy ref-delete syntax) removes a remote ref. Non-bypassable. Use git push --delete to be explicit, or LEAN4_GUARDRAILS_DISABLE=1 for this command." >&2
+  exit 2
+fi
+
+# Leading-`+` force-refspec: `git push origin +<ref>` or `git push origin +<src>:<dst>`.
+# Per git-push(1): a refspec prefixed with `+` requests non-fast-forward
+# (force) update for that ref, equivalent to `--force` scoped to the
+# specific refspec. The `+` must lead the token; subsequent `+` characters
+# inside a refspec are not the force prefix.
+if seg_match git '\bpush\b.*\s\+[^\s+][^\s]*(\s|$)' "$_push_exempt"; then
+  echo "BLOCKED (Lean guardrail): git push <remote> +<refspec> (leading-+ force-refspec) requests non-fast-forward update — rewrites shared history. Non-bypassable. Escape hatch: LEAN4_GUARDRAILS_DISABLE=1 for this command." >&2
   exit 2
 fi
 

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -136,14 +136,21 @@ COLLAB_POLICY="${LEAN4_GUARDRAILS_COLLAB_POLICY:-}"
 PUSH_POLICY="${LEAN4_GUARDRAILS_PUSH_POLICY:-${COLLAB_POLICY:-host}}"
 PR_CREATE_POLICY="${LEAN4_GUARDRAILS_PR_CREATE_POLICY:-${COLLAB_POLICY:-host}}"
 AMEND_POLICY="${LEAN4_GUARDRAILS_AMEND_POLICY:-${COLLAB_POLICY:-host}}"
-# Validate each; invalid → fall back to `host` (the friendly default).
+# Validate each. Two distinct fallbacks:
+#   - UNSET vars already resolved to `host` (the friendly default) via the
+#     parameter-expansion chain above, before validation runs.
+#   - SET but invalid values (typos like `alow`, `bock`, `yolo`, or
+#     legitimate values that get corrupted in env propagation) fall back
+#     to `ask` — the safer choice. A typo shouldn't silently relax the
+#     plugin-level guardrail; it should ask. This means
+#     `LEAN4_GUARDRAILS_PUSH_POLICY=alow` blocks rather than allowing.
 # ${!_p} indirect expansion works on Bash 3.2+. Writing back the
 # validated value still uses eval since indirect *assignment* via the
 # same name isn't supported by `${!_p}=...` on Bash 3.2.
 for _p in PUSH_POLICY PR_CREATE_POLICY AMEND_POLICY; do
   case "${!_p}" in
     host|ask|allow|block) ;;
-    *) eval "$_p=host" ;;
+    *) eval "$_p=ask" ;;
   esac
 done
 unset _p

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -83,37 +83,70 @@ BYPASS=0
 #                                 restore --staged <path>, etc. No gate.
 #
 #   2. SOFT-GATE (this section) — policy-controlled, bypass-token-able.
-#                                 Two independent vars cover the two
-#                                 risk categories:
-#                                   COLLAB_POLICY: push, amend, pr create
-#                                     (affects shared state, reversible
-#                                     via force-push / amend back / PR close)
-#                                   DESTRUCTIVE_POLICY: checkout -- <path…>,
-#                                     restore <path…>
-#                                     (path-scoped local data loss — one
-#                                     file, multiple files, a directory,
-#                                     or any explicit pathset; smaller
-#                                     blast radius than whole-worktree
-#                                     wipes which use `.` / `./` / `:/`)
+#                                 Per-op collab policies (v4.5.2+):
+#                                   PUSH_POLICY:       git push
+#                                   AMEND_POLICY:      git commit --amend
+#                                   PR_CREATE_POLICY:  gh pr create
+#                                 plus DESTRUCTIVE_POLICY for path-scoped
+#                                 local data loss (checkout -- <path>,
+#                                 restore <path>; smaller blast radius
+#                                 than whole-worktree wipes `.` / `:/`).
+#
+#                                 Back-compat: legacy
+#                                 LEAN4_GUARDRAILS_COLLAB_POLICY is
+#                                 honored as the fallback for any per-op
+#                                 collab policy that isn't explicitly
+#                                 set (so users who set
+#                                 COLLAB_POLICY=allow / =block keep
+#                                 their existing semantics).
 #
 #   3. HARD-BLOCK (below)       — non-bypassable, no policy override.
 #                                 reset --hard, clean -f/-fd/-fdx,
-#                                 checkout ., restore ., checkout -- .
-#                                 The blast radius is unbounded and
-#                                 git reflog can't recover uncommitted
-#                                 edits (and can't recover untracked
-#                                 files via clean -f at all).
+#                                 checkout ., restore ., checkout -- .,
+#                                 AND (v4.5.2+) push --force /
+#                                 --force-with-lease / --mirror /
+#                                 --delete / `<remote> :<ref>` ref-delete
+#                                 syntax. Blast radius is unbounded; for
+#                                 force-push it's shared-history rewrite
+#                                 (not just local). Escape hatch:
+#                                 LEAN4_GUARDRAILS_DISABLE=1 for that
+#                                 specific command.
 #
-# Each soft-gate policy independently accepts ask | allow | block:
-#   ask:   require human confirmation via one-shot bypass token (default)
-#   allow: permit without bypass token (user explicitly opted in)
-#   block: block even with bypass token (extra paranoia)
+# Each soft-gate policy independently accepts host | ask | allow | block:
+#   host:  exit 0 — defer to Claude Code's native Bash permission rule
+#          (recommended default; lets Claude Code "ask once, remember").
+#   ask:   require human confirmation via one-shot bypass token.
+#   allow: permit without bypass token (user explicitly opted in).
+#   block: block even with bypass token (extra paranoia).
 
-COLLAB_POLICY="${LEAN4_GUARDRAILS_COLLAB_POLICY:-ask}"
-case "$COLLAB_POLICY" in
-  ask|allow|block) ;;
-  *) COLLAB_POLICY="ask" ;;
-esac
+## Per-op collab policies (v4.5.2+).
+#
+# Each soft-gated collaboration op (push, --amend, gh pr create) has its
+# own policy var, accepting `host` | `ask` | `allow` | `block`. Defaults
+# are `host`, which means the hook exits 0 and Claude Code's native
+# `Bash(...)` permission rule handles the "ask once, remember" UX
+# instead of the hook fighting it with exit-2 + bypass-token retries.
+#
+# Back-compat: LEAN4_GUARDRAILS_COLLAB_POLICY (the legacy bundled var)
+# is honored as the fallback for any per-op policy that isn't explicitly
+# set. So users who already configured COLLAB_POLICY=allow / =block keep
+# their existing semantics on the soft-gate path; new users get the
+# `host` default automatically.
+COLLAB_POLICY="${LEAN4_GUARDRAILS_COLLAB_POLICY:-}"
+PUSH_POLICY="${LEAN4_GUARDRAILS_PUSH_POLICY:-${COLLAB_POLICY:-host}}"
+PR_CREATE_POLICY="${LEAN4_GUARDRAILS_PR_CREATE_POLICY:-${COLLAB_POLICY:-host}}"
+AMEND_POLICY="${LEAN4_GUARDRAILS_AMEND_POLICY:-${COLLAB_POLICY:-host}}"
+# Validate each; invalid → fall back to `host` (the friendly default).
+# Bash 3.2 doesn't support `${!_p}`-style indirect assignment universally,
+# so use eval to write back the validated value.
+for _p in PUSH_POLICY PR_CREATE_POLICY AMEND_POLICY; do
+  eval "_val=\$$_p"
+  case "$_val" in
+    host|ask|allow|block) ;;
+    *) eval "$_p=host" ;;
+  esac
+done
+unset _p _val
 
 DESTRUCTIVE_POLICY="${LEAN4_GUARDRAILS_DESTRUCTIVE_POLICY:-ask}"
 case "$DESTRUCTIVE_POLICY" in
@@ -418,16 +451,16 @@ done
 # $1 = short label (e.g. "git push")
 # $2 = user-facing message suffix
 _check_collab_op() {
-  local label="$1" msg="$2"
-  case "$COLLAB_POLICY" in
-    allow) return 0 ;;
+  local label="$1" msg="$2" policy_value="$3"
+  case "$policy_value" in
+    host|allow) return 0 ;;          # exit 0 — host: let Claude Code decide; allow: just pass.
     block)
-      echo "BLOCKED (Lean guardrail): $label - $msg [collab_policy=block]" >&2
+      echo "BLOCKED (Lean guardrail): $label - $msg [policy=block]" >&2
       exit 2
       ;;
-    *)  # ask (default): confirmation-gated; bypass is the one-time confirmed rerun path
+    *)  # ask: bypass-token-gated. Same UX as v4.5.1: confirm then rerun with the bypass prefix.
       if [[ $BYPASS -ne 1 ]]; then
-        echo "BLOCKED (Lean guardrail): $label - $msg [collab_policy=ask, confirm then rerun]" >&2
+        echo "BLOCKED (Lean guardrail): $label - $msg [policy=ask, confirm then rerun]" >&2
         echo "  To proceed once, prefix with: LEAN4_GUARDRAILS_BYPASS=1" >&2
         exit 2
       fi
@@ -485,17 +518,17 @@ _check_destructive_op() {
 
 # Block git push (not --dry-run, not stash push — exemptions scoped per-segment)
 if seg_match git '[[:space:]]push([[:space:]]|$)' '--dry-run\b|\bstash\b.*\bpush\b'; then
-  _check_collab_op "git push" "use /lean4:checkpoint, then push manually"
+  _check_collab_op "git push" "use /lean4:checkpoint, then push manually" "$PUSH_POLICY"
 fi
 
 # Block git commit --amend
 if seg_match git '\bcommit\b.*--amend\b'; then
-  _check_collab_op "git commit --amend" "proving workflow creates new commits for safe rollback"
+  _check_collab_op "git commit --amend" "proving workflow creates new commits for safe rollback" "$AMEND_POLICY"
 fi
 
 # Block gh pr create
 if seg_match gh '\bpr\b.*\bcreate\b'; then
-  _check_collab_op "gh pr create" "review first, then create PR manually"
+  _check_collab_op "gh pr create" "review first, then create PR manually" "$PR_CREATE_POLICY"
 fi
 
 # ---------------------------------------------------------------------------

--- a/plugins/lean4/hooks/guardrails.sh
+++ b/plugins/lean4/hooks/guardrails.sh
@@ -516,6 +516,53 @@ _check_destructive_op() {
 
 # --- Collaboration ops (policy-controlled) ---
 
+# Tier-3 hard-blocks for push variants that aren't ordinary feature-branch
+# upstream pushes. These rewrite shared history (force / force-with-lease),
+# delete refs (--delete, -d, `<remote> :<ref>` legacy syntax), or wipe all
+# refs (--mirror). Non-bypassable, no policy override — matching the
+# `git reset --hard` / `git clean -f` posture. Escape hatch:
+# LEAN4_GUARDRAILS_DISABLE=1 for the specific command.
+#
+# Ordering: these run BEFORE the soft-gate _check_collab_op call below
+# so that PUSH_POLICY=allow cannot unlock them.
+#
+# Standard exemptions (--dry-run, stash push) apply to all of these
+# via the seg_match exemption arg.
+_push_exempt='\bstash\b.*\bpush\b|--dry-run\b'
+
+# `--force` / `-f` (plain force-push; rewrites remote history)
+if seg_match git '\bpush\b.*\s(-f|--force)(\s|$)' "$_push_exempt"; then
+  echo "BLOCKED (Lean guardrail): git push --force / -f rewrites shared history. Non-bypassable. Escape hatch: LEAN4_GUARDRAILS_DISABLE=1 for this command." >&2
+  exit 2
+fi
+
+# `--force-with-lease[=ref]` (safer force-push, but still history-rewriting)
+if seg_match git '\bpush\b.*\s--force-with-lease(=|\s|$)' "$_push_exempt"; then
+  echo "BLOCKED (Lean guardrail): git push --force-with-lease rewrites shared history. Non-bypassable. Escape hatch: LEAN4_GUARDRAILS_DISABLE=1 for this command." >&2
+  exit 2
+fi
+
+# `--mirror` (replicates all refs from local to remote — destructive on the remote)
+if seg_match git '\bpush\b.*\s--mirror(\s|$)' "$_push_exempt"; then
+  echo "BLOCKED (Lean guardrail): git push --mirror replicates all refs to the remote, deleting any not present locally. Non-bypassable. Escape hatch: LEAN4_GUARDRAILS_DISABLE=1 for this command." >&2
+  exit 2
+fi
+
+# `--delete` / `-d` (delete remote ref)
+if seg_match git '\bpush\b.*\s(--delete|-d)(\s|$)' "$_push_exempt"; then
+  echo "BLOCKED (Lean guardrail): git push --delete / -d removes a remote ref. Non-bypassable. Escape hatch: LEAN4_GUARDRAILS_DISABLE=1 for this command." >&2
+  exit 2
+fi
+
+# Legacy delete-ref syntax: `git push <remote> :<ref>` (the leading `:` on a
+# pathspec-shaped token, after `push`, means "delete the named ref").
+# Requires a non-empty ref name after `:` to avoid matching `:` as a literal
+# pathspec separator in other tokens.
+if seg_match git '\bpush\b.*\s:[A-Za-z0-9_./-]+(\s|$)' "$_push_exempt"; then
+  echo "BLOCKED (Lean guardrail): git push <remote> :<ref> (legacy ref-delete syntax) removes a remote ref. Non-bypassable. Use git push --delete to be explicit, or LEAN4_GUARDRAILS_DISABLE=1 for this command." >&2
+  exit 2
+fi
+
 # Block git push (not --dry-run, not stash push — exemptions scoped per-segment)
 if seg_match git '[[:space:]]push([[:space:]]|$)' '--dry-run\b|\bstash\b.*\bpush\b'; then
   _check_collab_op "git push" "use /lean4:checkpoint, then push manually" "$PUSH_POLICY"

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -492,7 +492,7 @@ run_test_policy "block: reset --hard (still block)"     block "git reset --hard"
 
 echo ""
 echo "-- Collaboration policy: invalid/default --"
-run_test_policy "invalid: yolo push (falls back to host)" yolo "git push origin main"           0
+run_test_policy "invalid: yolo push (invalid → ask fallback, blocks)" yolo "git push origin main"           2
 run_test_policy "invalid: yolo bypass push (allow=ask)" yolo "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"   0
 run_test_policy "unset: plain push (host default)"      ""   "git push origin main"           0
 run_test_policy "unset: bypass push (allow=ask)"        ""   "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"   0
@@ -505,7 +505,8 @@ run_test_op_policy "PUSH_POLICY=ask: plain push (block)"          PUSH_POLICY as
 run_test_op_policy "PUSH_POLICY=ask: bypass push (allow)"         PUSH_POLICY ask   "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"  0
 run_test_op_policy "PUSH_POLICY=block: plain push (block)"        PUSH_POLICY block "git push origin main"     2
 run_test_op_policy "PUSH_POLICY=block: bypass push (still block)" PUSH_POLICY block "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"  2
-run_test_op_policy "PUSH_POLICY=yolo: plain push (host fallback)" PUSH_POLICY yolo  "git push origin main"     0
+run_test_op_policy "PUSH_POLICY=yolo: plain push (invalid → ask fallback, blocks)" PUSH_POLICY yolo  "git push origin main"     2
+run_test_op_policy "PUSH_POLICY=yolo: bypass push (invalid → ask + bypass, allows)" PUSH_POLICY yolo "LEAN4_GUARDRAILS_BYPASS=1 git push origin main" 0
 run_test_op_policy "PUSH_POLICY=host: push -u origin feat"        PUSH_POLICY host  "git push -u origin feat"  0
 run_test_op_policy "PUSH_POLICY=ask: push -u origin feat (block)" PUSH_POLICY ask   "git push -u origin feat"  2
 

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -11,11 +11,18 @@ PASS=0
 FAIL=0
 
 # Run a test case.  $1=description  $2=command  $3=expected exit code (0 or 2)
+#
+# Pins LEAN4_GUARDRAILS_COLLAB_POLICY=ask so the legacy soft-gate
+# behavior (block until bypass) is the test baseline. Without this,
+# the v4.5.2 default of `host` (exit 0; let Claude Code ask) would
+# make every collab-op test trivially pass with the wrong intent.
+# Per-op policy tests (run_test_policy, run_test_op_policy) override
+# this on a per-call basis.
 run_test() {
   local desc="$1" cmd="$2" expected="$3" actual
   actual=0
   echo "{\"tool_input\":{\"command\":$(printf '%s' "$cmd" | jq -Rs .)}}" \
-    | LEAN4_GUARDRAILS_FORCE=1 bash "$HOOK" >/dev/null 2>&1 || actual=$?
+    | LEAN4_GUARDRAILS_FORCE=1 LEAN4_GUARDRAILS_COLLAB_POLICY=ask bash "$HOOK" >/dev/null 2>&1 || actual=$?
   if [[ "$actual" -eq "$expected" ]]; then
     echo "  PASS: $desc"
     (( ++PASS ))
@@ -420,7 +427,7 @@ run_test_destructive_policy "bypass git clean -fd             (still block)" all
 echo ""
 echo "-- Policy independence: COLLAB and DESTRUCTIVE govern separately --"
 # DESTRUCTIVE_POLICY=allow doesn't unblock collab ops; COLLAB_POLICY=allow doesn't unblock destructive ops.
-run_test_destructive_policy "allow: git push (still block — collab governs)" allow "git push origin main"                              2
+run_test_destructive_policy "allow: git push (collab default host → allow)" allow "git push origin main"                              0
 run_test_policy "allow: checkout -- file (still block — destructive governs)" allow "git checkout -- file.lean"                       2
 run_test_policy "allow: restore file (still block — destructive governs)"    allow "git restore file.lean"                            2
 
@@ -459,9 +466,9 @@ run_test_policy "block: reset --hard (still block)"     block "git reset --hard"
 
 echo ""
 echo "-- Collaboration policy: invalid/default --"
-run_test_policy "invalid: yolo push (block=ask)"        yolo "git push origin main"           2
+run_test_policy "invalid: yolo push (falls back to host)" yolo "git push origin main"           0
 run_test_policy "invalid: yolo bypass push (allow=ask)" yolo "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"   0
-run_test_policy "unset: plain push (block=ask)"         ""   "git push origin main"           2
+run_test_policy "unset: plain push (host default)"      ""   "git push origin main"           0
 run_test_policy "unset: bypass push (allow=ask)"        ""   "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"   0
 
 echo ""

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -569,6 +569,36 @@ run_test_op_policy "PUSH_POLICY=allow: push --dry-run (exempt)"        PUSH_POLI
 run_test_op_policy "PUSH_POLICY=allow: push --tags (not force)"        PUSH_POLICY allow "git push --tags origin main"    0
 
 echo ""
+echo "-- Bundled short flags and +-refspec push hard-blocks --"
+# Bundled -f short flags: -fu, -uf, -vfu, etc. — any single-dash run containing `f`.
+run_test "git push -fu origin main                (always block)" "git push -fu origin main"                  2
+run_test "git push -uf origin main                (always block)" "git push -uf origin main"                  2
+run_test "git push -vfu origin main               (always block)" "git push -vfu origin main"                 2
+run_test "git push -fnq origin main               (always block, bundled -n doesn't exempt)" "git push -fnq origin main" 2
+# Bundled -d short flags: -dn, -nd, -vd, etc.
+run_test "git push -dn origin feat                (always block)" "git push -dn origin feat"                  2
+run_test "git push -nd origin feat                (always block)" "git push -nd origin feat"                  2
+run_test "git push -vd origin feat                (always block)" "git push -vd origin feat"                  2
+# Leading-+ force-refspec: +HEAD:main, +main, +src:dst.
+run_test "git push origin +HEAD:main              (always block)" "git push origin +HEAD:main"                2
+run_test "git push origin +main                   (always block)" "git push origin +main"                     2
+run_test "git push origin +refs/heads/feat:refs/heads/main (always block)" "git push origin +refs/heads/feat:refs/heads/main" 2
+# Non-bypassable even with PUSH_POLICY=allow + bypass.
+run_test_op_policy "PUSH_POLICY=allow: -fu still blocks" PUSH_POLICY allow "git push -fu origin main"   2
+run_test_op_policy "PUSH_POLICY=allow: -dn still blocks" PUSH_POLICY allow "git push -dn origin feat"   2
+run_test_op_policy "PUSH_POLICY=allow: +HEAD:main still blocks" PUSH_POLICY allow "git push origin +HEAD:main" 2
+run_test "bypass git push -fu origin main         (still block)" "LEAN4_GUARDRAILS_BYPASS=1 git push -fu origin main" 2
+run_test "bypass git push origin +main            (still block)" "LEAN4_GUARDRAILS_BYPASS=1 git push origin +main"   2
+# Negative controls: ordinary short-flag bundles without f/d must NOT hard-block.
+run_test_op_policy "PUSH_POLICY=allow: -uv (verbose+upstream)"  PUSH_POLICY allow "git push -uv origin feat"  0
+run_test_op_policy "PUSH_POLICY=allow: -uvq (multi non-force)"  PUSH_POLICY allow "git push -uvq origin feat" 0
+run_test_op_policy "PUSH_POLICY=allow: -n alone (dry-run)"      PUSH_POLICY allow "git push -n origin main"   0
+# Negative control: colon refspec WITHOUT leading + must NOT match the +-refspec regex.
+run_test_op_policy "PUSH_POLICY=allow: src:dst refspec (no +)"  PUSH_POLICY allow "git push origin main:feat" 0
+# Negative control: --dry-run with long-form force does exempt (back-compat).
+run_test_op_policy "PUSH_POLICY=allow: --force --dry-run (exempt)" PUSH_POLICY allow "git push --force --dry-run origin main" 0
+
+echo ""
 echo "-- Lean script stderr-suppression detector: \$LEAN4_SCRIPTS paths --"
 run_test "\$LEAN4_SCRIPTS/cycle_tracker.sh 2>/dev/null (block)"  'bash "$LEAN4_SCRIPTS/cycle_tracker.sh" tick 2>/dev/null'    2
 run_test "\${LEAN4_SCRIPTS}/sorry_analyzer.py 2>/dev/null (block)" 'python3 "${LEAN4_SCRIPTS}/sorry_analyzer.py" . 2>/dev/null' 2

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -52,6 +52,32 @@ run_test_policy() {
   fi
 }
 
+# Run a test with a specific per-op collab policy variable set (v4.5.2+).
+# $1=desc  $2=env var name (PUSH_POLICY|AMEND_POLICY|PR_CREATE_POLICY)
+# $3=value (host|ask|allow|block|"" for unset)  $4=command  $5=expected exit
+#
+# Unlike run_test_policy (which sets the legacy COLLAB_POLICY var), this
+# helper sets one per-op var while leaving the others (and COLLAB_POLICY)
+# unset — so it exercises the per-op default-to-host behavior on the
+# other ops while testing the targeted op's specific policy value.
+run_test_op_policy() {
+  local desc="$1" var_name="$2" value="$3" cmd="$4" expected="$5" actual
+  actual=0
+  local policy_env=()
+  if [[ -n "$value" ]]; then
+    policy_env=("LEAN4_GUARDRAILS_${var_name}=${value}")
+  fi
+  echo "{\"tool_input\":{\"command\":$(printf '%s' "$cmd" | jq -Rs .)}}" \
+    | env LEAN4_GUARDRAILS_FORCE=1 "${policy_env[@]}" bash "$HOOK" >/dev/null 2>&1 || actual=$?
+  if [[ "$actual" -eq "$expected" ]]; then
+    echo "  PASS: $desc"
+    (( ++PASS ))
+  else
+    echo "  FAIL: $desc (expected exit $expected, got $actual)"
+    (( ++FAIL ))
+  fi
+}
+
 # Run a test with a specific destructive policy (path-scoped destructive ops).
 # $1=desc  $2=policy value (ask|allow|block|"" for unset)  $3=command  $4=expected exit
 run_test_destructive_policy() {
@@ -470,6 +496,77 @@ run_test_policy "invalid: yolo push (falls back to host)" yolo "git push origin 
 run_test_policy "invalid: yolo bypass push (allow=ask)" yolo "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"   0
 run_test_policy "unset: plain push (host default)"      ""   "git push origin main"           0
 run_test_policy "unset: bypass push (allow=ask)"        ""   "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"   0
+
+echo ""
+echo "-- Per-op collab policies: PUSH_POLICY (v4.5.2+) --"
+run_test_op_policy "PUSH_POLICY=host: plain push (exit 0)"        PUSH_POLICY host  "git push origin main"     0
+run_test_op_policy "PUSH_POLICY=allow: plain push (exit 0)"       PUSH_POLICY allow "git push origin main"     0
+run_test_op_policy "PUSH_POLICY=ask: plain push (block)"          PUSH_POLICY ask   "git push origin main"     2
+run_test_op_policy "PUSH_POLICY=ask: bypass push (allow)"         PUSH_POLICY ask   "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"  0
+run_test_op_policy "PUSH_POLICY=block: plain push (block)"        PUSH_POLICY block "git push origin main"     2
+run_test_op_policy "PUSH_POLICY=block: bypass push (still block)" PUSH_POLICY block "LEAN4_GUARDRAILS_BYPASS=1 git push origin main"  2
+run_test_op_policy "PUSH_POLICY=yolo: plain push (host fallback)" PUSH_POLICY yolo  "git push origin main"     0
+run_test_op_policy "PUSH_POLICY=host: push -u origin feat"        PUSH_POLICY host  "git push -u origin feat"  0
+run_test_op_policy "PUSH_POLICY=ask: push -u origin feat (block)" PUSH_POLICY ask   "git push -u origin feat"  2
+
+echo ""
+echo "-- Per-op collab policies: AMEND_POLICY --"
+run_test_op_policy "AMEND_POLICY=host: amend (exit 0)"     AMEND_POLICY host  "git commit --amend -m x"  0
+run_test_op_policy "AMEND_POLICY=ask: amend (block)"       AMEND_POLICY ask   "git commit --amend -m x"  2
+run_test_op_policy "AMEND_POLICY=allow: amend (exit 0)"    AMEND_POLICY allow "git commit --amend -m x"  0
+run_test_op_policy "AMEND_POLICY=block: amend (block)"     AMEND_POLICY block "git commit --amend -m x"  2
+
+echo ""
+echo "-- Per-op collab policies: PR_CREATE_POLICY --"
+run_test_op_policy "PR_CREATE_POLICY=host: gh pr create (exit 0)"  PR_CREATE_POLICY host  "gh pr create --title t --body b" 0
+run_test_op_policy "PR_CREATE_POLICY=ask: gh pr create (block)"    PR_CREATE_POLICY ask   "gh pr create --title t --body b" 2
+run_test_op_policy "PR_CREATE_POLICY=allow: gh pr create (exit 0)" PR_CREATE_POLICY allow "gh pr create --title t --body b" 0
+run_test_op_policy "PR_CREATE_POLICY=block: gh pr create (block)"  PR_CREATE_POLICY block "gh pr create --title t --body b" 2
+
+echo ""
+echo "-- Per-op vs legacy COLLAB_POLICY: per-op wins --"
+# COLLAB_POLICY=block should propagate to ops without explicit per-op overrides;
+# explicit per-op overrides win.
+run_test_op_policy "COLLAB=block + PUSH_POLICY=host: push (exit 0)" PUSH_POLICY host "git push origin main" 0
+# When COLLAB is set (back-compat) and a per-op is also set, the per-op wins.
+# Simulating that requires setting both env vars; use a direct hook call.
+desc="COLLAB=block + PUSH=host: push exits 0 (per-op wins)"
+actual=0
+echo "{\"tool_input\":{\"command\":$(printf '%s' "git push origin main" | jq -Rs .)}}" \
+  | env LEAN4_GUARDRAILS_FORCE=1 LEAN4_GUARDRAILS_COLLAB_POLICY=block LEAN4_GUARDRAILS_PUSH_POLICY=host bash "$HOOK" >/dev/null 2>&1 || actual=$?
+if [[ "$actual" -eq 0 ]]; then echo "  PASS: $desc"; (( ++PASS )); else echo "  FAIL: $desc (expected 0, got $actual)"; (( ++FAIL )); fi
+# Inverse: COLLAB=allow with PUSH=block → push blocks (per-op wins).
+desc="COLLAB=allow + PUSH=block: push blocks (per-op wins)"
+actual=0
+echo "{\"tool_input\":{\"command\":$(printf '%s' "git push origin main" | jq -Rs .)}}" \
+  | env LEAN4_GUARDRAILS_FORCE=1 LEAN4_GUARDRAILS_COLLAB_POLICY=allow LEAN4_GUARDRAILS_PUSH_POLICY=block bash "$HOOK" >/dev/null 2>&1 || actual=$?
+if [[ "$actual" -eq 2 ]]; then echo "  PASS: $desc"; (( ++PASS )); else echo "  FAIL: $desc (expected 2, got $actual)"; (( ++FAIL )); fi
+# AMEND should still respect COLLAB=block via fallback when no AMEND override.
+desc="COLLAB=block + PUSH=host: amend still blocks (AMEND fallback to block)"
+actual=0
+echo "{\"tool_input\":{\"command\":$(printf '%s' "git commit --amend -m x" | jq -Rs .)}}" \
+  | env LEAN4_GUARDRAILS_FORCE=1 LEAN4_GUARDRAILS_COLLAB_POLICY=block LEAN4_GUARDRAILS_PUSH_POLICY=host bash "$HOOK" >/dev/null 2>&1 || actual=$?
+if [[ "$actual" -eq 2 ]]; then echo "  PASS: $desc"; (( ++PASS )); else echo "  FAIL: $desc (expected 2, got $actual)"; (( ++FAIL )); fi
+
+echo ""
+echo "-- Tier-3 push-variant hard-blocks (v4.5.2+): always exit 2, non-bypassable --"
+run_test "git push --force                       (always block)" "git push --force origin main"              2
+run_test "git push -f                            (always block)" "git push -f origin main"                   2
+run_test "git push --force-with-lease            (always block)" "git push --force-with-lease origin main"   2
+run_test "git push --force-with-lease=ref        (always block)" "git push --force-with-lease=ref origin main" 2
+run_test "git push --mirror                      (always block)" "git push --mirror origin"                  2
+run_test "git push --delete                      (always block)" "git push --delete origin feat"             2
+run_test "git push -d                            (always block)" "git push -d origin feat"                   2
+run_test "git push origin :feat (legacy delete)  (always block)" "git push origin :feat"                     2
+# Non-bypassable even with allow / bypass / DISABLE-not-set.
+run_test_op_policy "PUSH_POLICY=allow: --force still blocks" PUSH_POLICY allow "git push --force origin main" 2
+run_test_op_policy "PUSH_POLICY=allow: --mirror still blocks" PUSH_POLICY allow "git push --mirror origin"   2
+run_test "bypass git push --force                (still block)" "LEAN4_GUARDRAILS_BYPASS=1 git push --force origin main" 2
+run_test "bypass git push :feat                  (still block)" "LEAN4_GUARDRAILS_BYPASS=1 git push origin :feat" 2
+# Negative controls: ordinary push variants must NOT match the hard-block regexes.
+run_test_op_policy "PUSH_POLICY=allow: push -u origin feat (no force)" PUSH_POLICY allow "git push -u origin feat" 0
+run_test_op_policy "PUSH_POLICY=allow: push --dry-run (exempt)"        PUSH_POLICY allow "git push --dry-run origin main" 0
+run_test_op_policy "PUSH_POLICY=allow: push --tags (not force)"        PUSH_POLICY allow "git push --tags origin main"    0
 
 echo ""
 echo "-- Lean script stderr-suppression detector: \$LEAN4_SCRIPTS paths --"

--- a/plugins/lean4/tools/lint_docs.sh
+++ b/plugins/lean4/tools/lint_docs.sh
@@ -782,10 +782,13 @@ check_guardrail_impl() {
     if ! grep -q 'LEAN4_GUARDRAILS_COLLAB_POLICY' "$_gi_file" 2>/dev/null; then
         warn "guardrails.sh: Missing LEAN4_GUARDRAILS_COLLAB_POLICY support"
     fi
-    # Per-op policies (v4.5.2+) must fall back to `host` on invalid values.
-    # The fallback line is the `eval "$_p=host"` inside the validation loop.
-    if ! grep -qE 'eval "\$_p=host"' "$_gi_file" 2>/dev/null; then
-        warn "guardrails.sh: Missing invalid-policy fallback to host for per-op collab policies"
+    # Per-op policies (v4.5.2+) must fall back to `ask` on invalid values
+    # (typos are safer-blocked than silently-relaxed). The fallback line is
+    # the `eval "$_p=ask"` inside the validation loop. Note: UNSET vars
+    # resolve to `host` via the parameter-expansion chain above the loop,
+    # so a missing var ≠ an invalid one.
+    if ! grep -qE 'eval "\$_p=ask"' "$_gi_file" 2>/dev/null; then
+        warn "guardrails.sh: Missing invalid-policy fallback to ask for per-op collab policies"
     fi
     # At least 1 bypass hint in collaboration helper
     local _gi_hint_count

--- a/plugins/lean4/tools/lint_docs.sh
+++ b/plugins/lean4/tools/lint_docs.sh
@@ -782,9 +782,10 @@ check_guardrail_impl() {
     if ! grep -q 'LEAN4_GUARDRAILS_COLLAB_POLICY' "$_gi_file" 2>/dev/null; then
         warn "guardrails.sh: Missing LEAN4_GUARDRAILS_COLLAB_POLICY support"
     fi
-    # Invalid policy must fall back to ask (the *) default case)
-    if ! grep -qE 'COLLAB_POLICY="ask"' "$_gi_file" 2>/dev/null; then
-        warn "guardrails.sh: Missing invalid-policy fallback to ask"
+    # Per-op policies (v4.5.2+) must fall back to `host` on invalid values.
+    # The fallback line is the `eval "$_p=host"` inside the validation loop.
+    if ! grep -qE 'eval "\$_p=host"' "$_gi_file" 2>/dev/null; then
+        warn "guardrails.sh: Missing invalid-policy fallback to host for per-op collab policies"
     fi
     # At least 1 bypass hint in collaboration helper
     local _gi_hint_count


### PR DESCRIPTION
## Summary

Redesigns how `plugins/lean4/hooks/guardrails.sh` handles `git push`, `git commit --amend`, and `gh pr create` so the hook stops fighting Claude Code's native `Bash(...)` permission UX. Adds a new `host` policy mode (exit 0; defer to Claude Code), splits the legacy single `LEAN4_GUARDRAILS_COLLAB_POLICY` knob into three per-op env vars, and adds tier-3 hard-blocks for dangerous push variants (`--force`, `--force-with-lease`, `--mirror`, `--delete`, legacy `:<ref>`) that were previously falling through the soft-gate.

Plus folds three previously-merged-but-unversioned PRs (#137/#138/#139) into the v4.5.2 CHANGELOG entry.

Off `feat/collab-host-mode` from `origin/main` (`f42eda7`, post-#139). Nine focused commits, **patch bump 4.5.1 → 4.5.2**.

## Commits

1. **`feat(guardrails)`** (`de57f8a`) — host mode + per-op policy split. New env vars `LEAN4_GUARDRAILS_{PUSH,AMEND,PR_CREATE}_POLICY`, each `host` | `ask` | `allow` | `block`, default `host`. `_check_collab_op` extended to take a policy-value arg; `host` joins `allow` on the exit-0 path. Legacy `COLLAB_POLICY` honored as fallback for any per-op policy that isn't explicitly set.

2. **`feat(guardrails)`** (`731c84e`) — tier-3 push-variant hard-blocks. Non-bypassable, no policy override, ordered BEFORE the soft-gate so `PUSH_POLICY=allow` can't unlock them. Covers `--force` / `-f`, `--force-with-lease[=…]`, `--mirror`, `--delete` / `-d`, legacy `<remote> :<ref>` syntax. `LEAN4_GUARDRAILS_DISABLE=1` is the per-command escape hatch; `--dry-run` and `git stash push` still exempted.

3. **`test(guardrails)`** (`d6e88cf`) — +36 probes (270 → 306). New `run_test_op_policy` helper for per-op vars. Coverage matrix: each per-op policy × {host, ask, allow, block, yolo-fallback} × representative commands; per-op vs legacy `COLLAB_POLICY` interaction (per-op wins); all 8 push-variant hard-blocks confirmed non-bypassable even with `PUSH_POLICY=allow` and `BYPASS=1`; negative controls (`push -u origin feat`, `--dry-run`, `--tags`) confirm no false-matches.

4. **`docs(guardrails)`** (`788f936`) — README env-var table + new per-op policies subsection + push-variant hard-block list with recommended `.claude/settings.local.json` snippet (`Bash(git push *)` → `ask`); MIGRATION.md V4.5.1 → V4.5.2 walkthrough with the back-compat decision tree. `lint_docs.sh` "invalid-policy fallback" check updated to assert the new per-op validation loop's `eval "$_p=host"` line (was checking the legacy `COLLAB_POLICY="ask"` line).

5. **`release`** (`96620de`) — `plugin.json` + `marketplace.json` 4.5.1 → 4.5.2; CHANGELOG entry covering this PR's primary content **plus folding in #137 / #138 / #139** (each previously merged with "no version bump" framing), so future archeology against `git log` reads cleanly.

6. **`fix(guardrails)`** (`a362d87`) — shellcheck cleanup. Refactors the per-op validation loop to use `${!_p}` indirect expansion directly in the `case` statement instead of `eval "_val=\$$_p"; case "$_val"`, silencing shellcheck SC2154 (`_val` referenced but not assigned). Bash 3.2+ compatible. Behavior unchanged.

7. **`fix(guardrails)`** (`e858e30`) — closes a reviewer-flagged gap in commit 2's push-variant hard-blocks. The v1 regexes only caught exact `-f` / `-d` tokens and the long flags, letting these slip through under `PUSH_POLICY=allow`:
   - `git push -fu origin main` (bundled force + upstream)
   - `git push -uf origin main`, `-vfu`, `-fnq` (bundled in any order)
   - `git push -dn origin feat` (bundled delete + dry-run)
   - `git push -nd origin feat`, `-vd` (bundled in any order)
   - `git push origin +HEAD:main`, `+main`, `+src:dst` (leading-+ force-refspec)

   Updates the force regex to `\s(--force|-[A-Za-z]*f[A-Za-z]*)(\s|$)` (single-dash bundle containing `f`), the delete regex similarly, and adds a new check for leading-`+` refspec tokens. Bundled `-n` (short dry-run) is intentionally NOT added to the exemption — bundled-force-with-dry-run signals force intent the hook flags regardless. The long-form `--dry-run` exemption stays for back-compat. +20 probes (306 → 326): 11 positive coverage (all bundled + `+`-refspec forms under `PUSH_POLICY=allow` and `BYPASS=1`), 9 negative (`-uv`, `-uvq`, `-n` alone, `main:feat` without `+`, `--force --dry-run` long-form exemption all stay exit 0).

8. **`fix(guardrails)`** (`bb97cec`) — closes the reviewer-flagged semantic concern: **explicitly invalid policy values now fall back to `ask`, not `host`.** The earlier shape conflated "unset" and "set-but-invalid" both under `host`, which meant `LEAN4_GUARDRAILS_PUSH_POLICY=alow` (typo) silently relaxed the guardrail. Now:
   - UNSET → `host` (friendly default for new users; unchanged).
   - SET-BUT-INVALID → `ask` (typo blocks until bypass).

   `lint_docs.sh` regression check updated to assert the `ask` fallback line. Test probes updated: yolo cases now expect exit 2; added a paired bypass probe confirming `BYPASS=1` still allows a one-shot push through a typo'd config.

9. **`docs(guardrails)`** (`337fb67`) — closes the reviewer-flagged docs gap: the recommended `.claude/settings.local.json` snippet now includes the exact-form rule alongside the prefix-form for each op:

   ```json
   "ask": [
     "Bash(git push)",
     "Bash(git push *)",
     "Bash(gh pr create)",
     "Bash(gh pr create *)",
     "Bash(git commit --amend)",
     "Bash(git commit --amend *)"
   ]
   ```

   Per Claude Code's permission docs, `Bash(<cmd> *)` only matches `<cmd> <something>` (the space before `*` is required), not bare `<cmd>`. Without the exact-form rule, `git push` with no args (upstream-already-set, very common) slipped through unprompted. Both README and MIGRATION snippets updated with a paragraph explaining why both forms are needed.

## Test plan

- [x] **Local matrix:** `bash plugins/lean4/tests/test_guardrails.sh` — 327/327 (up from 270; +57 new probes across commits 3, 7, and 8).
- [x] **lint_docs.sh:** marketplace-version match green; 4 remaining warnings are preexisting on main (line-length flags + host-agnostic SKILL.md flag), unrelated to this PR.
- [x] **End-to-end sanity:** simulated the hook against representative commands via the test harness:
  - `git push origin main` with all env vars unset → exit 0 (host default).
  - `git push origin main` with `LEAN4_GUARDRAILS_PUSH_POLICY=ask` (no bypass) → exit 2.
  - `git push --force origin main` with `PUSH_POLICY=allow` → exit 2 (hard-block wins).
  - `LEAN4_GUARDRAILS_BYPASS=1 git push --force origin main` → exit 2 (non-bypassable).
  - `LEAN4_GUARDRAILS_COLLAB_POLICY=allow git push origin main` (per-op vars unset) → exit 0 (back-compat fallback).
- [x] **CI:** macos-bash3 + mypy + ruff + shellcheck stay green.
- [x] **Manual sandbox smoke (recommended before merge):** install the PR build in Claude Code, run `git push origin <feat>` and verify the prompt is Claude Code's native permission dialog (not the hook's exit-2 BLOCKED message). Then try `git push --force origin <feat>` and verify the hard-block message fires. CI cannot cover this.

## Out of scope (deferred)

- `lean4-skills-push` wrapper with richer preflight (ahead-commits, default-branch warning, `--dry-run`). Follow-up PR.
- Shipping plugin-default `permissions` JSON via the plugin manifest (Claude Code plugin format support uncertain).
- A separate `LEAN4_GUARDRAILS_FORCE_PUSH_POLICY` env var (user chose to hard-block `--force-with-lease` uniformly).
