### PR TITLE
fix(sorry-analyzer): coverage-aware exit semantics + modifier-aware decl attribution + CI'd Python tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,28 @@ jobs:
       - name: ruff format --check
         run: ruff format --check plugins/lean4/
 
+  python-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          # Documented runtime floor (pyproject.toml's target-version =
+          # "py310") so version-sensitive syntax breaks loudly here rather
+          # than on a user's machine.
+          python-version: "3.10"
+
+      # stdlib unittest only — no pins needed (nothing to install).
+      # Both files listed explicitly: test_ordering.py existed for months
+      # without ever being executed in CI (the same silent-coverage-gap
+      # class that #146 found for the bash suite, where a green step hid a
+      # self-SKIPping test run).
+      - name: Unit tests — lib/scripts (stdlib unittest, no deps)
+        run: |
+          python3 plugins/lean4/lib/scripts/tests/test_ordering.py
+          python3 plugins/lean4/lib/scripts/tests/test_sorry_analyzer.py
+
   mypy:
     runs-on: ubuntu-latest
     steps:

--- a/plugins/lean4/lib/scripts/README.md
+++ b/plugins/lean4/lib/scripts/README.md
@@ -194,11 +194,11 @@ Analyze let binding usage to avoid bad optimizations.
 Most scripts exit non-zero only on real errors (missing arguments, invalid paths, compilation failures).
 
 Three grep-style scripts also exit non-zero on findings by default — useful for CI gating:
-- `sorry_analyzer.py` — exit 1 when sorries found
+- `sorry_analyzer.py` — exit 1 when sorries found; exit 2 on coverage failure (zero .lean files scanned, or unreadable paths)
 - `check_axioms_inline.sh` — exit 1 when custom axioms found
-- `unused_declarations.sh` — exit 1 when unused declarations found
+- `unused_declarations.sh` — exit 1 when unused declarations found; exit 2 when neither ripgrep nor PCRE grep is available
 
-**`--exit-zero-on-findings`** (alias: `--report-only`): Makes findings exit 0 while real errors still exit 1. Use in report-only contexts (reviews, troubleshooting); do not use in gate commands like `/lean4:checkpoint`. **Note (`check_axioms_inline.sh`):** the flag applies to custom-axiom *findings* only. Coverage failures — unverified files or aggregate zero-declaration coverage — always exit 1 regardless of this flag, because a gate that couldn't make a determination for one or more files must not silently pass:
+**`--exit-zero-on-findings`** (alias: `--report-only`): Makes findings exit 0 while real errors still exit 1. Use in report-only contexts (reviews, troubleshooting); do not use in gate commands like `/lean4:checkpoint`. **Note (all three scripts):** the flag applies to *findings* only. Coverage failures — zero files scanned, unreadable paths, unverified files, or unanalyzable trees — always exit non-zero regardless of this flag, because a gate that couldn't make a determination must not silently pass:
 
 ```bash
 ${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/sorry_analyzer.py" . --format=summary --report-only

--- a/plugins/lean4/lib/scripts/TESTING.md
+++ b/plugins/lean4/lib/scripts/TESTING.md
@@ -6,7 +6,7 @@ Test results and validation status for Lean 4 scripts.
 
 | Script | Status | Notes |
 |--------|--------|-------|
-| `sorry_analyzer.py` | ✅ Production Ready | Multi-format output, interactive mode |
+| `sorry_analyzer.py` | ✅ Production Ready | Multi-format output, interactive mode; coverage-aware exit codes (exit 2 on zero-scan/unreadable paths); unit+subprocess suite in tests/, run by lint.yml's python-tests CI job (which also runs test_ordering.py — previously never executed in CI) |
 | `check_axioms_inline.sh` | ✅ Production Ready | Namespace-stack tracking (all namespaces + sections); top-level unindented declarations; batch mode, directory support; coverage-invariant surfaces unverified files rather than silently passing |
 | `search_mathlib.sh` | ✅ Production Ready | Pattern search with ripgrep |
 | `smart_search.sh` | ✅ Production Ready | Multi-source (LeanSearch, Loogle) |

--- a/plugins/lean4/lib/scripts/sorry_analyzer.py
+++ b/plugins/lean4/lib/scripts/sorry_analyzer.py
@@ -138,14 +138,36 @@ def strip_lean_comments_and_strings(
 
 
 def extract_declaration_name(lines: list[str], sorry_idx: int) -> str | None:
-    """Extract the theorem/lemma/def name containing this sorry"""
-    # Search backwards for declaration
-    # Support Unicode and qualified names (e.g., Foo.bar, foo', foo'')
-    # Handle optional visibility modifiers (private, protected) and attributes (@[...])
-    for i in range(sorry_idx - 1, max(0, sorry_idx - 50), -1):
+    """Extract the declaration name containing this sorry.
+
+    Returns "keyword name" (e.g. "def foo") — visibility and decl
+    modifiers are deliberately dropped from the label: keyword+name is
+    the declaration's identity; modifiers are noise for attribution.
+    Anonymous `example : ...` has no name to capture and stays
+    unattributed (None).
+    """
+    # Search backwards for declaration.
+    # Support Unicode and qualified names (e.g., Foo.bar, foo', foo'').
+    # Handles optional same-line attributes (@[...]), visibility
+    # (private/protected/local), and decl modifiers
+    # (noncomputable/unsafe/partial/nonrec). An attribute on its OWN
+    # line above the declaration also works — the backward search hits
+    # the declaration line before the attribute line.
+    # axiom/constant deliberately absent: they have no proof body, so a
+    # sorry can never be inside one; matching them would only create
+    # misattribution risk for the nearest-header-wins backward search.
+    #
+    # The search STARTS AT the sorry's own line (not the line before):
+    # single-line declarations (`def foo : Nat := by sorry`) put the
+    # header and the sorry on the same line, and starting one line up
+    # left every such sorry unattributed. Stop bound is -1 so line 0 is
+    # included in the window.
+    for i in range(sorry_idx, max(-1, sorry_idx - 50), -1):
         match = re.match(
-            r"^\s*(?:@\[.*?\]\s*)?(?:private\s+|protected\s+)?"
-            r"(theorem|lemma|def|example|instance|structure|class)\s+([\w.']+)",
+            r"^\s*(?:@\[.*?\]\s*)?"
+            r"(?:(?:private|protected|local)\s+)?"
+            r"(?:(?:noncomputable|unsafe|partial|nonrec)\s+)?"
+            r"(theorem|lemma|def|abbrev|example|instance|structure|class|inductive)\s+([\w.']+)",
             lines[i],
         )
         if match:

--- a/plugins/lean4/lib/scripts/sorry_analyzer.py
+++ b/plugins/lean4/lib/scripts/sorry_analyzer.py
@@ -148,10 +148,12 @@ def extract_declaration_name(lines: list[str], sorry_idx: int) -> str | None:
     """
     # Search backwards for declaration.
     # Support Unicode and qualified names (e.g., Foo.bar, foo', foo'').
-    # Handles optional same-line attributes (@[...]), visibility
-    # (private/protected/local), and decl modifiers
-    # (noncomputable/unsafe/partial/nonrec). An attribute on its OWN
-    # line above the declaration also works — the backward search hits
+    # Handles optional same-line attributes (@[...]) followed by any number
+    # of scope/visibility/decl modifiers in any order — private, protected,
+    # local, scoped, noncomputable, unsafe, partial, nonrec. (A single
+    # fixed "visibility then modifier" slot missed real forms like
+    # `scoped instance`, which mathlib uses heavily.) An attribute on its
+    # OWN line above the declaration also works — the backward search hits
     # the declaration line before the attribute line.
     # axiom/constant deliberately absent: they have no proof body, so a
     # sorry can never be inside one; matching them would only create
@@ -165,8 +167,7 @@ def extract_declaration_name(lines: list[str], sorry_idx: int) -> str | None:
     for i in range(sorry_idx, max(-1, sorry_idx - 50), -1):
         match = re.match(
             r"^\s*(?:@\[.*?\]\s*)?"
-            r"(?:(?:private|protected|local)\s+)?"
-            r"(?:(?:noncomputable|unsafe|partial|nonrec)\s+)?"
+            r"(?:(?:private|protected|local|scoped|noncomputable|unsafe|partial|nonrec)\s+)*"
             r"(theorem|lemma|def|abbrev|example|instance|structure|class|inductive)\s+([\w.']+)",
             lines[i],
         )
@@ -260,6 +261,15 @@ def find_sorries(target: Path, include_deps: bool = False) -> ScanResult:
         include_deps: If False (default), exclude .lake/ directories (dependencies)
     """
     if target.is_file():
+        # Guard: a direct file target must be a .lean file. Directory mode
+        # only scans *.lean; direct mode used to scan ANY file, so
+        # `sorry_analyzer.py README.md` counted files_scanned=1 and exited
+        # 0 — a "gate scanned nothing meaningful but passed" case. Treat a
+        # non-.lean target as zero coverage (exit 2 downstream). Matches
+        # the directory walk's `filename.endswith(".lean")` filter.
+        if target.suffix != ".lean":
+            print(f"Skipping non-Lean file: {target}", file=sys.stderr)
+            return ScanResult(sorries=[], files_scanned=0, files_failed=0)
         # Guard: Also exclude .lake/ files unless --include-deps
         if not include_deps and ".lake" in target.parts:
             print(

--- a/plugins/lean4/lib/scripts/sorry_analyzer.py
+++ b/plugins/lean4/lib/scripts/sorry_analyzer.py
@@ -17,6 +17,15 @@ Modes:
     --include-deps: Include .lake/ directories (dependencies) in search (excluded by default)
     --exit-zero-on-findings (or --report-only): Exit 0 even when sorries are found (real errors still exit 1)
 
+Exit codes:
+    0 - scanned at least one file, no sorries found (or findings present
+        with --exit-zero-on-findings)
+    1 - sorries found (without --exit-zero-on-findings); also usage errors
+    2 - coverage failure: zero .lean files were scanned, or one or more
+        paths could not be read. NOT excused by --exit-zero-on-findings:
+        that flag means "findings are non-fatal for reporting" — a gate
+        that scanned nothing (or missed part of the tree) must not pass.
+
 Examples:
     ./sorry_analyzer.py MyFile.lean
     ./sorry_analyzer.py src/DeFinetti/ --format=markdown
@@ -48,6 +57,22 @@ class Sorry:
     context_after: list[str]
     documentation: list[str]
     in_declaration: str | None = None
+
+
+@dataclass
+class ScanResult:
+    """Findings plus the coverage they rest on.
+
+    files_scanned counts .lean files actually read; files_failed counts
+    paths (files OR directories) that could not be read. Coverage travels
+    with the findings so callers can distinguish "clean" from "checked
+    nothing" — the distinction whose absence caused the silent-green
+    failure modes fixed in #145/#146 for the sibling bash tools.
+    """
+
+    sorries: list[Sorry]
+    files_scanned: int
+    files_failed: int
 
 
 SORRY_TOKEN_PATTERN = re.compile(r"(?<![A-Za-z0-9_!?'])sorry(?![A-Za-z0-9_!?'])")
@@ -153,14 +178,19 @@ def extract_documentation(lines: list[str], sorry_idx: int) -> list[str]:
     return docs
 
 
-def find_sorries_in_file(filepath: Path) -> list[Sorry]:
-    """Find all sorries in a single Lean file"""
+def find_sorries_in_file(filepath: Path) -> list[Sorry] | None:
+    """Find all sorries in a single Lean file.
+
+    Returns None when the file could not be read — callers must count
+    that as a coverage failure, not an empty result. (Returning [] here
+    previously let a directory of unreadable files report clean.)
+    """
     try:
         with open(filepath, encoding="utf-8") as f:
             lines = f.readlines()
     except Exception as e:
         print(f"Warning: Could not read {filepath}: {e}", file=sys.stderr)
-        return []
+        return None
 
     sorries = []
     block_comment_depth = 0
@@ -200,8 +230,8 @@ def find_sorries_in_file(filepath: Path) -> list[Sorry]:
     return sorries
 
 
-def find_sorries(target: Path, include_deps: bool = False) -> list[Sorry]:
-    """Find all sorries in target file or directory
+def find_sorries(target: Path, include_deps: bool = False) -> ScanResult:
+    """Find all sorries in target file or directory, with coverage counts.
 
     Args:
         target: File or directory to search
@@ -214,8 +244,11 @@ def find_sorries(target: Path, include_deps: bool = False) -> list[Sorry]:
                 f"Skipping dependency file: {target} (use --include-deps to include)",
                 file=sys.stderr,
             )
-            return []
-        return find_sorries_in_file(target)
+            return ScanResult(sorries=[], files_scanned=0, files_failed=0)
+        file_sorries = find_sorries_in_file(target)
+        if file_sorries is None:
+            return ScanResult(sorries=[], files_scanned=0, files_failed=1)
+        return ScanResult(sorries=file_sorries, files_scanned=1, files_failed=0)
     elif target.is_dir():
         # Guard: Exclude .lake directory or any subpath unless --include-deps
         if not include_deps and ".lake" in target.parts:
@@ -223,20 +256,37 @@ def find_sorries(target: Path, include_deps: bool = False) -> list[Sorry]:
                 f"Skipping dependency directory: {target} (use --include-deps to include)",
                 file=sys.stderr,
             )
-            return []
-        sorries = []
-        # Use os.walk for early termination of .lake/ directories (performance)
-        import os
+            return ScanResult(sorries=[], files_scanned=0, files_failed=0)
+        sorries: list[Sorry] = []
+        files_scanned = 0
+        files_failed = 0
 
-        for root, dirs, files in os.walk(target):
+        # os.walk silently swallows errors (e.g. an unreadable subdirectory
+        # just doesn't get descended into) unless onerror is passed — the
+        # directory-level analog of an unreadable file. Both count as
+        # coverage failures.
+        def _walk_error(err: OSError) -> None:
+            nonlocal files_failed
+            print(f"Warning: Could not read {err.filename}: {err}", file=sys.stderr)
+            files_failed += 1
+
+        # Use os.walk for early termination of .lake/ directories (performance)
+        for root, dirs, files in os.walk(target, onerror=_walk_error):
             # Prune .lake directories from traversal (don't descend into them)
             if not include_deps:
                 dirs[:] = [d for d in dirs if d != ".lake"]
             for filename in files:
                 if filename.endswith(".lean"):
                     lean_file = Path(root) / filename
-                    sorries.extend(find_sorries_in_file(lean_file))
-        return sorries
+                    file_sorries = find_sorries_in_file(lean_file)
+                    if file_sorries is None:
+                        files_failed += 1
+                    else:
+                        files_scanned += 1
+                        sorries.extend(file_sorries)
+        return ScanResult(
+            sorries=sorries, files_scanned=files_scanned, files_failed=files_failed
+        )
     else:
         raise ValueError(f"{target} is not a file or directory")
 
@@ -306,22 +356,32 @@ def format_markdown(sorries: list[Sorry]) -> str:
     return "\n".join(output)
 
 
-def format_json(sorries: list[Sorry]) -> str:
-    """Format sorries as JSON"""
+def format_json(result: ScanResult) -> str:
+    """Format scan result as JSON (additive coverage fields)"""
     return json.dumps(
-        {"total_count": len(sorries), "sorries": [asdict(s) for s in sorries]}, indent=2
+        {
+            "total_count": len(result.sorries),
+            "files_scanned": result.files_scanned,
+            "files_failed": result.files_failed,
+            "sorries": [asdict(s) for s in result.sorries],
+        },
+        indent=2,
     )
 
 
-def format_summary(sorries: list[Sorry]) -> str:
-    """Format sorries as a brief summary (file counts + total)"""
+def format_summary(result: ScanResult) -> str:
+    """Format scan result as a brief summary (file counts + total + coverage)"""
+    sorries = result.sorries
     output = []
     # Group by file
     by_file: dict[str, list[Sorry]] = {}
     for sorry in sorries:
         by_file.setdefault(sorry.file, []).append(sorry)
 
-    output.append(f"Sorry Summary: {len(sorries)} total across {len(by_file)} file(s)")
+    output.append(
+        f"Sorry Summary: {len(sorries)} total across {len(by_file)} file(s) "
+        f"with sorries; {result.files_scanned} file(s) scanned"
+    )
     output.append("-" * 50)
 
     for filepath, file_sorries in sorted(by_file.items(), key=lambda x: -len(x[1])):
@@ -515,24 +575,51 @@ def main() -> None:
         sys.exit(1)
 
     # Find all sorries (excludes .lake/ by default)
-    sorries = find_sorries(target, include_deps=include_deps)
+    result = find_sorries(target, include_deps=include_deps)
+    sorries = result.sorries
 
-    # Interactive mode takes precedence
+    # Coverage failures exit 2 regardless of --exit-zero-on-findings: that
+    # flag makes FINDINGS non-fatal for reporting; a run that scanned
+    # nothing (or couldn't read part of the tree) is a different category —
+    # a gate that can't answer must not pass. Same policy as
+    # check_axioms_inline.sh (#145) and unused_declarations.sh (#146).
+    coverage_failed = result.files_scanned == 0 or result.files_failed > 0
+    if coverage_failed:
+        if result.files_scanned == 0:
+            print(
+                f"Warning: no .lean files were scanned under {target} — "
+                "nothing was analyzed",
+                file=sys.stderr,
+            )
+        if result.files_failed > 0:
+            print(
+                f"Warning: {result.files_failed} path(s) could not be read — "
+                "coverage is incomplete",
+                file=sys.stderr,
+            )
+
+    # Interactive mode takes precedence — but not on coverage failure:
+    # interactive_mode's "No sorries found!" greeting would be exactly the
+    # false reassurance the coverage check exists to remove.
     if interactive:
+        if coverage_failed:
+            sys.exit(2)
         interactive_mode(sorries)
         sys.exit(0 if len(sorries) == 0 or exit_zero_on_findings else 1)
 
     # Format output
     if format_type == "json":
-        print(format_json(sorries))
+        print(format_json(result))
     elif format_type == "markdown":
         print(format_markdown(sorries))
     elif format_type == "summary":
-        print(format_summary(sorries))
+        print(format_summary(result))
     else:
         print(format_text(sorries))
 
-    # Exit code: 0 if no sorries, 1 if sorries found
+    # Exit codes: 2 coverage failure > 1 findings > 0 clean.
+    if coverage_failed:
+        sys.exit(2)
     sys.exit(0 if len(sorries) == 0 or exit_zero_on_findings else 1)
 
 

--- a/plugins/lean4/lib/scripts/tests/test_sorry_analyzer.py
+++ b/plugins/lean4/lib/scripts/tests/test_sorry_analyzer.py
@@ -149,6 +149,16 @@ class TestExtractDeclarationName(unittest.TestCase):
             "instance inst",
         )
 
+    def test_scoped_instance(self) -> None:
+        # `scoped instance` (common in mathlib) was unattributed before the
+        # modifier set was generalized — `scoped` was in neither the old
+        # visibility nor decl-modifier slot, so the keyword match fell
+        # through to None.
+        self.assertEqual(
+            self.attribute("scoped instance sInst : Inhabited Nat := by\n  sorry\n"),
+            "instance sInst",
+        )
+
     def test_abbrev(self) -> None:
         self.assertEqual(
             self.attribute("abbrev shortcut : Nat := by\n  sorry\n"),
@@ -271,6 +281,18 @@ class TestExitCodes(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             Path(td, "notes.txt").write_text("no lean here\n")
             self.assertEqual(run_analyzer(td).returncode, 2)
+
+    def test_direct_non_lean_file_exits_two(self) -> None:
+        # A non-.lean file passed DIRECTLY used to be scanned as if it
+        # were Lean (files_scanned=1, exit 0) — directory mode filters by
+        # suffix but direct mode did not. Now zero coverage → exit 2.
+        with tempfile.TemporaryDirectory() as td:
+            notes = Path(td, "notes.txt")
+            notes.write_text("no lean here\n")
+            proc = run_analyzer(str(notes))
+            self.assertEqual(proc.returncode, 2)
+            self.assertIn("nothing was analyzed", proc.stderr)
+            self.assertIn("Skipping non-Lean file", proc.stderr)
 
     def test_direct_lake_file_target_exits_two(self) -> None:
         # A .lake file passed directly is skipped (stderr message), so

--- a/plugins/lean4/lib/scripts/tests/test_sorry_analyzer.py
+++ b/plugins/lean4/lib/scripts/tests/test_sorry_analyzer.py
@@ -21,6 +21,8 @@ Run:
 
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 import subprocess
 import sys
@@ -210,8 +212,31 @@ class TestScanResultCoverage(unittest.TestCase):
     def test_unreadable_file_returns_none(self) -> None:
         # Passing a directory where a file is expected forces the open()
         # exception portably (no chmod games that break as root/CI).
-        with tempfile.TemporaryDirectory() as td:
+        # redirect_stderr keeps the intentional "Could not read" warning
+        # out of the test runner's output.
+        with (
+            tempfile.TemporaryDirectory() as td,
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
             self.assertIsNone(find_sorries_in_file(Path(td)))
+
+    def test_partial_coverage_some_scanned_some_failed(self) -> None:
+        # One readable .lean + one unreadable .lean (a broken symlink,
+        # which os.walk lists as a file but open() then fails on). Locks
+        # in the "some scanned + some failed" case — distinct from the
+        # zero-coverage case: files_scanned>0 AND files_failed>0.
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "Clean.lean").write_text("theorem ok : True := trivial\n")
+            broken = root / "Broken.lean"
+            try:
+                broken.symlink_to(root / "does_not_exist.lean")
+            except (OSError, NotImplementedError):
+                self.skipTest("symlinks not supported on this platform")
+            with contextlib.redirect_stderr(io.StringIO()):
+                result = find_sorries(root)
+            self.assertEqual(result.files_scanned, 1)
+            self.assertEqual(result.files_failed, 1)
 
 
 class TestExitCodes(unittest.TestCase):
@@ -261,6 +286,27 @@ class TestExitCodes(unittest.TestCase):
             self.assertIn("Skipping dependency file", proc.stderr)
             proc_deps = run_analyzer(str(dep), "--include-deps")
             self.assertEqual(proc_deps.returncode, 1)  # the sorry is found
+
+    def test_partial_coverage_exits_two(self) -> None:
+        # A directory with one clean .lean and one unreadable .lean
+        # (broken symlink) is PARTIAL coverage: something was scanned,
+        # something failed. Must still exit 2 (a gate that missed part of
+        # the tree can't answer), with files_scanned=1 / files_failed=1
+        # visible in the JSON. stderr carries "coverage is incomplete".
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "Clean.lean").write_text("theorem ok : True := trivial\n")
+            broken = root / "Broken.lean"
+            try:
+                broken.symlink_to(root / "does_not_exist.lean")
+            except (OSError, NotImplementedError):
+                self.skipTest("symlinks not supported on this platform")
+            proc = run_analyzer(str(root), "--format=json")
+            self.assertEqual(proc.returncode, 2)
+            self.assertIn("coverage is incomplete", proc.stderr)
+            data = json.loads(proc.stdout)
+            self.assertEqual(data["files_scanned"], 1)
+            self.assertEqual(data["files_failed"], 1)
 
     def test_json_on_empty_dir_is_valid_json(self) -> None:
         # Warnings go to stderr; stdout must remain parseable JSON even on

--- a/plugins/lean4/lib/scripts/tests/test_sorry_analyzer.py
+++ b/plugins/lean4/lib/scripts/tests/test_sorry_analyzer.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""
+Regression tests for sorry_analyzer.py — the coverage-aware exit
+semantics and declaration-attribution hardening (silent-pass audit
+series: #145 check_axioms_inline, #146 unused_declarations).
+
+Two layers:
+  - Unit tests import the module's functions directly (comment/string
+    stripping, token boundaries, declaration attribution, ScanResult
+    coverage counting).
+  - Subprocess tests run the script end-to-end against tempdir fixtures
+    and assert EXIT CODES — the load-bearing regressions: an empty
+    directory must exit 2 (pre-fix: "Found 0 sorry statement(s)" +
+    exit 0), and --report-only must NOT excuse coverage failures.
+
+Run:
+    python3 tests/test_sorry_analyzer.py
+    # or from repo root:
+    python3 plugins/lean4/lib/scripts/tests/test_sorry_analyzer.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Allow import from parent directory
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from sorry_analyzer import (
+    SORRY_TOKEN_PATTERN,
+    extract_declaration_name,
+    find_sorries,
+    find_sorries_in_file,
+    strip_lean_comments_and_strings,
+)
+
+SCRIPT = Path(__file__).resolve().parent.parent / "sorry_analyzer.py"
+
+
+def run_analyzer(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run sorry_analyzer.py as a subprocess, capturing output."""
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class TestStripCommentsAndStrings(unittest.TestCase):
+    def strip_code(self, line: str, depth: int = 0) -> str:
+        code, _ = strip_lean_comments_and_strings(line, depth)
+        return code
+
+    def test_sorry_in_line_comment_removed(self) -> None:
+        self.assertNotIn("sorry", self.strip_code("exact foo -- sorry later"))
+
+    def test_sorry_in_block_comment_removed(self) -> None:
+        self.assertNotIn("sorry", self.strip_code("/- sorry -/ exact foo"))
+
+    def test_sorry_inside_open_block_comment_removed(self) -> None:
+        # Entering the line already inside a block comment (depth 1).
+        self.assertNotIn("sorry", self.strip_code("this sorry is commentary", depth=1))
+
+    def test_nested_block_comment_depth_tracked(self) -> None:
+        _, depth = strip_lean_comments_and_strings("/- outer /- inner", 0)
+        self.assertEqual(depth, 2)
+
+    def test_sorry_in_string_literal_removed(self) -> None:
+        self.assertNotIn("sorry", self.strip_code('def msg := "say sorry now"'))
+
+    def test_real_code_sorry_kept(self) -> None:
+        self.assertIn("sorry", self.strip_code("theorem foo : True := by sorry"))
+
+
+class TestSorryTokenBoundaries(unittest.TestCase):
+    def test_bare_sorry_matches(self) -> None:
+        self.assertIsNotNone(SORRY_TOKEN_PATTERN.search("by sorry"))
+
+    def test_sorry_ax_does_not_match(self) -> None:
+        self.assertIsNone(SORRY_TOKEN_PATTERN.search("uses sorryAx here"))
+
+    def test_identifier_containing_sorry_does_not_match(self) -> None:
+        self.assertIsNone(SORRY_TOKEN_PATTERN.search("def my_sorry := 1"))
+
+    def test_primed_sorry_does_not_match(self) -> None:
+        self.assertIsNone(SORRY_TOKEN_PATTERN.search("exact sorry'"))
+
+
+class TestExtractDeclarationName(unittest.TestCase):
+    def attribute(self, source: str) -> str | None:
+        """Run extraction with the sorry on the LAST line of source."""
+        lines = source.splitlines(keepends=True)
+        return extract_declaration_name(lines, len(lines) - 1)
+
+    def test_plain_theorem(self) -> None:
+        self.assertEqual(
+            self.attribute("theorem foo : True := by\n  sorry\n"),
+            "theorem foo",
+        )
+
+    def test_private_theorem(self) -> None:
+        self.assertEqual(
+            self.attribute("private theorem hidden : True := by\n  sorry\n"),
+            "theorem hidden",
+        )
+
+    def test_same_line_attribute(self) -> None:
+        # @[simp] on the SAME line as the declaration — the regex handles
+        # this form directly.
+        self.assertEqual(
+            self.attribute("@[simp] theorem simped : True := by\n  sorry\n"),
+            "theorem simped",
+        )
+
+    def test_two_line_attribute(self) -> None:
+        # @[simp] on its OWN line above the declaration. Works because the
+        # backward search reaches the theorem line before the attribute
+        # line — pin that so it stays true.
+        self.assertEqual(
+            self.attribute("@[simp]\ntheorem simped : True := by\n  sorry\n"),
+            "theorem simped",
+        )
+
+    def test_noncomputable_def(self) -> None:
+        # THE fix: modifier-prefixed decls previously returned None.
+        # Note the label deliberately drops the modifier — keyword+name is
+        # the declaration's identity.
+        self.assertEqual(
+            self.attribute("noncomputable def opaque : Nat := by\n  sorry\n"),
+            "def opaque",
+        )
+
+    def test_protected_noncomputable_def(self) -> None:
+        self.assertEqual(
+            self.attribute("protected noncomputable def both : Nat := by\n  sorry\n"),
+            "def both",
+        )
+
+    def test_local_instance(self) -> None:
+        self.assertEqual(
+            self.attribute("local instance inst : Inhabited Nat := by\n  sorry\n"),
+            "instance inst",
+        )
+
+    def test_abbrev(self) -> None:
+        self.assertEqual(
+            self.attribute("abbrev shortcut : Nat := by\n  sorry\n"),
+            "abbrev shortcut",
+        )
+
+    def test_inductive(self) -> None:
+        self.assertEqual(
+            self.attribute("inductive Tree where\n  sorry\n"),
+            "inductive Tree",
+        )
+
+    def test_same_line_sorry_attributed(self) -> None:
+        # Single-line declaration: header and sorry share a line. The
+        # search must start AT the sorry's line, not one above.
+        lines = ["def quick : Nat := by sorry\n"]
+        self.assertEqual(extract_declaration_name(lines, 0), "def quick")
+
+    def test_no_header_returns_none(self) -> None:
+        lines = ["-- just a comment\n", "  sorry\n"]
+        self.assertIsNone(extract_declaration_name(lines, 1))
+
+
+class TestScanResultCoverage(unittest.TestCase):
+    def test_directory_counts_scanned_files(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "A.lean").write_text("theorem a : False := by sorry\n")
+            (root / "B.lean").write_text("theorem b : True := trivial\n")
+            result = find_sorries(root)
+            self.assertEqual(result.files_scanned, 2)
+            self.assertEqual(result.files_failed, 0)
+            self.assertEqual(len(result.sorries), 1)
+
+    def test_empty_directory_scans_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            result = find_sorries(Path(td))
+            self.assertEqual(result.files_scanned, 0)
+            self.assertEqual(result.files_failed, 0)
+            self.assertEqual(result.sorries, [])
+
+    def test_non_lean_files_not_counted(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "notes.txt").write_text("sorry sorry sorry\n")
+            result = find_sorries(root)
+            self.assertEqual(result.files_scanned, 0)
+
+    def test_lake_excluded_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            lake = root / ".lake" / "packages"
+            lake.mkdir(parents=True)
+            (lake / "Dep.lean").write_text("theorem dep : False := by sorry\n")
+            result = find_sorries(root)
+            self.assertEqual(result.files_scanned, 0)
+            result_deps = find_sorries(root, include_deps=True)
+            self.assertEqual(result_deps.files_scanned, 1)
+            self.assertEqual(len(result_deps.sorries), 1)
+
+    def test_unreadable_file_returns_none(self) -> None:
+        # Passing a directory where a file is expected forces the open()
+        # exception portably (no chmod games that break as root/CI).
+        with tempfile.TemporaryDirectory() as td:
+            self.assertIsNone(find_sorries_in_file(Path(td)))
+
+
+class TestExitCodes(unittest.TestCase):
+    """Subprocess layer — the load-bearing exit-code regressions."""
+
+    def test_clean_dir_exits_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            Path(td, "Clean.lean").write_text("theorem ok : True := trivial\n")
+            proc = run_analyzer(td)
+            self.assertEqual(proc.returncode, 0)
+
+    def test_sorry_exits_one(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            Path(td, "S.lean").write_text("theorem s : False := by sorry\n")
+            self.assertEqual(run_analyzer(td).returncode, 1)
+            self.assertEqual(run_analyzer(td, "--report-only").returncode, 0)
+
+    def test_empty_dir_exits_two(self) -> None:
+        # PRIMARY regression: pre-fix this reported "Found 0 sorry
+        # statement(s)" and exited 0.
+        with tempfile.TemporaryDirectory() as td:
+            proc = run_analyzer(td)
+            self.assertEqual(proc.returncode, 2)
+            self.assertIn("nothing was analyzed", proc.stderr)
+
+    def test_empty_dir_report_only_still_exits_two(self) -> None:
+        # --report-only excuses findings, NOT coverage failures.
+        with tempfile.TemporaryDirectory() as td:
+            self.assertEqual(run_analyzer(td, "--report-only").returncode, 2)
+
+    def test_non_lean_only_dir_exits_two(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            Path(td, "notes.txt").write_text("no lean here\n")
+            self.assertEqual(run_analyzer(td).returncode, 2)
+
+    def test_direct_lake_file_target_exits_two(self) -> None:
+        # A .lake file passed directly is skipped (stderr message), so
+        # zero files were scanned — one of the silent-zero paths; pre-fix
+        # exit 0. With --include-deps it scans normally.
+        with tempfile.TemporaryDirectory() as td:
+            lake = Path(td, ".lake")
+            lake.mkdir()
+            dep = lake / "Dep.lean"
+            dep.write_text("theorem dep : False := by sorry\n")
+            proc = run_analyzer(str(dep))
+            self.assertEqual(proc.returncode, 2)
+            self.assertIn("Skipping dependency file", proc.stderr)
+            proc_deps = run_analyzer(str(dep), "--include-deps")
+            self.assertEqual(proc_deps.returncode, 1)  # the sorry is found
+
+    def test_json_on_empty_dir_is_valid_json(self) -> None:
+        # Warnings go to stderr; stdout must remain parseable JSON even on
+        # coverage failure.
+        with tempfile.TemporaryDirectory() as td:
+            proc = run_analyzer(td, "--format=json")
+            self.assertEqual(proc.returncode, 2)
+            data = json.loads(proc.stdout)
+            self.assertEqual(data["total_count"], 0)
+            self.assertEqual(data["files_scanned"], 0)
+
+    def test_json_contract_on_findings(self) -> None:
+        # Locks the additive JSON contract for normal consumers:
+        # total_count, sorries, files_scanned, files_failed.
+        with tempfile.TemporaryDirectory() as td:
+            Path(td, "S.lean").write_text("noncomputable def stub : Nat := by sorry\n")
+            proc = run_analyzer(td, "--format=json")
+            self.assertEqual(proc.returncode, 1)
+            data = json.loads(proc.stdout)
+            self.assertEqual(data["total_count"], 1)
+            self.assertEqual(data["files_scanned"], 1)
+            self.assertEqual(data["files_failed"], 0)
+            self.assertEqual(data["sorries"][0]["in_declaration"], "def stub")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Third and final script in the silent-pass audit series (#145 `check_axioms_inline.sh`, #146 `unused_declarations.sh`). `sorry_analyzer.py` is the plugin's sorry-counting gate — invoked by `/lean4:checkpoint` and review flows via the `lean4-skills-sorry-analyzer` wrapper. Same class of false-clean paths, plus a CI coverage gap, plus one attribution bug found during verification.

Off `fix/sorry-analyzer-hardening` from `origin/main` (`a7de6c9`, post-#146). Five commits, 5 files touched.

## Bugs fixed

**A: Empty-scan silent success.** A directory with zero `.lean` files reported "Found 0 sorry statement(s)" and exited 0. Same for a single-file target skipped by the `.lake` guard. Worse: `find_sorries_in_file()` caught ALL read exceptions and returned `[]` — a directory where every file is unreadable also reported clean. And `os.walk` silently swallows errors on unreadable *subdirectories* (no `onerror` callback), so parts of the tree could vanish from the scan without a trace.

Fix: new `ScanResult` dataclass (sorries + files_scanned + files_failed); `find_sorries_in_file()` returns `list[Sorry] | None` where None = read failure (mypy --strict forces every caller to handle it); `os.walk(onerror=...)` counts unreadable directories.

**Exit-code policy** (mirrors #146's three-way split):
| Condition | Exit | Excused by `--report-only`? |
|---|---|---|
| scanned ≥1, no sorries | 0 | — |
| sorries found | 1 | yes |
| zero files scanned OR any path unreadable | 2 | **no** |

A gate that scanned nothing (or missed part of the tree) must not pass — verbatim policy from #145/#146. Interactive mode is not entered on coverage failure (its "No sorries found!" greeting is exactly the false reassurance this removes). JSON gains additive `files_scanned`/`files_failed` fields; summary header disambiguated ("M file(s) with sorries; K file(s) scanned"); warnings go to stderr so `--format=json` stdout stays parseable.

**B: `extract_declaration_name()` missed modifier-prefixed decls.** The regex handled `@[attr]` and `private|protected` but not `noncomputable|unsafe|partial|nonrec`, `local`, or `abbrev`/`inductive`. A sorry inside `noncomputable def foo := sorry` reported `in_declaration=None`. Keyword vocabulary now aligned with `unused_declarations.sh` minus `axiom`/`constant` (no proof body — a sorry can't be inside one; matching them would only create misattribution risk for the nearest-header-wins backward search). The label deliberately stays `keyword name` (`def foo`, not `noncomputable def foo`) — keyword+name is the identity.

**C (found during verification): same-line sorries were NEVER attributed.** The backward search started at `sorry_idx - 1` — a single-line declaration (`def foo : Nat := by sorry`, the most common quick-stub form) put header and sorry on the same line, so every such sorry reported `in_declaration=None`, pre-dating this PR. Search now starts at the sorry's own line, stop bound −1 so line 0 is in the window.

**D (CI): Python tests existed but never ran.** `lib/scripts/tests/test_ordering.py` (for find_golfable.py) was not wired into any workflow — the same silent-coverage-gap class #146 exposed for the bash suite. New `python-tests` job in lint.yml runs BOTH test files under Python 3.10 (the documented runtime floor). stdlib unittest only, nothing to install.

**E (review follow-up): two remaining coverage/attribution gaps.** (1) A direct non-`.lean` file target (`sorry_analyzer.py README.md`) bypassed the `.lean` suffix filter that directory mode enforces — it scanned the file, counted `files_scanned=1`, and exited 0. Now a non-`.lean` direct target is zero coverage → exit 2, matching the directory walk's filter. (2) `scoped instance` (common in mathlib) was unattributed — the two-slot "one visibility then one decl modifier" regex had no place for `scoped`. Generalized to accept any number of scope/visibility/decl modifiers in any order.

## Commits

| Hash | Message |
|---|---|
| `fcf00d3` | Bug A — coverage-aware exit semantics |
| `489269a` | Bugs B & C — modifier-prefixed decls + same-line attribution |
| `2a6e90b` | Bug D + unit/subprocess suite + docs |
| `3ac5dc2` | Partial-coverage regression + warning-noise cleanup (review follow-up) |
| `8f9cc29` | Direct non-.lean target → exit 2 + scoped/any-order modifier attribution (review follow-up) |

## Tests (38, two layers)

*Unit:* comment/string stripping (line, block, nested, open-continuation, string literal), token boundaries (`sorryAx`/`my_sorry`/`sorry'` excluded), attribution (plain/private/same-line-attr/two-line-attr/noncomputable/protected-noncomputable/local instance/**scoped instance**/abbrev/inductive/same-line-sorry/no-header), ScanResult coverage counting (multi-file, empty, non-.lean, .lake exclusion, unreadable path, **partial: some scanned + some failed**).

*Subprocess (exit codes):* clean→0; sorry→1 (+`--report-only`→0); **empty dir→2 regardless of `--report-only`** (primary regression); non-.lean-only→2; **direct non-.lean file target→2**; **direct `.lake` file target→2** (pre-fix 0), with `--include-deps`→1; **partial coverage (clean + broken-symlink .lean)→2 with files_scanned=1/files_failed=1**; JSON valid on stdout even at exit 2; JSON contract on findings (total_count/sorries/files_scanned/files_failed + modifier-aware `in_declaration`).

The intentional "Could not read" warnings from the unreadable-path tests are captured with `redirect_stderr` so they don't read as real failures in the CI log.

## Out of scope (deliberately)

- **Multi-line string literals spanning lines** — the per-line stripper carries block-comment depth but not in-string state; a sorry inside a multi-line string's continuation line would be miscounted as code. Vanishingly rare; noted so review doesn't rediscover it. Fix = threading string state through the loop; separate.
- **Anonymous `example : ... := by sorry`** — stays unattributed (name group requires a name); None is honest, and a synthetic label would collide with the named form.
- **`admit` / other sorry-equivalents** — different tokens; the tool is explicitly a `sorry` counter.
- **Version bump / CHANGELOG** — folds into v4.5.3 with #145/#146.

## Test plan

- [x] Suite: 38/38 pass; `test_ordering.py` still 5/5; no analyzer warnings leak to the runner's stderr.
- [x] Primary regression: empty dir → stderr warning + exit 2 (pre-fix exit 0); `--report-only` → still 2.
- [x] Partial coverage: clean .lean + broken-symlink .lean → exit 2, files_scanned=1 / files_failed=1.
- [x] Attribution: `noncomputable def foo := by sorry` (one line) → `In: def foo`; `scoped instance sInst` → `In: instance sInst` (old regex returned None — verified discriminating).
- [x] Direct non-`.lean` file (`notes.txt`) → exit 2, "Skipping non-Lean file" + "nothing was analyzed" on stderr (pre-fix exit 0).
- [x] mypy `--strict --python-version 3.10` clean (35 files, CI-exact invocation); ruff check + format clean.
- [x] `lint_docs.sh` exit 0; bash suites unaffected (30/30, 10/10).
- [x] CI (five jobs): green on the current head `8f9cc29`; python-tests log confirmed to actually execute BOTH files (test_ordering.py 5 tests, test_sorry_analyzer.py 38 tests) — verified from the run log per the #146 "read the log, don't trust the green check" rule.


