### PR TITLE
docs(insight): module docstrings must come after imports

### DIFF
--- a/plugins/lean4/skills/lean4/references/compilation-errors.md
+++ b/plugins/lean4/skills/lean4/references/compilation-errors.md
@@ -14,6 +14,7 @@ This reference provides detailed explanations and fixes for the most common comp
 | **"numerals are data but expected Prop"** | Value where proof expected | Use proof term: `tendsto_const_nhds` not `1` |
 | **"tactic 'exact' failed"** | Goal/term type mismatch | Use `apply` for unification or restructure: `⟨h.2, h.1⟩` |
 | **"unknown identifier"** | Missing import OR namespace not opened | Import tactic OR `open Filter Topology` |
+| **"invalid 'import' command"** | Module docstring placed before imports | Move `/-! ... -/` after the `import` block; see [§ 13 below](#13-invalid-import-command-module-docstring-before-imports) |
 | **"unexpected token/identifier"** | Section comment in proof | Replace `/-! -/` with `--` in tactic mode |
 | **"no goals to be solved"** | Tactic already finished | Remove redundant tactics after `simp` |
 | **"equation compiler failed"** | Can't prove termination | Add `termination_by my_rec n => n` clause |
@@ -642,6 +643,32 @@ exact h_goal.symm
 3. Unfold with `simpa [hF]` or `rw [hF]`
 
 **See also:** [lean-phrasebook.md](lean-phrasebook.md) - "Name complex expression to avoid alpha/beta-equivalence issues"
+
+### 13. Invalid 'import' Command (Module Docstring Before Imports)
+
+**Problem:** A module-level `/-! ... -/` docstring placed before the `import` block turns the imports into a parse error.
+
+**Full error message:**
+```
+error: invalid 'import' command, it must be used in the beginning of the file
+```
+
+**What's wrong:** In Lean 4, imports must be the first non-comment content in the file (after the copyright header). Plain comments such as the copyright header are allowed before imports, but a module docstring (`/-! ... -/`) is parsed as file content — everything after it is treated as the file body, so the subsequent `import` lines become invalid.
+
+**Example failure:**
+```lean
+-- ✗ Fails:
+/-! # My Module -/
+import Mathlib.Data.Real.Basic
+
+-- ✓ Works:
+import Mathlib.Data.Real.Basic
+/-! # My Module -/
+```
+
+**Fix:** Move the `/-! ... -/` module docstring after the `import` block. The error message names `import`, not the docstring — the docstring's position is the cause.
+
+**See also:** [mathlib-style.md § 2 Placement](mathlib-style.md#placement) for the canonical file-top order (copyright → imports → module docstring).
 
 ---
 

--- a/plugins/lean4/skills/lean4/references/compilation-errors.md
+++ b/plugins/lean4/skills/lean4/references/compilation-errors.md
@@ -653,7 +653,7 @@ exact h_goal.symm
 error: invalid 'import' command, it must be used in the beginning of the file
 ```
 
-**What's wrong:** In Lean 4, imports must be the first non-comment content in the file (after the copyright header). Plain comments such as the copyright header are allowed before imports, but a module docstring (`/-! ... -/`) is parsed as file content — everything after it is treated as the file body, so the subsequent `import` lines become invalid.
+**What's wrong:** In Lean 4, imports must appear before any command or module-docstring content in the file. Plain comments such as the copyright header are allowed before imports, but a module docstring (`/-! ... -/`) is parsed as file content — everything after it is treated as the file body, so the subsequent `import` lines become invalid.
 
 **Example failure:**
 ```lean

--- a/plugins/lean4/skills/lean4/references/mathlib-style.md
+++ b/plugins/lean4/skills/lean4/references/mathlib-style.md
@@ -58,6 +58,22 @@ Brief description of what this file does.
 -/
 ```
 
+#### Placement
+
+The module docstring must come **after** the `import` block, not before. Plain comments such as the copyright header may precede imports, but a module docstring (`/-! ... -/`) before imports is parsed as file content, and Lean then reports the later imports as invalid.
+
+```lean
+-- ✗ Fails — "invalid 'import' command, it must be used in the beginning of the file":
+/-! # My Module -/
+import Mathlib.Data.Real.Basic
+
+-- ✓ Works:
+import Mathlib.Data.Real.Basic
+/-! # My Module -/
+```
+
+The error message names `import`, not the docstring — the docstring's position is the cause.
+
 ### 3. Naming Conventions
 
 **Case conventions:**

--- a/plugins/lean4/skills/lean4/references/mathlib-style.md
+++ b/plugins/lean4/skills/lean4/references/mathlib-style.md
@@ -60,7 +60,7 @@ Brief description of what this file does.
 
 #### Placement
 
-The module docstring must come **after** the `import` block, not before. Plain comments such as the copyright header may precede imports, but a module docstring (`/-! ... -/`) before imports is parsed as file content, and Lean then reports the later imports as invalid.
+When a file has imports, the module docstring must come **after** all import lines. Plain comments such as the copyright header may precede imports, but a module docstring (`/-! ... -/`) before imports is parsed as file content, and Lean then reports the later imports as invalid. Files with no imports (rare) can place the module docstring anywhere.
 
 ```lean
 -- ✗ Fails — "invalid 'import' command, it must be used in the beginning of the file":


### PR DESCRIPTION
## Summary

Closes #61 — an `insight`-labeled antipattern where placing a module-level `/-! ... -/` docstring before the `import` block produces a misleading compiler error:

```
error: invalid 'import' command, it must be used in the beginning of the file
```

The error names `import`, not the docstring. Two reference-doc surfaces close the gap: `mathlib-style.md § 2` (where a model authoring a docstring lands) now has a `#### Placement` subheading with the rule, and `compilation-errors.md` gets a Quick Reference row + new `### 13.` section (where a model debugging the compiler error lands).

Off `docs/module-docstring-placement` from `origin/main` (`6cd7efd`, post-#141). Three commits, two files touched, 44-line net diff. No SKILL.md change, no lint guard, no version bump.

## Context

The rule was almost documented already: `mathlib-style.md § 1. Copyright Headers (CRITICAL)` shows the canonical top-of-file order via example (copyright → imports → module docstring) and notes "Blank line between imports and module docstring." But § 2 documents the docstring's *content* without saying *where* it goes, and `compilation-errors.md` doesn't cover the symptom at all.

## Commits

**`4f82d42` — `docs(insight): module docstrings must come after imports (#61)`:**

**(a) `mathlib-style.md` § 2** — new `#### Placement` subheading with the rule, the ❌/✅ example pair from the issue body, and a one-line note that the compiler error names `import`, not the docstring. The wording deliberately distinguishes ordinary comments / copyright headers (allowed before imports) from module docstrings (not allowed before imports) — "first non-comment content" would be shorthand but `/-! ... -/` looks comment-like while behaving specially. Made it a real `#### Placement` subheading (not a bold-prose run-in) so the cross-reference from `compilation-errors.md` has a stable GitHub anchor `#placement`.

**(b) `compilation-errors.md`** — one new row in the Quick Reference Table (`"invalid 'import' command"` → "module docstring placed before imports" → "move `/-! ... -/` after the `import` block; see § 13 below"), plus new `### 13. Invalid 'import' Command (Module Docstring Before Imports)` section appended after existing `### 12.` **without renumbering any existing section**. The file has pre-existing duplicate `### 9.` / `### 10.` headings — intentionally not touched here (separate cleanup, out of scope). The § 13 body restates the symptom, includes the same ❌/✅ pair as `mathlib-style.md` (so a model debugging the symptom doesn't have to follow the cross-ref to get the fix), and cross-links back via `[mathlib-style.md § 2 Placement](mathlib-style.md#placement)`. Fallback anchor if `#placement` ever collides: `mathlib-style.md#2-module-docstrings-required` + "see the Placement subsection" — no collision today.

**`99a2787` — `docs(compilation-errors): drop "non-comment content" shorthand in § 13`:**

Reviewer nit follow-up. The § 13 "What's wrong" sentence originally led with `imports must be the first non-comment content in the file` — the same shorthand the plan deliberately avoided in the `mathlib-style.md § 2` Placement wording. The following sentence already spelled out the distinction (plain comments allowed, module docstrings not), so leading with the shorthand undermined its own follow-up. Reworded to `imports must appear before any command or module-docstring content in the file` for consistency with the mathlib-style precision. Word-count-neutral wording-only fix.

**`c8acb20` — `docs(mathlib-style): scope § 2 Placement to files with imports`:**

Second reviewer nit. Issue #61's original body carries a useful caveat that the first-pass wording flattened: "Files with no imports (rare) can place the docstring anywhere." The pre-nit § 2 Placement lead read as an absolute rule (`must come after the import block, not before`), which technically overstates the constraint on files without imports.

Reworded lead: `When a file has imports, the module docstring must come **after** all import lines.` Added trailing sentence: `Files with no imports (rare) can place the module docstring anywhere.` `compilation-errors.md § 13` is not touched — that whole section is scoped by its title (`Invalid 'import' Command (Module Docstring Before Imports)`) to the with-imports symptom; the caveat is implicit there.

## Test plan

- [x] **Compiler-symptom check:** wrote both examples to `/tmp/module_docstring_before_import.lean` and `/tmp/module_docstring_after_import.lean`, ran `lean` on each under Lean 4.31.0 (elan toolchain). Failing case produced exactly the quoted error wording verbatim (`invalid 'import' command, it must be used in the beginning of the file`); succeeding case exited 0. No adjustment to the quoted string needed.
- [x] **Warning-set stability:** `bash plugins/lean4/tools/lint_docs.sh` warning set on the branch matches `origin/main` exactly. The bar isn't "fully green" (lint_docs.sh has preexisting warnings on main — `autoprove.md` / `formalize.md` / `learn.md` line-length flags + `SKILL.md mentions Claude` flag); the bar is "no additions."
- [x] **Visual review:** open `mathlib-style.md` and `compilation-errors.md` on rendered GitHub. Confirm § 2's new `#### Placement` subheading reads cleanly and the cross-reference from § 13 to `mathlib-style.md#placement` resolves.
- [x] **Anchor check:** GitHub-flavored markdown derives `#placement` from the `#### Placement` heading (lowercase, hyphens, no punctuation). Spot-check by clicking through from `compilation-errors.md`'s new § 13.
- [x] **CI:** standard four-job suite (macos-bash3 + mypy + ruff + shellcheck) — green on `99a2787` and awaiting re-run on `c8acb20`.

## Out of scope (deliberately)

- **Adding the rule to SKILL.md's always-loaded surface.** Module-docstring placement is a file-structure rule, not a Type Class Pattern. The #137 omit-rule precedent (declaration-level parse-order foot-gun in a proof block) doesn't generalize.
- **A `lint_docs.sh` regression guard.** The omit-rule lint guard (Check 8a) protected an always-loaded surface; a guard here would protect two reference files, which isn't the same load-bearing motivation. If the rule later moves to SKILL.md, a guard makes sense.
- **Fixing the pre-existing duplicate `### 9.` / `### 10.` headings** in `compilation-errors.md`. Real, but a separate cleanup — this PR's § 13 doesn't renumber anything.
- **A `references/file-structure.md` reference.** Overkill for one rule; § 1 + § 2 of `mathlib-style.md` cover copyright + module docstring sufficiently after this PR.
- **Version bump.** Pure docs polish, no functional change.

