### PR TITLE
fix(unused-decls): rg mode flagged everything unused; expand decl classes; harden zero-decls paths

### DIFF
--- a/.github/workflows/bash3-compat.yml
+++ b/.github/workflows/bash3-compat.yml
@@ -29,5 +29,8 @@ jobs:
       - name: Self-test — check_axioms_inline (#132)
         run: /bin/bash plugins/lean4/tests/test_check_axioms_inline.sh
 
+      - name: Self-test — unused_declarations
+        run: /bin/bash plugins/lean4/tests/test_unused_declarations.sh
+
       - name: Runtime smoke — cycle_tracker.sh under /bin/bash
         run: /bin/bash plugins/lean4/tests/test_bash3_smoke.sh

--- a/.github/workflows/bash3-compat.yml
+++ b/.github/workflows/bash3-compat.yml
@@ -29,8 +29,18 @@ jobs:
       - name: Self-test — check_axioms_inline (#132)
         run: /bin/bash plugins/lean4/tests/test_check_axioms_inline.sh
 
+      - name: Install ripgrep (unused_declarations self-test needs rg or PCRE grep)
+        run: brew install ripgrep
+
       - name: Self-test — unused_declarations
-        run: /bin/bash plugins/lean4/tests/test_unused_declarations.sh
+        # rg --version is a hard assertion: macOS runners ship neither
+        # ripgrep nor a PCRE-capable grep, so without the install step the
+        # suite self-SKIPs (exit 0) and the rg-regression coverage silently
+        # vanishes while the job stays green. Printing the version makes
+        # the coverage auditable from logs.
+        run: |
+          rg --version
+          /bin/bash plugins/lean4/tests/test_unused_declarations.sh
 
       - name: Runtime smoke — cycle_tracker.sh under /bin/bash
         run: /bin/bash plugins/lean4/tests/test_bash3_smoke.sh

--- a/plugins/lean4/lib/scripts/unused_declarations.sh
+++ b/plugins/lean4/lib/scripts/unused_declarations.sh
@@ -105,16 +105,20 @@ if [[ "$USE_RG" == true ]]; then
     # then looks for `path:name` in file CONTENT, finds nothing, and flags
     # every declaration in the project as unused. This was the pre-fix
     # behavior whenever ripgrep was installed (the recommended configuration).
+    # `|| true` is load-bearing: rg exits 1 when it finds no matches, and
+    # under `set -euo pipefail` that killed the whole script mid-run on any
+    # declaration-free tree — exit 1 with no summary, making the
+    # TOTAL_DECLS==0 branch below unreachable in rg mode.
     rg -t lean "^(($DECL_MODIFIERS)\s+)?($DECL_KEYWORDS)\s+([\w'.]+)" \
         "$SEARCH_DIR" \
         --no-heading \
         --no-filename \
         --only-matching \
-        --replace '$4' | sort -u > "$DECLARATIONS"
+        --replace '$4' | sort -u > "$DECLARATIONS" || true
 else
     find "$SEARCH_DIR" -name "*.lean" -type f -exec \
         grep -hoP "^(($DECL_MODIFIERS)\s+)?($DECL_KEYWORDS)\s+\K[\w'.]+" {} \; | \
-        sort -u > "$DECLARATIONS"
+        sort -u > "$DECLARATIONS" || true
 fi
 
 TOTAL_DECLS=$(wc -l < "$DECLARATIONS" | tr -d ' ')
@@ -123,6 +127,23 @@ echo -e "${GREEN}Found ${BOLD}$TOTAL_DECLS${NC}${GREEN} declarations${NC}"
 echo ""
 
 if [[ $TOTAL_DECLS -eq 0 ]]; then
+    # Distinguish two cases (same policy as check_axioms_inline.sh, #145):
+    #   (a) legitimately declaration-free tree (imports only, comments only,
+    #       or no .lean files at all) — safe to report and exit 0
+    #   (b) tree HAS declaration-shaped content the extraction regex missed
+    #       (indented decls, private/protected/local prefixes, @[attr]
+    #       lines, mutual blocks) — the analysis can't see those, so a
+    #       "no declarations" report would be false reassurance; exit 1.
+    # grep -r --include (supported by both GNU and BSD grep) avoids the
+    # find|xargs pitfalls: BSD xargs skips empty input (making the pipeline
+    # exit 0 → false positive on decl-free dirs) while GNU xargs would run
+    # grep against stdin; and head-terminated pipes risk SIGPIPE flakiness
+    # under pipefail.
+    _shape_re="^[[:space:]]+($DECL_KEYWORDS)[[:space:]]|^(private|protected|local)[[:space:]]|^@\[|^mutual[[:space:]]*$"
+    if grep -rqE --include='*.lean' "$_shape_re" "$SEARCH_DIR" 2>/dev/null; then
+        echo -e "${YELLOW}⚠ No top-level declarations matched, but declaration-shaped content exists (indented / private / @[attr] / mutual) — analysis cannot cover it${NC}"
+        exit 1
+    fi
     echo -e "${YELLOW}No declarations found in $SEARCH_DIR${NC}"
     exit 0
 fi

--- a/plugins/lean4/lib/scripts/unused_declarations.sh
+++ b/plugins/lean4/lib/scripts/unused_declarations.sh
@@ -88,17 +88,32 @@ trap 'rm -f "$DECLARATIONS" "$UNUSED"' EXIT
 
 echo -e "${GREEN}Step 1: Finding all declarations...${NC}"
 
-# Extract all theorem/lemma/def declarations
-# Use [\w'.]+ to match Lean identifiers (allows primes and dots for qualified names)
+# Extract all top-level declarations.
+# Use [\w'.]+ to match Lean identifiers (allows primes and dots for qualified names).
+# Keyword set covers definition-shaped forms plus `axiom|constant` (dead axioms
+# are exactly what a cleanup pass should surface) and `structure|class|inductive`
+# (type definitions can be dead code too). An optional modifier prefix covers
+# `noncomputable def`, `unsafe def`, `partial def`, `nonrec def` — real Lean
+# forms whose column-0 keyword is the modifier, not the decl keyword.
+# `example` is deliberately absent: examples are anonymous, no name to track.
+DECL_KEYWORDS='theorem|lemma|def|abbrev|instance|axiom|constant|structure|class|inductive'
+DECL_MODIFIERS='noncomputable|unsafe|partial|nonrec'
 if [[ "$USE_RG" == true ]]; then
-    rg -t lean "^(theorem|lemma|def|abbrev|instance)\s+([\w'.]+)" \
+    # --no-filename is load-bearing: without it, rg prefixes every match with
+    # `path:` when searching a directory (even with --no-heading), so every
+    # extracted "declaration" is actually `path:name`. The Step 2 usage search
+    # then looks for `path:name` in file CONTENT, finds nothing, and flags
+    # every declaration in the project as unused. This was the pre-fix
+    # behavior whenever ripgrep was installed (the recommended configuration).
+    rg -t lean "^(($DECL_MODIFIERS)\s+)?($DECL_KEYWORDS)\s+([\w'.]+)" \
         "$SEARCH_DIR" \
         --no-heading \
+        --no-filename \
         --only-matching \
-        --replace '$2' | sort -u > "$DECLARATIONS"
+        --replace '$4' | sort -u > "$DECLARATIONS"
 else
     find "$SEARCH_DIR" -name "*.lean" -type f -exec \
-        grep -hoP "^(theorem|lemma|def|abbrev|instance)\s+\K[\w'.]+" {} \; | \
+        grep -hoP "^(($DECL_MODIFIERS)\s+)?($DECL_KEYWORDS)\s+\K[\w'.]+" {} \; | \
         sort -u > "$DECLARATIONS"
 fi
 
@@ -170,14 +185,16 @@ else
 
     # Show unused declarations with file locations
     while IFS= read -r decl; do
-        # Find where it's defined (escape for regex)
+        # Find where it's defined (escape for regex). Keyword set + modifier
+        # prefix must mirror the Step 1 extraction regex, else expanded-class
+        # decls (axiom, noncomputable def, ...) report without a location.
         escaped_decl=$(escape_regex "$decl")
         if [[ "$USE_RG" == true ]]; then
-            LOCATION=$(rg -t lean "^(theorem|lemma|def|abbrev|instance)\s+$escaped_decl$LEAN_ID_AFTER" \
+            LOCATION=$(rg -t lean "^(($DECL_MODIFIERS)\s+)?($DECL_KEYWORDS)\s+$escaped_decl$LEAN_ID_AFTER" \
                 "$SEARCH_DIR" --no-heading | head -1 || echo "")
         else
             LOCATION=$(find "$SEARCH_DIR" -name "*.lean" -type f -exec \
-                grep -En "^(theorem|lemma|def|abbrev|instance)\s+$escaped_decl$LEAN_ID_AFTER" {} + | \
+                grep -En "^(($DECL_MODIFIERS)\s+)?($DECL_KEYWORDS)\s+$escaped_decl$LEAN_ID_AFTER" {} + | \
                 head -1 || echo "")
         fi
 

--- a/plugins/lean4/lib/scripts/unused_declarations.sh
+++ b/plugins/lean4/lib/scripts/unused_declarations.sh
@@ -15,6 +15,17 @@
 #   - List of unused declarations
 #   - Suggestions for marking as private or removing
 #   - Summary statistics
+#
+# Known limitations (grep-based analysis, no Lean elaboration):
+#   - Namespace-qualified usage is NOT credited: a decl `foo` inside
+#     `namespace A` referenced elsewhere as `A.foo` is still flagged
+#     unused, because extraction records the short name and the usage
+#     boundary deliberately excludes `.`-prefixed forms. Verify with
+#     find_usages.sh before removing anything namespaced.
+#   - Usages in comments and strings ARE counted (may hide dead code).
+#   - Indented, private/protected/local, @[attr], and mutual-block decls
+#     are not extracted; trees containing ONLY those are reported as
+#     unverifiable (exit 1) rather than clean.
 
 set -euo pipefail
 
@@ -59,6 +70,16 @@ if command -v rg &> /dev/null; then
     USE_RG=true
 else
     USE_RG=false
+    # The fallback extraction uses grep -P (PCRE, for \K). BSD grep (macOS)
+    # doesn't support -P: without this hard check, the extraction pipeline
+    # would fail, the `|| true` guard would mask it, and a tree full of
+    # ordinary declarations would report "No declarations found" with
+    # exit 0 — a false green. A tool that can't run must say so loudly.
+    if ! echo x | grep -oP 'x' >/dev/null 2>&1; then
+        echo -e "${RED}Error: this script requires ripgrep (rg) or a PCRE-capable grep (grep -P).${NC}" >&2
+        echo -e "${RED}Neither is available — cannot analyze. Install ripgrep: https://github.com/BurntSushi/ripgrep${NC}" >&2
+        exit 2
+    fi
     echo -e "${YELLOW}Note: ripgrep not found. Install ripgrep for 10-100x faster analysis${NC}"
     echo ""
 fi
@@ -139,7 +160,14 @@ if [[ $TOTAL_DECLS -eq 0 ]]; then
     # exit 0 → false positive on decl-free dirs) while GNU xargs would run
     # grep against stdin; and head-terminated pipes risk SIGPIPE flakiness
     # under pipefail.
-    _shape_re="^[[:space:]]+($DECL_KEYWORDS)[[:space:]]|^(private|protected|local)[[:space:]]|^@\[|^mutual[[:space:]]*$"
+    #
+    # Shape regex: any line that is optional-indent + optional access
+    # modifier + optional decl modifier + a decl keyword — at ANY indent
+    # depth, including column 0. Since this branch only runs when the
+    # extraction found NOTHING, a column-0 match here means the extraction
+    # itself failed (regex bug, tool misbehavior) and must be loud, not a
+    # friendly zero. Also catches @[attr] lines and mutual blocks.
+    _shape_re="^[[:space:]]*((private|protected|local)[[:space:]]+)?(($DECL_MODIFIERS)[[:space:]]+)?($DECL_KEYWORDS)[[:space:]]|^[[:space:]]*@\[|^mutual[[:space:]]*$"
     if grep -rqE --include='*.lean' "$_shape_re" "$SEARCH_DIR" 2>/dev/null; then
         echo -e "${YELLOW}⚠ No top-level declarations matched, but declaration-shaped content exists (indented / private / @[attr] / mutual) — analysis cannot cover it${NC}"
         exit 1

--- a/plugins/lean4/lib/scripts/unused_declarations.sh
+++ b/plugins/lean4/lib/scripts/unused_declarations.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 #
-# unused_declarations.sh - Find unused theorems, lemmas, and definitions in Lean 4 project
+# unused_declarations.sh - Find unused declarations in a Lean 4 project
 #
 # Usage:
 #   ./unused_declarations.sh [directory] [--exit-zero-on-findings]
 #
-# Finds declarations (theorem, lemma, def) that are never used in the project.
+# Finds top-level declarations that are never used in the project.
+# Covered keywords: theorem, lemma, def, abbrev, instance, axiom,
+# constant, structure, class, inductive — optionally prefixed by
+# noncomputable, unsafe, partial, or nonrec.
 #
 # Examples:
 #   ./unused_declarations.sh
@@ -167,7 +170,7 @@ if [[ $TOTAL_DECLS -eq 0 ]]; then
     # extraction found NOTHING, a column-0 match here means the extraction
     # itself failed (regex bug, tool misbehavior) and must be loud, not a
     # friendly zero. Also catches @[attr] lines and mutual blocks.
-    _shape_re="^[[:space:]]*((private|protected|local)[[:space:]]+)?(($DECL_MODIFIERS)[[:space:]]+)?($DECL_KEYWORDS)[[:space:]]|^[[:space:]]*@\[|^mutual[[:space:]]*$"
+    _shape_re="^[[:space:]]*((private|protected|local)[[:space:]]+)?(($DECL_MODIFIERS)[[:space:]]+)?($DECL_KEYWORDS)[[:space:]]|^[[:space:]]*@\[|^[[:space:]]*mutual[[:space:]]*$"
     if grep -rqE --include='*.lean' "$_shape_re" "$SEARCH_DIR" 2>/dev/null; then
         echo -e "${YELLOW}⚠ No top-level declarations matched, but declaration-shaped content exists (indented / private / @[attr] / mutual) — analysis cannot cover it${NC}"
         exit 1

--- a/plugins/lean4/tests/fixtures/unused_decls/all_used/Sample.lean
+++ b/plugins/lean4/tests/fixtures/unused_decls/all_used/Sample.lean
@@ -1,9 +1,8 @@
 -- Fixture: every declaration is referenced at least once beyond its
--- definition line. The leaf (`final_thm`) is referenced in the comment
--- below — usages in comments ARE counted (documented limitation of the
--- grep-based analysis), which conveniently lets an all-used fixture
--- exist at all.
+-- definition line. The leaf (`final_thm`) is referenced by a real Lean
+-- command (#check) rather than a comment, so the green path doesn't
+-- depend on the comments-count-as-usage limitation.
 theorem base_thm : True := trivial
 def uses_base := base_thm
 theorem final_thm : True := uses_base
--- final_thm is the exported result: final_thm
+#check final_thm

--- a/plugins/lean4/tests/fixtures/unused_decls/all_used/Sample.lean
+++ b/plugins/lean4/tests/fixtures/unused_decls/all_used/Sample.lean
@@ -1,0 +1,9 @@
+-- Fixture: every declaration is referenced at least once beyond its
+-- definition line. The leaf (`final_thm`) is referenced in the comment
+-- below — usages in comments ARE counted (documented limitation of the
+-- grep-based analysis), which conveniently lets an all-used fixture
+-- exist at all.
+theorem base_thm : True := trivial
+def uses_base := base_thm
+theorem final_thm : True := uses_base
+-- final_thm is the exported result: final_thm

--- a/plugins/lean4/tests/fixtures/unused_decls/expanded_classes/Sample.lean
+++ b/plugins/lean4/tests/fixtures/unused_decls/expanded_classes/Sample.lean
@@ -1,6 +1,7 @@
--- Fixture: one used theorem + eight dead decls spanning the expanded
--- keyword classes (axiom, constant, structure, and the four
--- modifier-prefixed def forms). Locks in the Step 1 extraction regex.
+-- Fixture: two used decls (used_thm + uses_thm, the latter via the
+-- trailing comment) and seven dead decls spanning the expanded keyword
+-- classes (axiom, constant, structure, and the four modifier-prefixed
+-- def forms). Locks in the Step 1 extraction regex.
 theorem used_thm : True := trivial
 axiom dead_axiom : False
 constant dead_constant : Nat

--- a/plugins/lean4/tests/fixtures/unused_decls/expanded_classes/Sample.lean
+++ b/plugins/lean4/tests/fixtures/unused_decls/expanded_classes/Sample.lean
@@ -1,0 +1,14 @@
+-- Fixture: one used theorem + eight dead decls spanning the expanded
+-- keyword classes (axiom, constant, structure, and the four
+-- modifier-prefixed def forms). Locks in the Step 1 extraction regex.
+theorem used_thm : True := trivial
+axiom dead_axiom : False
+constant dead_constant : Nat
+noncomputable def dead_noncomp : Nat := 0
+unsafe def dead_unsafe : Nat := 0
+partial def dead_partial : Nat := 0
+nonrec def dead_nonrec : Nat := 0
+structure DeadStruct where
+  x : Nat
+def uses_thm := used_thm
+-- uses_thm is referenced here so it counts as used: uses_thm

--- a/plugins/lean4/tests/fixtures/unused_decls/expanded_classes/Sample.lean
+++ b/plugins/lean4/tests/fixtures/unused_decls/expanded_classes/Sample.lean
@@ -1,7 +1,7 @@
 -- Fixture: two used decls (used_thm + uses_thm, the latter via the
--- trailing comment) and seven dead decls spanning the expanded keyword
--- classes (axiom, constant, structure, and the four modifier-prefixed
--- def forms). Locks in the Step 1 extraction regex.
+-- trailing comment) and nine dead decls spanning the expanded keyword
+-- classes (axiom, constant, structure, class, inductive, and the four
+-- modifier-prefixed def forms). Locks in the Step 1 extraction regex.
 theorem used_thm : True := trivial
 axiom dead_axiom : False
 constant dead_constant : Nat
@@ -11,5 +11,9 @@ partial def dead_partial : Nat := 0
 nonrec def dead_nonrec : Nat := 0
 structure DeadStruct where
   x : Nat
+class DeadClass where
+  y : Nat
+inductive DeadInductive where
+  | one
 def uses_thm := used_thm
 -- uses_thm is referenced here so it counts as used: uses_thm

--- a/plugins/lean4/tests/fixtures/unused_decls/has_unused/Sample.lean
+++ b/plugins/lean4/tests/fixtures/unused_decls/has_unused/Sample.lean
@@ -1,0 +1,10 @@
+-- Fixture: the pre-fix rg-mode regression. The first theorem is plainly
+-- referenced; pre-fix (missing --no-filename), the extraction produced
+-- path-prefixed names so the usage search matched nothing and ALL decls
+-- were flagged unused. Post-fix: only the last one is flagged.
+-- NOTE: comments must never name the dead decl — usages in comments
+-- are counted by the grep-based analysis (documented limitation).
+theorem used_thm : True := trivial
+def uses_thm := used_thm
+-- second reference so the def above counts as used: uses_thm
+theorem dead_thm : True := trivial

--- a/plugins/lean4/tests/fixtures/unused_decls/imports_only/Sample.lean
+++ b/plugins/lean4/tests/fixtures/unused_decls/imports_only/Sample.lean
@@ -1,0 +1,3 @@
+-- Fixture: genuinely declaration-free file. The shape heuristic must
+-- NOT fire; the script reports "No declarations found" and exits 0.
+import Init

--- a/plugins/lean4/tests/fixtures/unused_decls/indented_modifier/Sample.lean
+++ b/plugins/lean4/tests/fixtures/unused_decls/indented_modifier/Sample.lean
@@ -1,0 +1,7 @@
+-- Fixture: the only decl is BOTH indented AND modifier-prefixed. The
+-- extraction regex (column-0 only) can't see it; the shape heuristic
+-- must still detect it and exit 1. Reviewer-caught: the first-pass
+-- heuristic matched indented `def` but not indented `noncomputable def`.
+namespace N
+  noncomputable def hidden : Nat := 0
+end N

--- a/plugins/lean4/tests/fixtures/unused_decls/mixed_dir/Dead.lean
+++ b/plugins/lean4/tests/fixtures/unused_decls/mixed_dir/Dead.lean
@@ -1,0 +1,7 @@
+-- Fixture (mixed_dir): the dead half. The last theorem below is never
+-- referenced anywhere in the directory; the shared theorem from
+-- Used.lean IS referenced here (cross-file usage counting).
+-- NOTE: comments must never name the dead decl — comment usages count.
+def uses_shared := shared_thm
+-- second reference so the def above counts as used: uses_shared
+theorem local_dead : True := trivial

--- a/plugins/lean4/tests/fixtures/unused_decls/mixed_dir/Used.lean
+++ b/plugins/lean4/tests/fixtures/unused_decls/mixed_dir/Used.lean
@@ -1,0 +1,4 @@
+-- Fixture (mixed_dir): the used half. Cross-file usage — `shared_thm`
+-- is defined here and referenced from Dead.lean, exercising the
+-- directory-wide usage search.
+theorem shared_thm : True := trivial

--- a/plugins/lean4/tests/fixtures/unused_decls/private_only/Sample.lean
+++ b/plugins/lean4/tests/fixtures/unused_decls/private_only/Sample.lean
@@ -1,0 +1,5 @@
+-- Fixture: only a `private` decl. The extraction regex intentionally
+-- skips access-modifier decls, so TOTAL_DECLS is 0 — but the tree is
+-- NOT declaration-free. The shape heuristic must warn and exit 1
+-- rather than report the friendly "No declarations found".
+private theorem hidden : True := trivial

--- a/plugins/lean4/tests/test_unused_declarations.sh
+++ b/plugins/lean4/tests/test_unused_declarations.sh
@@ -135,7 +135,7 @@ fi
 # ---------------------------------------------------------------------------
 run_probe "P2 expanded-classes" expanded_classes
 p2_ok=1
-assert_out_has     "P2" "Found 9 declarations"          || p2_ok=0
+assert_out_has     "P2" "Found 11 declarations"         || p2_ok=0
 assert_out_has     "P2" "dead_axiom"                    || p2_ok=0
 assert_out_has     "P2" "dead_constant"                 || p2_ok=0
 assert_out_has     "P2" "dead_noncomp"                  || p2_ok=0
@@ -143,10 +143,12 @@ assert_out_has     "P2" "dead_unsafe"                   || p2_ok=0
 assert_out_has     "P2" "dead_partial"                  || p2_ok=0
 assert_out_has     "P2" "dead_nonrec"                   || p2_ok=0
 assert_out_has     "P2" "DeadStruct"                    || p2_ok=0
-assert_out_has     "P2" "Potentially unused: 7"         || p2_ok=0
+assert_out_has     "P2" "DeadClass"                     || p2_ok=0
+assert_out_has     "P2" "DeadInductive"                 || p2_ok=0
+assert_out_has     "P2" "Potentially unused: 9"         || p2_ok=0
 assert_exit        "P2" 1                               || p2_ok=0
 if [[ $p2_ok -eq 1 ]]; then
-    echo "  PASS: P2 expanded-classes — axiom/constant/struct/modifier defs all extracted"
+    echo "  PASS: P2 expanded-classes — axiom/constant/struct/class/inductive/modifier defs all extracted"
     ((PASS++)) || true
 else
     ((FAIL++)) || true

--- a/plugins/lean4/tests/test_unused_declarations.sh
+++ b/plugins/lean4/tests/test_unused_declarations.sh
@@ -250,6 +250,80 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Probe 9 — indented_modifier: the only decl is indented AND
+# modifier-prefixed (`  noncomputable def hidden`). Extraction can't see
+# it; the shape heuristic must catch it (optional indent + optional
+# modifier before the keyword) and exit 1. Reviewer-caught: first-pass
+# heuristic matched indented `def` but not indented `noncomputable def`.
+# ---------------------------------------------------------------------------
+run_probe "P9 indented-modifier" indented_modifier
+p9_ok=1
+assert_out_has     "P9" "declaration-shaped content exists" || p9_ok=0
+assert_out_missing "P9" "No declarations found"             || p9_ok=0
+assert_exit        "P9" 1                                   || p9_ok=0
+if [[ $p9_ok -eq 1 ]]; then
+    echo "  PASS: P9 indented-modifier — heuristic catches indented noncomputable def"
+    ((PASS++)) || true
+else
+    ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
+# Probe 10 — no rg, no PCRE grep: the script must fail LOUDLY (exit 2
+# with an error naming the requirement), not report "No declarations
+# found" + exit 0. Reviewer-caught false green: with rg hidden and a
+# BSD-style grep that rejects -P, `|| true` masked the extraction
+# failure entirely.
+#
+# Simulated via a constrained PATH: symlinks to the real utilities the
+# script needs, a `grep` shim that rejects any -P usage (BSD behavior),
+# and NO rg.
+# ---------------------------------------------------------------------------
+((++PROBE_COUNTER))
+P10_DIR="$SCRATCH_ROOT/probe-$PROBE_COUNTER"
+mkdir -p "$P10_DIR/bin" "$P10_DIR/tree"
+cp "$FIXTURE_ROOT/has_unused/Sample.lean" "$P10_DIR/tree/"
+
+# Symlink the utilities the script needs (resolved from the current PATH).
+for util in sort wc tr find sed awk head rm mktemp cat dirname; do
+    src=$(command -v "$util" 2>/dev/null || true)
+    [[ -n "$src" ]] && ln -s "$src" "$P10_DIR/bin/$util"
+done
+REAL_GREP=$(command -v grep)
+cat > "$P10_DIR/bin/grep" <<EOF
+#!$BASH_FOR_COMPAT
+# BSD-style grep shim: reject any -P (PCRE) usage, delegate the rest.
+for a in "\$@"; do
+    case "\$a" in
+        --) break ;;
+        -*P*) echo "grep: invalid option -- P" >&2; exit 2 ;;
+        -*) ;;
+        *) break ;;
+    esac
+done
+exec "$REAL_GREP" "\$@"
+EOF
+chmod +x "$P10_DIR/bin/grep"
+
+set +e
+PROBE_OUT=$(PATH="$P10_DIR/bin" "$BASH_FOR_COMPAT" "$UNUSED_SCRIPT" "$P10_DIR/tree" 2>&1)
+PROBE_EXIT=$?
+set -e
+# shellcheck disable=SC2001  # regex replace — ${var//} can't do this
+PROBE_OUT=$(sed "s/$(printf '\033')\[[0-9;]*m//g" <<< "$PROBE_OUT")
+
+p10_ok=1
+assert_out_has     "P10" "requires ripgrep"             || p10_ok=0
+assert_out_missing "P10" "No declarations found"        || p10_ok=0
+assert_exit        "P10" 2                              || p10_ok=0
+if [[ $p10_ok -eq 1 ]]; then
+    echo "  PASS: P10 no-PCRE-grep — loud config error, exit 2 (not false green)"
+    ((PASS++)) || true
+else
+    ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
 echo ""
 echo "=== test_unused_declarations.sh: $PASS passed, $FAIL failed ==="
 [[ "$FAIL" -eq 0 ]]

--- a/plugins/lean4/tests/test_unused_declarations.sh
+++ b/plugins/lean4/tests/test_unused_declarations.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Self-test for unused_declarations.sh — regression coverage for the
+# silent-pass/false-positive hardening pass (sibling of #145's
+# check_axioms_inline hardening). Verifies:
+#   (a) rg-mode extraction produces bare decl names (the pre-fix
+#       `path:name` corruption flagged EVERYTHING as unused);
+#   (b) the expanded keyword set (axiom, constant, structure, and the
+#       noncomputable/unsafe/partial/nonrec modifier prefixes) is
+#       extracted and located;
+#   (c) decl-free trees no longer kill the script under pipefail;
+#   (d) trees whose only decls are unmatched shapes (private, indented)
+#       warn and exit 1 instead of reporting a friendly zero;
+#   (e) genuinely declaration-free trees still exit 0.
+#
+# Unlike test_check_axioms_inline.sh, no shim is needed: the script is
+# pure grep/rg over the filesystem, so tests point it at fixture
+# directories directly. Fixtures are copied to a temp dir per probe so
+# the script can't disturb the sources.
+#
+# Probes invoke the script under $BASH_FOR_COMPAT (default /bin/bash) so
+# the self-test runs under macOS Bash 3.2 in CI. On hosts without
+# /bin/bash (e.g. NixOS) the test SKIPs gracefully.
+
+BASH_FOR_COMPAT="${BASH_FOR_COMPAT:-/bin/bash}"
+if [[ ! -x "$BASH_FOR_COMPAT" ]]; then
+    echo "SKIP: $BASH_FOR_COMPAT not found — cannot run unused_declarations self-test"
+    exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+UNUSED_SCRIPT="$PLUGIN_ROOT/lib/scripts/unused_declarations.sh"
+FIXTURE_ROOT="$SCRIPT_DIR/fixtures/unused_decls"
+
+if [[ ! -x "$UNUSED_SCRIPT" ]]; then
+    echo "FAIL: unused_declarations.sh not found at $UNUSED_SCRIPT"
+    exit 1
+fi
+
+# The script uses `grep -hoP` (PCRE) in its non-rg fallback, which BSD
+# grep doesn't support. Require ripgrep OR a PCRE-capable grep; SKIP
+# otherwise (matches the script's own degradation story).
+if ! command -v rg >/dev/null 2>&1; then
+    if ! echo x | grep -oP 'x' >/dev/null 2>&1; then
+        echo "SKIP: neither ripgrep nor PCRE-capable grep available"
+        exit 0
+    fi
+fi
+
+PASS=0
+FAIL=0
+
+SCRATCH_ROOT=$(mktemp -d)
+trap 'rm -rf "$SCRATCH_ROOT"' EXIT
+PROBE_COUNTER=0
+
+# ---------------------------------------------------------------------------
+# Copies a fixture dir into scratch and runs unused_declarations.sh on it.
+# Args: $1 probe label, $2 fixture subdir name, $3+ extra script args.
+# Populates PROBE_OUT / PROBE_EXIT.
+# ---------------------------------------------------------------------------
+run_probe() {
+    local label="$1"; shift
+    local fixture="$1"; shift
+    ((++PROBE_COUNTER))
+    local tmpdir="$SCRATCH_ROOT/probe-$PROBE_COUNTER"
+    mkdir -p "$tmpdir"
+    cp -r "$FIXTURE_ROOT/$fixture/." "$tmpdir/"
+
+    set +e
+    PROBE_OUT=$("$BASH_FOR_COMPAT" "$UNUSED_SCRIPT" "$tmpdir" "$@" 2>&1)
+    PROBE_EXIT=$?
+    set -e
+    # Strip ANSI color codes: the script embeds them mid-phrase (e.g.
+    # "Found ${BOLD}9${NC} declarations"), which would break substring
+    # assertions on the plain text. ESC comes from printf because BSD sed
+    # (macOS CI) doesn't understand the \x1b escape in patterns.
+    # shellcheck disable=SC2001  # regex replace — ${var//} can't do this
+    PROBE_OUT=$(sed "s/$(printf '\033')\[[0-9;]*m//g" <<< "$PROBE_OUT")
+}
+
+assert_out_has() {
+    local label="$1" want="$2"
+    if grep -qF "$want" <<< "$PROBE_OUT"; then
+        return 0
+    fi
+    echo "  FAIL: $label — expected output substring: $want"
+    echo "        relevant output:"
+    tail -20 <<< "$PROBE_OUT" | sed 's/^/          /'
+    return 1
+}
+
+assert_out_missing() {
+    local label="$1" bad="$2"
+    if grep -qF "$bad" <<< "$PROBE_OUT"; then
+        echo "  FAIL: $label — output unexpectedly contains: $bad"
+        grep -F "$bad" <<< "$PROBE_OUT" | sed 's/^/          /'
+        return 1
+    fi
+}
+
+assert_exit() {
+    local label="$1" want="$2"
+    if [[ "$PROBE_EXIT" -eq "$want" ]]; then
+        return 0
+    fi
+    echo "  FAIL: $label — expected exit $want, got $PROBE_EXIT"
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Probe 1 — has_unused: the pre-fix rg-mode regression. used_thm is
+# referenced; only dead_thm may be flagged. Pre-fix (path:name
+# corruption) flagged both and showed no locations.
+# ---------------------------------------------------------------------------
+run_probe "P1 has-unused" has_unused
+p1_ok=1
+assert_out_has     "P1" "Found 3 declarations"          || p1_ok=0
+assert_out_has     "P1" "dead_thm"                      || p1_ok=0
+assert_out_has     "P1" "Potentially unused: 1"         || p1_ok=0
+assert_out_has     "P1" "Location:"                     || p1_ok=0
+assert_exit        "P1" 1                               || p1_ok=0
+if [[ $p1_ok -eq 1 ]]; then
+    echo "  PASS: P1 has-unused — only dead_thm flagged, with location (rg path-prefix regression)"
+    ((PASS++)) || true
+else
+    ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
+# Probe 2 — expanded_classes: axiom/constant/structure + all four
+# modifier-prefixed defs extracted; exactly the 8 dead ones flagged.
+# ---------------------------------------------------------------------------
+run_probe "P2 expanded-classes" expanded_classes
+p2_ok=1
+assert_out_has     "P2" "Found 9 declarations"          || p2_ok=0
+assert_out_has     "P2" "dead_axiom"                    || p2_ok=0
+assert_out_has     "P2" "dead_constant"                 || p2_ok=0
+assert_out_has     "P2" "dead_noncomp"                  || p2_ok=0
+assert_out_has     "P2" "dead_unsafe"                   || p2_ok=0
+assert_out_has     "P2" "dead_partial"                  || p2_ok=0
+assert_out_has     "P2" "dead_nonrec"                   || p2_ok=0
+assert_out_has     "P2" "DeadStruct"                    || p2_ok=0
+assert_out_has     "P2" "Potentially unused: 7"         || p2_ok=0
+assert_exit        "P2" 1                               || p2_ok=0
+if [[ $p2_ok -eq 1 ]]; then
+    echo "  PASS: P2 expanded-classes — axiom/constant/struct/modifier defs all extracted"
+    ((PASS++)) || true
+else
+    ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
+# Probe 3 — all_used: every decl referenced; green verdict, exit 0.
+# ---------------------------------------------------------------------------
+run_probe "P3 all-used" all_used
+p3_ok=1
+assert_out_has     "P3" "All declarations appear to be used" || p3_ok=0
+assert_exit        "P3" 0                                    || p3_ok=0
+if [[ $p3_ok -eq 1 ]]; then
+    echo "  PASS: P3 all-used — green verdict, exit 0"
+    ((PASS++)) || true
+else
+    ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
+# Probe 4 — private_only: extraction finds nothing, but the tree has
+# decl-shaped content. Shape heuristic must warn + exit 1 (not the
+# friendly "No declarations found" + exit 0).
+# ---------------------------------------------------------------------------
+run_probe "P4 private-only" private_only
+p4_ok=1
+assert_out_has     "P4" "declaration-shaped content exists" || p4_ok=0
+assert_out_missing "P4" "No declarations found"             || p4_ok=0
+assert_exit        "P4" 1                                   || p4_ok=0
+if [[ $p4_ok -eq 1 ]]; then
+    echo "  PASS: P4 private-only — shape heuristic warns, exit 1"
+    ((PASS++)) || true
+else
+    ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
+# Probe 5 — imports_only: genuinely decl-free. Pre-fix, pipefail killed
+# the script mid-run here (rg exits 1 on no matches). Post-fix: clean
+# "No declarations found" + exit 0, and no shape warning.
+# ---------------------------------------------------------------------------
+run_probe "P5 imports-only" imports_only
+p5_ok=1
+assert_out_has     "P5" "No declarations found"             || p5_ok=0
+assert_out_missing "P5" "declaration-shaped content exists" || p5_ok=0
+assert_exit        "P5" 0                                   || p5_ok=0
+if [[ $p5_ok -eq 1 ]]; then
+    echo "  PASS: P5 imports-only — clean exit 0 (pipefail crash regression)"
+    ((PASS++)) || true
+else
+    ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
+# Probe 6 — mixed_dir: cross-file usage counting. shared_thm defined in
+# Used.lean, referenced in Dead.lean → used. local_dead referenced
+# nowhere → flagged.
+# ---------------------------------------------------------------------------
+run_probe "P6 mixed-dir" mixed_dir
+p6_ok=1
+assert_out_has     "P6" "local_dead"                    || p6_ok=0
+assert_out_has     "P6" "Potentially unused: 1"         || p6_ok=0
+assert_exit        "P6" 1                               || p6_ok=0
+if [[ $p6_ok -eq 1 ]]; then
+    echo "  PASS: P6 mixed-dir — cross-file usage counted; only local_dead flagged"
+    ((PASS++)) || true
+else
+    ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
+# Probe 7 — --report-only on a tree with unused decls: findings exit 0.
+# (Coverage failures like P4's shape warning deliberately do NOT get
+# this treatment — mirroring check_axioms_inline's policy — but plain
+# findings do.)
+# ---------------------------------------------------------------------------
+run_probe "P7 report-only" has_unused --report-only
+p7_ok=1
+assert_out_has     "P7" "Potentially unused: 1"         || p7_ok=0
+assert_exit        "P7" 0                               || p7_ok=0
+if [[ $p7_ok -eq 1 ]]; then
+    echo "  PASS: P7 report-only — findings exit 0 under the flag"
+    ((PASS++)) || true
+else
+    ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
+# Probe 8 — --report-only does NOT excuse the shape-heuristic exit.
+# A tree the analysis cannot cover must exit 1 regardless of the flag.
+# ---------------------------------------------------------------------------
+run_probe "P8 report-only shape" private_only --report-only
+p8_ok=1
+assert_out_has     "P8" "declaration-shaped content exists" || p8_ok=0
+assert_exit        "P8" 1                                   || p8_ok=0
+if [[ $p8_ok -eq 1 ]]; then
+    echo "  PASS: P8 report-only+shape — coverage failure still exit 1"
+    ((PASS++)) || true
+else
+    ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== test_unused_declarations.sh: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Hardening pass on `unused_declarations.sh`, applying the silent-pass audit that produced #145 to its sibling script. Found six real bugs — one of which made the script's primary mode **completely non-functional** — plus a CI coverage gap where the new test suite was silently SKIPping on the macOS runner.

Off `fix/unused-decls-hardening` from `origin/main` (`b9d43b9`, post-#145). Five commits, 13 files touched, +504/−27.

## Bugs fixed

**A (severe): rg-mode extraction produced `path:name`, flagging EVERYTHING unused.** `--no-heading` only changes output *grouping*; rg still prefixes every match with `path:` when searching a directory. Every "declaration" in the list was `/abs/path/File.lean:name`, the usage search matched nothing, and every declaration in any project was flagged as potentially unused — with no location lines. This was the behavior whenever ripgrep was installed (the recommended configuration). Fix: `--no-filename`.

**B: missing declaration classes.** Same class as #145 bug 9. Missed `axiom`, `constant`, `structure|class|inductive`, and modifier-prefixed decls. Extraction and location-lookup now share `DECL_KEYWORDS`/`DECL_MODIFIERS`. `example` deliberately absent (anonymous).

**C (pre-existing crash): pipefail killed the script on decl-free trees.** rg exits 1 on zero matches under `set -euo pipefail` → died mid-run, no summary. The `TOTAL_DECLS -eq 0` branch was unreachable in rg mode. Fix: `|| true` guards.

**D (policy): zero-decls exit 0 was indistinguishable from missed coverage.** Shape-detection heuristic distinguishes genuinely-empty trees (exit 0) from decl-shaped-content-the-extraction-missed (warn + exit 1, regardless of `--report-only`).

**E (review-caught): fallback false-green when neither rg nor PCRE grep available.** On stock macOS without ripgrep, `grep -hoP` failed, the Bug-C guard masked it, and ordinary declarations reported "No declarations found" + exit 0. Fix: hard PCRE check when rg absent; exit 2 with a loud requirement error.

**F (review-caught): shape heuristic missed indented modifier-prefixed decls.** `  noncomputable def hidden` reported a friendly zero. Rewritten: optional indent + optional access modifier + optional decl modifier + keyword at any depth — also defense-in-depth against future extraction regressions.

**G (review-caught, CI): the test suite was silently SKIPping on the macOS runner.** The runner ships neither ripgrep nor PCRE grep, so the suite's portability SKIP fired and the job stayed green with zero actual coverage. The reviewer asked for auditable rg logging; checking the logs confirmed the gap. Fix: `brew install ripgrep` step + `rg --version` hard assertion in the workflow.

## Known limitation (documented, deferred)

**Namespace-qualified usage is not credited.** `theorem foo` inside `namespace A`, referenced as `A.foo`, is still flagged unused — extraction records the short name and the usage boundary deliberately excludes `.`-prefixed forms. Needs namespace inference (#145's frame-stack walk) + qualified-name matching. Documented in the script header's Known Limitations block with a pointer to `find_usages.sh`.

## Commits

| Hash | Message |
|---|---|
| `cd92d56` | Bugs A & B — `--no-filename` + expanded decl classes |
| `828f47a` | Bugs C & D — pipefail guard + shape heuristic |
| `2482609` | Tests — 8 fixture-based probes + bash3 CI wire-in |
| `33f3aa9` | Bugs E & F — PCRE hard-check + broadened heuristic + ns-usage limitation docs |
| `435c204` | Bug G + class/inductive fixture coverage + `#check`-based all_used + header polish |

## Self-test (10 probes)

- P1 has-unused — the rg path-prefix regression (referenced decl NOT flagged; dead one flagged WITH location)
- P2 expanded-classes — axiom/constant/structure/class/inductive + all four modifier prefixes; exactly the 9 dead decls flagged (11 total)
- P3 all-used — leaf referenced via real `#check` command; green verdict, exit 0
- P4 private-only — shape heuristic warns + exit 1
- P5 imports-only — the pipefail crash regression (clean exit 0)
- P6 mixed-dir — cross-file usage counting
- P7 --report-only — plain findings exit 0
- P8 --report-only + shape — coverage failure still exit 1
- P9 indented-modifier — heuristic catches indented `noncomputable def`
- P10 no-PCRE-grep — constrained-PATH simulation: loud config error, exit 2, no false green

First test coverage this script has ever had. CI now installs ripgrep and asserts `rg --version` so the suite actually executes (previously SKIPped silently — see Bug G).

## Out of scope (deliberately)

- **`sorry_analyzer.py` hardening** — same audit flagged an empty-input silent-success path; separate PR.
- **Namespace-qualified usage crediting** — see Known Limitation.
- **Comment/string-usage false-credit** — documented limitation; stripping comments requires Lean parsing.
- **Version bump / CHANGELOG** — behavior fix; folds into v4.5.3.

## Test plan

- [x] Self-test: 10 passed, 0 failed (local, rg path).
- [x] Existing suites unaffected: `test_check_axioms_inline.sh` 30/30, `lint_docs.sh` exit 0.
- [x] Shellcheck clean.
- [x] Manual repro matrix: used/unused pair, expanded-class fixture, private-only, indented-modifier, imports-only, empty dir, no-PCRE PATH.
- [x] CI: awaiting run on `435c204` — the first where the suite actually executes on the runner (rg now installed).