### PR TITLE
docs(skill): reframe "Never" rules in SKILL.md to lead with imperative + WHY

### DIFF
--- a/plugins/lean4/skills/lean4/SKILL.md
+++ b/plugins/lean4/skills/lean4/SKILL.md
@@ -19,7 +19,7 @@ Use this skill whenever you're editing Lean 4 proofs, debugging Lean builds, for
 
 **Mathlib style quick check.** For ordinary mathematical lambdas, write `fun x ↦ ...` (`\mapsto`), not `fun x => ...`. Use `=>` for `match`/`do` branches and metaprogramming callback idioms. Prefer `show P by tac` for tactic proofs; use `show P from term` only for term proofs. See [mathlib-style](references/mathlib-style.md).
 
-**Never change statements or add axioms without explicit permission.** Theorem/lemma statements, type signatures, and docstrings are off-limits unless the user requests changes. Inline comments may be adjusted; docstrings may not (they're part of the API). Custom axioms require explicit approval—if a proof seems to need one, stop and discuss. Exception: within synthesis wrappers (`/lean4:formalize`, `/lean4:autoformalize`), session-generated declarations may be redrafted under the outer-loop statement-safety rules; see cycle-engine.md.
+**Preserve statements, signatures, and docstrings — they're the file's API.** Theorem/lemma statements, type signatures, and docstrings are off-limits unless the user explicitly requests changes; changing them can break callers or alter the theorem being proved. Inline comments may be adjusted. Custom axioms require explicit approval because they change the proof's trust basis. Exception: within synthesis wrappers (`/lean4:formalize`, `/lean4:autoformalize`), session-generated declarations may be redrafted under the outer-loop statement-safety rules; see cycle-engine.md.
 
 ## Commands
 
@@ -194,7 +194,7 @@ Read proof state and assess quality. No edits, no commits, no subagent dispatch.
 3. `/tmp` scratch files only when `lean_run_code` is unavailable and the experiment must not touch the live file
 4. Never create scratch files in the repo root
 
-**File inspection:** Use Read and Grep to view source files. Never write Python scripts, temp files, or use `cat` pipelines just to read lines from a file you already have access to.
+**File inspection:** Use direct file-read and search tools for source files. Spinning up Python scripts, temp files, or `cat` pipelines just to read accessible lines is tool thrashing — slower per iteration and harder to review than one direct read/search call.
 
 **Staging:** Stage only files touched during the current session. Never use `git add -A` or broad glob patterns. Print the exact staged set before committing.
 

--- a/plugins/lean4/skills/lean4/SKILL.md
+++ b/plugins/lean4/skills/lean4/SKILL.md
@@ -19,7 +19,7 @@ Use this skill whenever you're editing Lean 4 proofs, debugging Lean builds, for
 
 **Mathlib style quick check.** For ordinary mathematical lambdas, write `fun x ↦ ...` (`\mapsto`), not `fun x => ...`. Use `=>` for `match`/`do` branches and metaprogramming callback idioms. Prefer `show P by tac` for tactic proofs; use `show P from term` only for term proofs. See [mathlib-style](references/mathlib-style.md).
 
-**Preserve statements, signatures, and docstrings — they're the file's API.** Theorem/lemma statements, type signatures, and docstrings are off-limits unless the user explicitly requests changes; changing them can break callers or alter the theorem being proved. Inline comments may be adjusted. Custom axioms require explicit approval because they change the proof's trust basis. Exception: within synthesis wrappers (`/lean4:formalize`, `/lean4:autoformalize`), session-generated declarations may be redrafted under the outer-loop statement-safety rules; see cycle-engine.md.
+**Preserve statements, signatures, and docstrings — they're the file's API.** Theorem/lemma statements, type signatures, and docstrings are off-limits unless the user explicitly requests changes; changing them can break callers or alter the theorem being proved. Inline comments may be adjusted, but docstrings may not. If a proof seems to require changing a statement or adding a custom axiom, stop and discuss first because that changes the contract or the proof's trust basis. Exception: within synthesis wrappers (`/lean4:formalize`, `/lean4:autoformalize`), session-generated declarations may be redrafted under the outer-loop statement-safety rules; see cycle-engine.md.
 
 ## Commands
 
@@ -194,7 +194,7 @@ Read proof state and assess quality. No edits, no commits, no subagent dispatch.
 3. `/tmp` scratch files only when `lean_run_code` is unavailable and the experiment must not touch the live file
 4. Never create scratch files in the repo root
 
-**File inspection:** Use direct file-read and search tools for source files. Spinning up Python scripts, temp files, or `cat` pipelines just to read accessible lines is tool thrashing — slower per iteration and harder to review than one direct read/search call.
+**File inspection:** Use direct file-read and search tools for source files — for example Read/Grep when available, or line-range reads and `rg` in shell. Do not spin up Python scripts, temp files, or `cat` pipelines just to read accessible lines; reserve scripts for real parsing, transformation, or multi-file analysis that direct read/search tools cannot handle cleanly.
 
 **Staging:** Stage only files touched during the current session. Never use `git add -A` or broad glob patterns. Print the exact staged set before committing.
 


### PR DESCRIPTION
## Summary

Tiny docs polish to `plugins/lean4/skills/lean4/SKILL.md` applying the `superpowers:writing-skills` guidance: *"If you find yourself writing ALWAYS or NEVER in all caps, or using super rigid structures, that's a yellow flag — if possible, reframe and explain the reasoning so that the model understands why the thing you're asking for is important."*

Off `docs/skill-imperative-why` from `origin/main` (`2668a88`, post-#140). Two commits, one file touched, 4-line net diff. No version bump.

## Context

I audited SKILL.md against `superpowers:writing-skills` (CSO, imperative + WHY, progressive disclosure) and `skill-creator:skill-creator` (interview/iterate, explain WHY rather than mechanical MUSTs). The skill graded **very well** on every dimension:

- **Description field (CSO):** exemplary — "Use when…" + 8+ tech-specific triggers (`.lean`, `lake build`, `sorry`, `mathlib`) + explicit negative carve-outs (`Do NOT trigger for Coq/Rocq…`). 493 chars.
- **Anatomy:** 361 lines, well under the 500-line progressive-disclosure target.
- **References folder:** 40 reference files (~17.9K lines total), categorized and annotated; heavy content systematically demand-loaded.
- **Adjacent surfaces:** `plugin.json` (54-char inventory) and 4 agent descriptions (each carves a distinct escalation tier) don't compete with SKILL.md's triggering signal.
- **Test fixtures:** `tests/pressure/disprove_prime_directive.md` is a real, model-tier-varying pressure test with RED→GREEN evidence preserved in-repo.

The *one* dimension with surface room: two free-standing `Never X` rules in Core Principles + File Handling Rules lead with the prohibition but bury (or omit) the WHY. This PR reframes those two and only those two.

## Commits

**`2300c77` — `docs(skill): reframe two "Never" rules to lead with imperative + WHY`:**

1. **Line 22 — statement preservation.** Pre-PR text led with `Never change statements or add axioms without explicit permission.` and buried the reasoning mid-paragraph. Reframed to `Preserve statements, signatures, and docstrings — they're the file's API.` with the WHY ("changing them can break callers or alter the theorem being proved" / "axioms change the proof's trust basis") leading each clause.

2. **Line 197 — file inspection.** Pre-PR text led with `Use Read and Grep to view source files. Never write Python scripts, temp files, or use cat pipelines …` Reframed to host-agnostic wording: `Use direct file-read and search tools for source files. Spinning up Python scripts, temp files, or cat pipelines just to read accessible lines is tool thrashing — slower per iteration and harder to review than one direct read/search call.` Removing hard-coded "Read" / "Grep" tool names lets the rule travel across hosts (Codex CLI, Copilot CLI, Gemini, etc.) without rewording.

**`c364154` — `docs(skill): restore operational cues lost in the WHY-reframe`:**

Reviewer correctly noted that the first reframe surfaced the WHY but quietly dropped two useful operational cues from the originals. Restoring them without re-introducing a `Never` lead:

1. **Statement preservation** — added back `but docstrings may not` (the load-bearing comments-vs-docstrings distinction was lost when "Inline comments may be adjusted" stood alone), and the explicit protocol `If a proof seems to require changing a statement or adding a custom axiom, stop and discuss first because that changes the contract or the proof's trust basis`. The "stop and discuss" action names the protocol the model should follow instead of leaving "approval required" as an abstract gate; folding axioms into the same sentence gives one protocol, not two.

2. **File inspection** — added back concrete primitive examples: `for example Read/Grep when available, or line-range reads and \`rg\` in shell`. Names the intended primitives across hosts (the pure-class description in commit 1 was too abstract — shell-fallback users didn't get an actionable alternative). Also restored the boundary `reserve scripts for real parsing, transformation, or multi-file analysis that direct read/search tools cannot handle cleanly` — the first reframe risked over-discouraging legitimate script use.

Net effect across both commits: same WHY-rule improvement on both rules, but with the original's crisp `don't do X / do Y instead / exception when Z` structure preserved.

## Out of scope (deliberately)

- **Other `Never` statements in SKILL.md** (lines 79, 82, 93, 116, 124, 195, 199 post-edit) — reviewed and left alone. Each sits inside a structured bullet list or command-flow / header-fence context where the contrast pattern (`Never X → Use Y`) is load-bearing and the surrounding context already supplies the reasoning. Reframing them in isolation would shave bytes without improving clarity.
- **Description field tightening** — graded exemplary by the audit; no improvement available without losing CSO keywords.
- **Moving operating-profile detail to `references/`** — that detail is load-bearing for users in degraded environments (no MCP / scripts-only mode) and belongs in-line for discoverability.
- **Skill-triggering pressure test** (e.g. "model asked to use lean4 skill for a Coq task") — the description's negative carve-outs already address this; pressure-testing would be belt-and-suspenders.
- **`lint_docs.sh` regression guard for orphan `Never` statements** — two reframings don't justify infrastructure.
- **Version bump** — pure docs polish, no functional change.

## Test plan

- [x] **Warning-set stability:** `bash plugins/lean4/tools/lint_docs.sh` warning set on the branch matches main exactly after **both** commits (re-checked after `c364154` landed). The bar isn't "fully green" (lint_docs.sh has preexisting warnings on main — `autoprove.md` / `formalize.md` / `learn.md` line-length flags + `SKILL.md mentions Claude` flag); the bar is "no additions."
- [x] **Visual review:** both edits read as intended on the rendered file — imperative-first, WHY-in-line, no broken cross-references (no internal cross-refs touched).
- [x] **CI:** standard four-job suite (macos-bash3 + mypy + ruff + shellcheck) stays green. No code or test files touched, so this is a pure formality.
