### PR TITLE
fix(bootstrap): persist bin/ PATH + validate env + stop reporting false "ready"; release v4.5.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Lean 4 theorem proving with guided + autonomous proving, LSP-first workflows, guardrails, and contribution helpers",
-    "version": "4.5.2"
+    "version": "4.5.3"
   },
   "plugins": [
     {

--- a/.github/workflows/bash3-compat.yml
+++ b/.github/workflows/bash3-compat.yml
@@ -42,5 +42,20 @@ jobs:
           rg --version
           /bin/bash plugins/lean4/tests/test_unused_declarations.sh
 
+      - name: Self-test — bootstrap env honesty + PATH persistence (#108)
+        run: /bin/bash plugins/lean4/tests/test_bootstrap_env.sh
+
+      - name: Self-test — preflight_env + doctor wording agreement (#108)
+        run: /bin/bash plugins/lean4/tests/test_preflight_env.sh
+
+      # These hook self-tests existed but ran in NO workflow (the same
+      # silent-coverage-gap class #146/#147 fixed for the script suites) —
+      # wire them in here so they actually execute.
+      - name: Self-test — guardrails hook
+        run: /bin/bash plugins/lean4/tests/test_guardrails.sh
+
+      - name: Self-test — validate_user_prompt hook
+        run: /bin/bash plugins/lean4/tests/test_validate_user_prompt.sh
+
       - name: Runtime smoke — cycle_tracker.sh under /bin/bash
         run: /bin/bash plugins/lean4/tests/test_bash3_smoke.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v4.5.3 (July 2026)
+
+Bootstrap now fails honestly and persists the wrapper `PATH`, plus a shared env-preflight so bootstrap and doctor agree on one recovery message. Also folds in six docs/lint/bugfix PRs that landed on `main` after v4.5.2 without their own version bumps.
+
+### Bootstrap env honesty + shared preflight (primary, closes #108)
+
+- **`hooks/bootstrap.sh` stops reporting false success.** It previously printed `Lean4 v4 ready` and exited 0 *unconditionally* — even when `CLAUDE_ENV_FILE` was empty so `persist_env` silently wrote nothing, so a failed bootstrap masqueraded as a good one. Now it validates its inputs, persists, re-checks that persistence took effect, and prints `ready` only on the genuine happy path; every degraded path prints a canonical recovery block to stderr instead (warn + exit 0, so a broken bootstrap doesn't disrupt session start while still being loud and actionable).
+- **Bootstrap now persists `PATH`** (`export PATH="$CLAUDE_PLUGIN_ROOT/bin:$PATH"`, `:$PATH` kept literal, deduped idempotently). This makes reality match `INSTALLATION.md`'s long-standing claim that bootstrap adds `plugins/lean4/bin/` to PATH — the missing PATH export was why the self-locating `lean4-skills-*` wrappers could be off PATH after a partial bootstrap.
+- **New `lib/scripts/preflight_env.sh`** — the single source of the env checks and the canonical recovery wording, with `--bootstrap` (validate a SessionStart's inputs) and `--runtime` (diagnose the live session) modes. New `bin/lean4-skills-preflight` wrapper runs it as a manual diagnostic.
+- **`/lean4:doctor env`** now runs the preflight for a live diagnosis (resolved without depending on PATH — doctor is exactly where a broken PATH must stay diagnosable) and its troubleshooting rows reproduce the same three canonical recovery steps, so doctor and bootstrap can't drift.
+- **Scope note:** the original issue also flagged seven commands doing raw `"$LEAN4_SCRIPTS/foo.py"` invocations; those were already migrated to self-locating wrappers in #117/#130, so this PR narrows to the still-live bootstrap/PATH truthfulness bug. Migrating `disprove.md`'s remaining raw invocations (needs new `disprove_*` wrappers) is a deferred follow-up.
+- **Regression coverage:** new `tests/test_bootstrap_env.sh` and `tests/test_preflight_env.sh`, plus the previously-unwired `test_guardrails.sh` and `test_validate_user_prompt.sh` hook suites, are all now run by the `bash3-compat` CI workflow.
+
+### Folded-in PRs (previously merged without version bumps)
+
+Six PRs landed on `main` after the v4.5.2 release without their own CHANGELOG entries (each was scoped "no version bump" at the time). Folded in here so `git log` archeology reads cleanly:
+
+- **#141: `docs(skill): reframe "Never" rules in SKILL.md to lead with imperative + WHY`** — reframed two free-standing `Never X` rules in SKILL.md's Core Principles / File Handling to lead with the imperative and the reasoning, per the `superpowers:writing-skills` guidance, without dropping their operational cues.
+- **#142 (closes #61): `docs(insight): module docstrings must come after imports`** — documents that a module docstring (`/-! … -/`) placed before the `import` block yields the misleading `invalid 'import' command` error; adds a `mathlib-style.md § 2 Placement` subheading and a `compilation-errors.md` section + Quick Reference row.
+- **#143: `chore(lint-hygiene): renumber duplicate headings, add uniqueness check, clear persistent warnings`** — fixed the pre-existing duplicate `### 9`/`### 10` headings in `compilation-errors.md`, added a `lint_docs.sh` check (8e) for duplicate `### N.` numbering, and cleared the four chronic line-length / host-agnostic lint warnings.
+- **#145 (closes #132): `fix(axiom-check): resolve namespaced declarations correctly + refuse zero-coverage green verdict`** — `check_axioms_inline.sh` now walks a namespace/section stack for correct qualified names, recognizes modern Lean 4 `#print axioms` output (incl. primed names and `does not depend on any axioms`), refuses a green verdict on zero/partial coverage, and ships a 30-probe CI'd self-test.
+- **#146 (closes #108-adjacent dead-code gaps): `fix(unused-decls): rg mode flagged everything unused; expand decl classes; harden zero-decls paths`** — fixed `unused_declarations.sh`'s rg extraction (a `path:` prefix flagged *every* declaration as unused), expanded the recognized decl keywords, added a zero-coverage heuristic + hard-fail without PCRE grep, and added a 10-probe CI'd self-test.
+- **#147: `fix(sorry-analyzer): coverage-aware exit semantics + modifier-aware decl attribution + CI'd Python tests`** — `sorry_analyzer.py` now exits 2 on zero/partial scan coverage (not a silent clean), attributes modifier-prefixed and same-line-`sorry` declarations, and ships a 38-test unit+subprocess suite that (with `test_ordering.py`) is finally run by CI.
+
 ## v4.5.2 (June 2026)
 
 Collab-policy redesign so the hook stops fighting Claude Code's native permission UX, plus three folded-in docs/lint hardening PRs that landed on `main` after v4.5.1 without their own version bump.

--- a/plugins/lean4/.claude-plugin/plugin.json
+++ b/plugins/lean4/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lean4",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "description": "Unified Lean 4 plugin (draft, formalize, autoformalize, prove, autoprove, disprove, checkpoint, review, refactor, golf, learn, doctor) — LSP-first, scripts fallback",
   "author": {"name": "Cameron Freer", "email": "cameronfreer@gmail.com"}
 }

--- a/plugins/lean4/bin/lean4-skills-preflight
+++ b/plugins/lean4/bin/lean4-skills-preflight
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# lean4-skills-preflight — model-facing wrapper around lib/scripts/preflight_env.sh.
+# Runs the runtime env diagnosis (LEAN4_* vars, bin/ on PATH, wrappers
+# resolvable) and prints the canonical recovery block on failure.
+# See lean4-skills-cycle-tracker for the bin/-wrapper rationale.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+exec bash "$PLUGIN_ROOT/lib/scripts/preflight_env.sh" --runtime "$@"

--- a/plugins/lean4/commands/doctor.md
+++ b/plugins/lean4/commands/doctor.md
@@ -41,6 +41,29 @@ Diagnostics, troubleshooting, and migration assistance for the Lean4 plugin.
 
 Environment variables: `LEAN4_PLUGIN_ROOT`, `LEAN4_SCRIPTS`, `LEAN4_REFS`, `LEAN4_PYTHON_BIN`
 
+Run the shared env preflight for a live diagnosis. Resolve it **without
+depending on PATH** — `doctor env` is exactly where a broken PATH must
+still be diagnosable, so a bare `lean4-skills-preflight` alone could fail
+command-not-found:
+
+```bash
+if command -v lean4-skills-preflight >/dev/null 2>&1; then
+    lean4-skills-preflight
+elif [[ -n "${LEAN4_PLUGIN_ROOT:-}" && -x "$LEAN4_PLUGIN_ROOT/bin/lean4-skills-preflight" ]]; then
+    "$LEAN4_PLUGIN_ROOT/bin/lean4-skills-preflight"
+else
+    echo "Lean4 bootstrap environment is not fully set up in this Claude Code session." >&2
+    echo "  Recovery:" >&2
+    echo "    1. Run /lean4:doctor env for a full diagnosis." >&2
+    echo "    2. Restart the Claude Code session (re-runs the SessionStart bootstrap hook)." >&2
+    echo "    3. If it persists, check the plugin hook/bootstrap state (hooks.json, bootstrap.sh)." >&2
+fi
+```
+
+The preflight validates that `LEAN4_*` point at real dirs, that
+`$LEAN4_PLUGIN_ROOT/bin` is on `PATH`, and that the `lean4-skills-*`
+wrappers resolve; on failure it prints the canonical recovery block.
+
 ### 1b. MCP Tools
 
 | Check | Detection | Status |
@@ -195,8 +218,8 @@ No changes made. Run `/lean4:doctor cleanup --apply` to remove.
 
 | Issue | Fix |
 |-------|-----|
-| LEAN4_SCRIPTS not set | Restart session, check hooks.json |
-| `lean4-skills-*` wrapper not found on PATH | Verify bootstrap appended `$LEAN4_PLUGIN_ROOT/bin` to `PATH`; restart session if missing |
+| LEAN4_SCRIPTS not set | 1. Run `/lean4:doctor env` for a full diagnosis. 2. Restart the Claude Code session (re-runs the SessionStart bootstrap hook). 3. If it persists, check the plugin hook/bootstrap state (hooks.json, bootstrap.sh). |
+| `lean4-skills-*` wrapper not found on PATH | 1. Run `/lean4:doctor env` for a full diagnosis. 2. Restart the Claude Code session (re-runs the SessionStart bootstrap hook). 3. If it persists, check the plugin hook/bootstrap state (hooks.json, bootstrap.sh). |
 | lake not found | Install via elan |
 | Scripts not executable | Wrappers should be shipped executable — check `command -v lean4-skills-sorry-analyzer`. For unwrapped internals: `chmod +x $LEAN4_SCRIPTS/*.sh $LEAN4_SCRIPTS/*.py` |
 | Build fails | `lake update && lake clean && lake build` |

--- a/plugins/lean4/hooks/bootstrap.sh
+++ b/plugins/lean4/hooks/bootstrap.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
-: "${CLAUDE_PLUGIN_ROOT:?missing CLAUDE_PLUGIN_ROOT}"
+
+# Resolve the plugin root. CLAUDE_PLUGIN_ROOT is set by Claude Code at hook
+# time; if it's missing the hook was invoked abnormally. We do NOT hard-fail
+# on that (a `:?` abort would bypass the honest degraded-warning path below);
+# instead we self-locate a fallback root from BASH_SOURCE purely so we can
+# still emit the canonical recovery message, and treat missing
+# CLAUDE_PLUGIN_ROOT as a degraded state (no persistence, no "ready").
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FALLBACK_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+PREFLIGHT="${PLUGIN_ROOT:-$FALLBACK_ROOT}/lib/scripts/preflight_env.sh"
+
 ENV_OUT="${CLAUDE_ENV_FILE:-}"
 
 # Persist env var: update if exists with different value, add if missing
@@ -18,12 +29,74 @@ persist_env() {
   fi
 }
 
+# Emit the canonical recovery block and exit 0. We warn (not hard-fail)
+# because a nonzero SessionStart exit risks disrupting session start and the
+# self-locating lean4-skills-* wrappers may still function; a loud,
+# actionable stderr warning is the right severity. Reuses preflight_env.sh's
+# wording when reachable so bootstrap and doctor never drift; falls back to
+# an inline copy only if the helper itself can't be located.
+warn_degraded_and_exit() {
+  local problem="$1"
+  if [[ -f "$PREFLIGHT" ]]; then
+    # Re-run the helper so the exact canonical block is emitted. Its own
+    # checks will restate the concrete problem; suppress its exit status.
+    CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" bash "$PREFLIGHT" --bootstrap "$PLUGIN_ROOT" || true
+  else
+    {
+      echo "Lean4 bootstrap environment is not fully set up in this Claude Code session."
+      echo "  Problem: ${problem}"
+      echo "  Recovery:"
+      echo "    1. Run /lean4:doctor env for a full diagnosis."
+      echo "    2. Restart the Claude Code session (re-runs the SessionStart bootstrap hook)."
+      echo "    3. If it persists, check the plugin hook/bootstrap state (hooks.json, bootstrap.sh)."
+    } >&2
+  fi
+  exit 0
+}
+
+# Missing CLAUDE_PLUGIN_ROOT: degraded — warn via the canonical block and
+# exit 0 without persisting off a guessed root.
+if [[ -z "$PLUGIN_ROOT" ]]; then
+  warn_degraded_and_exit "CLAUDE_PLUGIN_ROOT is not set (bootstrap hook invoked without it)"
+fi
+
+# Step 1: validate INPUTS (tree layout + CLAUDE_ENV_FILE usability) before
+# persisting anything. If they don't hold, nothing gets written — warn.
+if ! bash "$PREFLIGHT" --bootstrap "$PLUGIN_ROOT"; then
+  exit 0  # preflight already emitted the canonical block on stderr
+fi
+
+# Step 2: persist LEAN4_* and PATH. The PATH line keeps `:$PATH` literal
+# (escaped) so each fresh shell prepends bin/ to its own PATH; persist_env's
+# dedup keeps re-bootstraps from stacking duplicate lines. This is what makes
+# the lean4-skills-* wrappers resolvable in later tool calls (and makes
+# INSTALLATION.md's "bootstrap adds bin/ to PATH" claim true).
 PYTHON_BIN="$(command -v python3 || command -v python || true)"
 
-persist_env "export LEAN4_PLUGIN_ROOT=\"${CLAUDE_PLUGIN_ROOT}\""
-persist_env "export LEAN4_SCRIPTS=\"${CLAUDE_PLUGIN_ROOT}/lib/scripts\""
-persist_env "export LEAN4_REFS=\"${CLAUDE_PLUGIN_ROOT}/skills/lean4/references\""
+persist_env "export LEAN4_PLUGIN_ROOT=\"${PLUGIN_ROOT}\""
+persist_env "export LEAN4_SCRIPTS=\"${PLUGIN_ROOT}/lib/scripts\""
+persist_env "export LEAN4_REFS=\"${PLUGIN_ROOT}/skills/lean4/references\""
+persist_env "export PATH=\"${PLUGIN_ROOT}/bin:\$PATH\""
 [[ -n "${PYTHON_BIN}" ]] && persist_env "export LEAN4_PYTHON_BIN=\"${PYTHON_BIN}\""
 
-echo "Lean4 v4 ready: PLUGIN_ROOT=${CLAUDE_PLUGIN_ROOT}"
+# Step 3: re-validate that persistence actually happened — "ready" must mean
+# the environment was written, not merely that inputs looked okay. Confirm
+# the env file now carries the expected exports.
+persisted_ok=true
+for expected in \
+  "export LEAN4_PLUGIN_ROOT=" \
+  "export LEAN4_SCRIPTS=" \
+  "export LEAN4_REFS=" \
+  "export PATH="; do
+  if ! grep -q "^${expected}" "${ENV_OUT}" 2>/dev/null; then
+    persisted_ok=false
+    break
+  fi
+done
+
+if [[ "$persisted_ok" != true ]]; then
+  warn_degraded_and_exit "env persistence to CLAUDE_ENV_FILE did not take effect"
+fi
+
+echo "Lean4 v4 ready: PLUGIN_ROOT=${PLUGIN_ROOT}"
 exit 0

--- a/plugins/lean4/hooks/bootstrap.sh
+++ b/plugins/lean4/hooks/bootstrap.sh
@@ -50,25 +50,24 @@ persist_path() {
 # Emit the canonical recovery block and exit 0. We warn (not hard-fail)
 # because a nonzero SessionStart exit risks disrupting session start and the
 # self-locating lean4-skills-* wrappers may still function; a loud,
-# actionable stderr warning is the right severity. Reuses preflight_env.sh's
-# wording when reachable so bootstrap and doctor never drift; falls back to
-# an inline copy only if the helper itself can't be located.
+# actionable stderr warning is the right severity.
+#
+# ALWAYS emits the caller's concrete $problem inline — it does NOT re-run
+# the preflight. A re-run could pass (e.g. a post-write validation failure
+# where the INPUTS still look fine, such as CLAUDE_ENV_FILE being a symlink
+# to /dev/null) and emit nothing, silently swallowing the warning. The
+# canonical wording here is kept byte-identical to preflight_env.sh's
+# emit_recovery (test_preflight_env.sh asserts the shared lines).
 warn_degraded_and_exit() {
   local problem="$1"
-  if [[ -f "$PREFLIGHT" ]]; then
-    # Re-run the helper so the exact canonical block is emitted. Its own
-    # checks will restate the concrete problem; suppress its exit status.
-    CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" bash "$PREFLIGHT" --bootstrap "$PLUGIN_ROOT" || true
-  else
-    {
-      echo "Lean4 bootstrap environment is not fully set up in this Claude Code session."
-      echo "  Problem: ${problem}"
-      echo "  Recovery:"
-      echo "    1. Run /lean4:doctor env for a full diagnosis."
-      echo "    2. Restart the Claude Code session (re-runs the SessionStart bootstrap hook)."
-      echo "    3. If it persists, check the plugin hook/bootstrap state (hooks.json, bootstrap.sh)."
-    } >&2
-  fi
+  {
+    echo "Lean4 bootstrap environment is not fully set up in this Claude Code session."
+    echo "  Problem: ${problem}"
+    echo "  Recovery:"
+    echo "    1. Run /lean4:doctor env for a full diagnosis."
+    echo "    2. Restart the Claude Code session (re-runs the SessionStart bootstrap hook)."
+    echo "    3. If it persists, check the plugin hook/bootstrap state (hooks.json, bootstrap.sh)."
+  } >&2
   exit 0
 }
 

--- a/plugins/lean4/hooks/bootstrap.sh
+++ b/plugins/lean4/hooks/bootstrap.sh
@@ -14,7 +14,9 @@ PREFLIGHT="${PLUGIN_ROOT:-$FALLBACK_ROOT}/lib/scripts/preflight_env.sh"
 
 ENV_OUT="${CLAUDE_ENV_FILE:-}"
 
-# Persist env var: update if exists with different value, add if missing
+# Persist env var: update if exists with different value, add if missing.
+# Safe for singleton VAR=VALUE exports (LEAN4_*), where removing every
+# `^export VAR=` line before re-adding is exactly the intended dedup.
 persist_env() {
   local kv="$1"
   local var_name="${kv%%=*}"  # extract VAR_NAME from "export VAR_NAME=..."
@@ -26,6 +28,22 @@ persist_env() {
       mv "${ENV_OUT}.tmp" "${ENV_OUT}"
     fi
     printf '%s\n' "$kv" >> "${ENV_OUT}"
+  fi
+}
+
+# Persist PATH specifically. Unlike persist_env, PATH is NOT a singleton —
+# other hooks/plugins may write their own `export PATH=...` lines into the
+# same CLAUDE_ENV_FILE. Dedup on the EXACT own-line only (grep -vF), so a
+# re-bootstrap replaces just our entry and leaves every other plugin's PATH
+# export intact.
+persist_path() {
+  local own_line="$1"
+  if [[ -n "${ENV_OUT}" ]]; then
+    if [[ -f "${ENV_OUT}" ]]; then
+      grep -vxF "$own_line" "${ENV_OUT}" > "${ENV_OUT}.tmp" 2>/dev/null || true
+      mv "${ENV_OUT}.tmp" "${ENV_OUT}"
+    fi
+    printf '%s\n' "$own_line" >> "${ENV_OUT}"
   fi
 }
 
@@ -60,6 +78,13 @@ if [[ -z "$PLUGIN_ROOT" ]]; then
   warn_degraded_and_exit "CLAUDE_PLUGIN_ROOT is not set (bootstrap hook invoked without it)"
 fi
 
+# Guard: if the preflight helper itself is missing, don't let a raw
+# "No such file" error stand in for the diagnosis — emit the canonical
+# block (warn_degraded_and_exit falls back to an inline copy).
+if [[ ! -f "$PREFLIGHT" ]]; then
+  warn_degraded_and_exit "preflight helper not found at $PREFLIGHT"
+fi
+
 # Step 1: validate INPUTS (tree layout + CLAUDE_ENV_FILE usability) before
 # persisting anything. If they don't hold, nothing gets written — warn.
 if ! bash "$PREFLIGHT" --bootstrap "$PLUGIN_ROOT"; then
@@ -67,16 +92,17 @@ if ! bash "$PREFLIGHT" --bootstrap "$PLUGIN_ROOT"; then
 fi
 
 # Step 2: persist LEAN4_* and PATH. The PATH line keeps `:$PATH` literal
-# (escaped) so each fresh shell prepends bin/ to its own PATH; persist_env's
-# dedup keeps re-bootstraps from stacking duplicate lines. This is what makes
-# the lean4-skills-* wrappers resolvable in later tool calls (and makes
-# INSTALLATION.md's "bootstrap adds bin/ to PATH" claim true).
+# (escaped) so each fresh shell prepends bin/ to its own PATH. PATH goes
+# through persist_path (exact-own-line dedup) so re-bootstraps don't stack
+# duplicates AND other plugins' PATH exports in the same env file survive.
+# This is what makes the lean4-skills-* wrappers resolvable in later tool
+# calls (and makes INSTALLATION.md's "bootstrap adds bin/ to PATH" true).
 PYTHON_BIN="$(command -v python3 || command -v python || true)"
 
 persist_env "export LEAN4_PLUGIN_ROOT=\"${PLUGIN_ROOT}\""
 persist_env "export LEAN4_SCRIPTS=\"${PLUGIN_ROOT}/lib/scripts\""
 persist_env "export LEAN4_REFS=\"${PLUGIN_ROOT}/skills/lean4/references\""
-persist_env "export PATH=\"${PLUGIN_ROOT}/bin:\$PATH\""
+persist_path "export PATH=\"${PLUGIN_ROOT}/bin:\$PATH\""
 [[ -n "${PYTHON_BIN}" ]] && persist_env "export LEAN4_PYTHON_BIN=\"${PYTHON_BIN}\""
 
 # Step 3: re-validate that persistence actually happened — "ready" must mean

--- a/plugins/lean4/lib/scripts/README.md
+++ b/plugins/lean4/lib/scripts/README.md
@@ -201,9 +201,13 @@ Three grep-style scripts also exit non-zero on findings by default — useful fo
 **`--exit-zero-on-findings`** (alias: `--report-only`): Makes findings exit 0 while real errors still exit 1. Use in report-only contexts (reviews, troubleshooting); do not use in gate commands like `/lean4:checkpoint`. **Note (all three scripts):** the flag applies to *findings* only. Coverage failures — zero files scanned, unreadable paths, unverified files, or unanalyzable trees — always exit non-zero regardless of this flag, because a gate that couldn't make a determination must not silently pass:
 
 ```bash
-${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/sorry_analyzer.py" . --format=summary --report-only
-bash "$LEAN4_SCRIPTS/check_axioms_inline.sh" src/*.lean --report-only
+lean4-skills-sorry-analyzer . --format=summary --report-only
+lean4-skills-check-axioms-inline src/*.lean --report-only
 ```
+
+(These `lean4-skills-*` wrappers self-locate their scripts and don't
+depend on `$LEAN4_SCRIPTS`; a raw `"$LEAN4_SCRIPTS/sorry_analyzer.py"`
+form expands to `/sorry_analyzer.py` when the bootstrap env is missing.)
 
 Keep stderr visible when invoking scripts; suppressing stderr to `/dev/null` hides actionable errors.
 

--- a/plugins/lean4/lib/scripts/preflight_env.sh
+++ b/plugins/lean4/lib/scripts/preflight_env.sh
@@ -55,9 +55,12 @@ check_bootstrap() {
     [[ -d "$root/bin" ]] || problems+=("$root/bin does not exist")
 
     # CLAUDE_ENV_FILE usability: the var must be nonempty, its PARENT dir
-    # must exist and be writable, and IF the file already exists it must be
-    # writable. We do not require the file itself to pre-exist — first-run
-    # bootstrap creates it.
+    # must exist and be writable, and IF the file already exists it must be a
+    # REGULAR writable file. We do not require the file to pre-exist —
+    # first-run bootstrap creates it. The regular-file check rejects a
+    # writable-but-non-persistent target (a directory, /dev/null, or a
+    # symlink to a device): persistence there silently no-ops, which would
+    # otherwise slip past input validation into a silent degraded bootstrap.
     local env_file="${CLAUDE_ENV_FILE:-}"
     if [[ -z "$env_file" ]]; then
         problems+=("CLAUDE_ENV_FILE is not set — env cannot be persisted for later tool calls")
@@ -68,7 +71,9 @@ check_bootstrap() {
             problems+=("CLAUDE_ENV_FILE parent directory $env_dir does not exist")
         elif [[ ! -w "$env_dir" ]]; then
             problems+=("CLAUDE_ENV_FILE parent directory $env_dir is not writable")
-        elif [[ -e "$env_file" && ! -w "$env_file" ]]; then
+        elif [[ -e "$env_file" && ! -f "$env_file" ]]; then
+            problems+=("CLAUDE_ENV_FILE $env_file exists but is not a regular file (persistence would not stick)")
+        elif [[ -f "$env_file" && ! -w "$env_file" ]]; then
             problems+=("CLAUDE_ENV_FILE $env_file exists but is not writable")
         fi
     fi

--- a/plugins/lean4/lib/scripts/preflight_env.sh
+++ b/plugins/lean4/lib/scripts/preflight_env.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# preflight_env.sh — single source of the Lean4 env validation checks AND
+# the canonical "bootstrap environment not set up" recovery message.
+#
+# Two modes:
+#   --bootstrap   Validate the INPUTS a SessionStart bootstrap needs, given
+#                 CLAUDE_PLUGIN_ROOT (passed as $2, or read from env): the
+#                 plugin tree layout exists and CLAUDE_ENV_FILE is usable.
+#                 Called by hooks/bootstrap.sh before it persists anything.
+#   --runtime     (default) Validate the SESSION state a later Bash tool call
+#                 depends on: LEAN4_* vars point at real dirs, bin/ is on
+#                 PATH, and the lean4-skills-* wrappers resolve. Used for
+#                 on-demand diagnosis (e.g. /lean4:doctor env, or manual run
+#                 via the lean4-skills-preflight wrapper).
+#
+# Exit 0 when the checked mode passes; exit 2 with the canonical recovery
+# block on stderr when it fails. Self-locating (BASH_SOURCE) so it never
+# depends on $LEAN4_SCRIPTS being set.
+#
+# The three numbered recovery steps below are CANONICAL: doctor.md
+# reproduces them byte-for-byte. If you change them here, update doctor.md
+# (test_preflight_env.sh asserts doctor.md still contains each line).
+
+set -euo pipefail
+
+# emit_recovery <problem-description>
+# Prints the canonical recovery block to stderr. $1 is a mode-specific,
+# one-line description of what was wrong (interpolated into "Problem:").
+emit_recovery() {
+    local problem="$1"
+    {
+        echo "Lean4 bootstrap environment is not fully set up in this Claude Code session."
+        echo "  Problem: ${problem}"
+        echo "  Recovery:"
+        echo "    1. Run /lean4:doctor env for a full diagnosis."
+        echo "    2. Restart the Claude Code session (re-runs the SessionStart bootstrap hook)."
+        echo "    3. If it persists, check the plugin hook/bootstrap state (hooks.json, bootstrap.sh)."
+    } >&2
+}
+
+# check_bootstrap <plugin-root>
+# Validates the tree layout + CLAUDE_ENV_FILE usability. Returns 0 on
+# success; on failure emits the canonical block and returns 2.
+check_bootstrap() {
+    local root="$1"
+    local problems=()
+
+    if [[ -z "$root" ]]; then
+        emit_recovery "CLAUDE_PLUGIN_ROOT is not set (bootstrap hook invoked without it)"
+        return 2
+    fi
+    [[ -d "$root/lib/scripts" ]] || problems+=("$root/lib/scripts does not exist")
+    [[ -d "$root/skills/lean4/references" ]] || problems+=("$root/skills/lean4/references does not exist")
+    [[ -d "$root/bin" ]] || problems+=("$root/bin does not exist")
+
+    # CLAUDE_ENV_FILE usability: the var must be nonempty, its PARENT dir
+    # must exist and be writable, and IF the file already exists it must be
+    # writable. We do not require the file itself to pre-exist — first-run
+    # bootstrap creates it.
+    local env_file="${CLAUDE_ENV_FILE:-}"
+    if [[ -z "$env_file" ]]; then
+        problems+=("CLAUDE_ENV_FILE is not set — env cannot be persisted for later tool calls")
+    else
+        local env_dir
+        env_dir="$(dirname "$env_file")"
+        if [[ ! -d "$env_dir" ]]; then
+            problems+=("CLAUDE_ENV_FILE parent directory $env_dir does not exist")
+        elif [[ ! -w "$env_dir" ]]; then
+            problems+=("CLAUDE_ENV_FILE parent directory $env_dir is not writable")
+        elif [[ -e "$env_file" && ! -w "$env_file" ]]; then
+            problems+=("CLAUDE_ENV_FILE $env_file exists but is not writable")
+        fi
+    fi
+
+    if [[ ${#problems[@]} -gt 0 ]]; then
+        local joined
+        joined="$(printf '%s; ' "${problems[@]}")"
+        emit_recovery "${joined%; }"
+        return 2
+    fi
+    return 0
+}
+
+# check_runtime
+# Validates the session env a later Bash tool call depends on. Returns 0 on
+# success; on failure emits the canonical block and returns 2.
+check_runtime() {
+    local problems=()
+    local root="${LEAN4_PLUGIN_ROOT:-}"
+
+    if [[ -z "$root" ]]; then
+        problems+=("LEAN4_PLUGIN_ROOT is not set")
+    elif [[ ! -d "$root" ]]; then
+        problems+=("LEAN4_PLUGIN_ROOT ($root) is not a directory")
+    fi
+
+    if [[ -z "${LEAN4_SCRIPTS:-}" ]]; then
+        problems+=("LEAN4_SCRIPTS is not set")
+    elif [[ ! -d "${LEAN4_SCRIPTS}" ]]; then
+        problems+=("LEAN4_SCRIPTS (${LEAN4_SCRIPTS}) is not a directory")
+    fi
+
+    if [[ -z "${LEAN4_REFS:-}" ]]; then
+        problems+=("LEAN4_REFS is not set")
+    elif [[ ! -d "${LEAN4_REFS}" ]]; then
+        problems+=("LEAN4_REFS (${LEAN4_REFS}) is not a directory")
+    fi
+
+    # bin/ on PATH + a representative wrapper resolvable.
+    if [[ -n "$root" ]] && [[ ":$PATH:" != *":$root/bin:"* ]]; then
+        problems+=("$root/bin is not on PATH")
+    fi
+    if ! command -v lean4-skills-sorry-analyzer >/dev/null 2>&1; then
+        problems+=("lean4-skills-* wrappers do not resolve on PATH")
+    fi
+
+    if [[ ${#problems[@]} -gt 0 ]]; then
+        local joined
+        joined="$(printf '%s; ' "${problems[@]}")"
+        emit_recovery "${joined%; }"
+        return 2
+    fi
+    return 0
+}
+
+main() {
+    local mode="${1:---runtime}"
+    case "$mode" in
+        --bootstrap)
+            # Prefer the explicitly-passed root ($2); fall back to
+            # CLAUDE_PLUGIN_ROOT from the environment.
+            check_bootstrap "${2:-${CLAUDE_PLUGIN_ROOT:-}}"
+            ;;
+        --runtime)
+            check_runtime
+            ;;
+        *)
+            echo "Usage: preflight_env.sh [--bootstrap [PLUGIN_ROOT] | --runtime]" >&2
+            exit 64
+            ;;
+    esac
+}
+
+main "$@"

--- a/plugins/lean4/tests/test_bootstrap_env.sh
+++ b/plugins/lean4/tests/test_bootstrap_env.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression tests for hooks/bootstrap.sh (#108): honest reporting, PATH
+# persistence, and PATH idempotency. Drives the hook with a fabricated
+# CLAUDE_PLUGIN_ROOT (the real tree) and a CLAUDE_ENV_FILE in a tempdir.
+#
+# Runs under $BASH_FOR_COMPAT (default /bin/bash) so it exercises macOS
+# Bash 3.2 in CI. SKIPs gracefully if that shell is unavailable.
+
+BASH_FOR_COMPAT="${BASH_FOR_COMPAT:-/bin/bash}"
+if [[ ! -x "$BASH_FOR_COMPAT" ]]; then
+    echo "SKIP: $BASH_FOR_COMPAT not found — cannot run bootstrap self-test"
+    exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BOOTSTRAP="$PLUGIN_ROOT/hooks/bootstrap.sh"
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS: $1"; (( ++PASS )) || true; }
+fail() { echo "  FAIL: $1"; (( ++FAIL )) || true; }
+
+SCRATCH=$(mktemp -d)
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# run_bootstrap: env-scoped invocation. Sets globals BS_OUT, BS_EXIT.
+#   $1 = CLAUDE_PLUGIN_ROOT value ("" to leave unset)
+#   $2 = CLAUDE_ENV_FILE value    ("" to leave unset)
+run_bootstrap() {
+    local root="$1" envfile="$2"
+    # env(1) requires all -u options BEFORE any NAME=VALUE assignment —
+    # once it sees an assignment the rest is the command. So collect unset
+    # flags first, then assignments.
+    local -a unset_flags=() assigns=()
+    if [[ -n "$root" ]]; then assigns+=("CLAUDE_PLUGIN_ROOT=$root"); else unset_flags+=("-u" "CLAUDE_PLUGIN_ROOT"); fi
+    if [[ -n "$envfile" ]]; then assigns+=("CLAUDE_ENV_FILE=$envfile"); else unset_flags+=("-u" "CLAUDE_ENV_FILE"); fi
+    BS_EXIT=0
+    BS_OUT=$(env "${unset_flags[@]+"${unset_flags[@]}"}" "${assigns[@]+"${assigns[@]}"}" \
+        "$BASH_FOR_COMPAT" "$BOOTSTRAP" 2>&1) || BS_EXIT=$?
+}
+
+# ---------------------------------------------------------------------------
+# Happy path: writable env-file parent, file absent (bootstrap creates it).
+# ---------------------------------------------------------------------------
+ef="$SCRATCH/happy_env"
+run_bootstrap "$PLUGIN_ROOT" "$ef"
+happy_ok=1
+[[ "$BS_EXIT" -eq 0 ]] || { happy_ok=0; }
+grep -qF "Lean4 v4 ready" <<<"$BS_OUT" || happy_ok=0
+grep -q '^export LEAN4_PLUGIN_ROOT=' "$ef" 2>/dev/null || happy_ok=0
+grep -q '^export LEAN4_SCRIPTS=' "$ef" 2>/dev/null || happy_ok=0
+grep -q '^export LEAN4_REFS=' "$ef" 2>/dev/null || happy_ok=0
+grep -q '^export PATH=' "$ef" 2>/dev/null || happy_ok=0
+if [[ $happy_ok -eq 1 ]]; then
+    pass "happy path: 'ready' + all LEAN4_* and PATH persisted, exit 0"
+else
+    fail "happy path (exit=$BS_EXIT); env file:"; sed 's/^/      /' "$ef" 2>/dev/null || true
+fi
+
+# The persisted PATH line keeps :$PATH literal (each shell prepends bin/).
+if grep -qF "export PATH=\"$PLUGIN_ROOT/bin:\$PATH\"" "$ef" 2>/dev/null; then
+    pass "PATH line keeps literal :\$PATH (bin/ prepended per-shell)"
+else
+    fail "PATH line not in expected literal form"
+fi
+
+# ---------------------------------------------------------------------------
+# PATH idempotency: a second run must not stack a duplicate PATH line.
+# ---------------------------------------------------------------------------
+run_bootstrap "$PLUGIN_ROOT" "$ef"
+n_path=$(grep -c '^export PATH=' "$ef" 2>/dev/null || echo 0)
+if [[ "$n_path" -eq 1 ]]; then
+    pass "PATH idempotency: exactly one export PATH= line after two runs"
+else
+    fail "PATH idempotency: expected 1 export PATH= line, got $n_path"
+fi
+
+# ---------------------------------------------------------------------------
+# Degraded: CLAUDE_ENV_FILE unset → no 'ready', canonical block, exit 0.
+# ---------------------------------------------------------------------------
+run_bootstrap "$PLUGIN_ROOT" ""
+if [[ "$BS_EXIT" -eq 0 ]] \
+   && ! grep -qF "Lean4 v4 ready" <<<"$BS_OUT" \
+   && grep -qF "Run /lean4:doctor env for a full diagnosis." <<<"$BS_OUT"; then
+    pass "degraded: CLAUDE_ENV_FILE unset → no 'ready', canonical block, exit 0"
+else
+    fail "degraded CLAUDE_ENV_FILE unset (exit=$BS_EXIT)"
+fi
+
+# ---------------------------------------------------------------------------
+# Degraded: CLAUDE_PLUGIN_ROOT unset → no crash, canonical naming it, exit 0.
+# (The removed `:?` hard-require used to abort nonzero here.)
+# ---------------------------------------------------------------------------
+run_bootstrap "" "$SCRATCH/root_unset_env"
+if [[ "$BS_EXIT" -eq 0 ]] \
+   && ! grep -qF "Lean4 v4 ready" <<<"$BS_OUT" \
+   && grep -qF "CLAUDE_PLUGIN_ROOT is not set" <<<"$BS_OUT"; then
+    pass "degraded: CLAUDE_PLUGIN_ROOT unset → canonical block naming it, exit 0"
+else
+    fail "degraded CLAUDE_PLUGIN_ROOT unset (exit=$BS_EXIT)"
+fi
+# ...and nothing was persisted off a guessed root.
+[[ ! -e "$SCRATCH/root_unset_env" ]] && pass "root-unset: nothing persisted" \
+    || fail "root-unset: env file unexpectedly written"
+
+# ---------------------------------------------------------------------------
+# Degraded: CLAUDE_ENV_FILE parent dir unwritable → no 'ready', warn, exit 0.
+# (Skip if running as root, where write bits are ignored.)
+# ---------------------------------------------------------------------------
+if [[ "$(id -u)" -ne 0 ]]; then
+    roDir="$SCRATCH/ro"; mkdir -p "$roDir"; chmod 555 "$roDir"
+    run_bootstrap "$PLUGIN_ROOT" "$roDir/env"
+    if [[ "$BS_EXIT" -eq 0 ]] && ! grep -qF "Lean4 v4 ready" <<<"$BS_OUT"; then
+        pass "degraded: unwritable env-file parent → no 'ready', exit 0"
+    else
+        fail "degraded unwritable parent (exit=$BS_EXIT)"
+    fi
+    chmod 755 "$roDir"
+else
+    echo "  SKIP: unwritable-parent case (running as root)"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== test_bootstrap_env.sh: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/plugins/lean4/tests/test_bootstrap_env.sh
+++ b/plugins/lean4/tests/test_bootstrap_env.sh
@@ -124,6 +124,41 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# PATH coexistence: a foreign `export PATH=` line (another plugin's) and an
+# unrelated var in the same env file must SURVIVE a bootstrap — persist_path
+# dedups only our exact own-line, not every PATH line.
+# ---------------------------------------------------------------------------
+coex="$SCRATCH/coex_env"
+printf 'export PATH="/opt/otherplugin/bin:$PATH"\nexport OTHER_VAR="keep me"\n' > "$coex"
+run_bootstrap "$PLUGIN_ROOT" "$coex"
+coex_ok=1
+grep -qF 'export PATH="/opt/otherplugin/bin:$PATH"' "$coex" || coex_ok=0   # foreign PATH survived
+grep -qF 'export OTHER_VAR="keep me"' "$coex" || coex_ok=0                 # unrelated var survived
+grep -qF "$PLUGIN_ROOT/bin" "$coex" || coex_ok=0                           # our PATH added
+run_bootstrap "$PLUGIN_ROOT" "$coex"                                       # second run
+[[ "$(grep -c '^export PATH=' "$coex")" -eq 2 ]] || coex_ok=0             # still exactly 2 PATH lines
+if [[ $coex_ok -eq 1 ]]; then
+    pass "PATH coexistence: foreign PATH + unrelated var survive; ours deduped"
+else
+    fail "PATH coexistence"; sed 's/^/      /' "$coex"
+fi
+
+# ---------------------------------------------------------------------------
+# Missing preflight helper → canonical block (not a raw "No such file"), exit 0.
+# Point CLAUDE_PLUGIN_ROOT at a tree with an empty lib/scripts/ (no helper).
+# ---------------------------------------------------------------------------
+nohelper="$SCRATCH/nohelper"
+mkdir -p "$nohelper/lib/scripts" "$nohelper/skills/lean4/references" "$nohelper/bin"
+run_bootstrap "$nohelper" "$SCRATCH/nohelper_env"
+if [[ "$BS_EXIT" -eq 0 ]] \
+   && ! grep -qF "Lean4 v4 ready" <<<"$BS_OUT" \
+   && grep -qF "Run /lean4:doctor env for a full diagnosis." <<<"$BS_OUT"; then
+    pass "missing preflight helper → canonical block, exit 0"
+else
+    fail "missing preflight helper (exit=$BS_EXIT): $BS_OUT"
+fi
+
+# ---------------------------------------------------------------------------
 echo ""
 echo "=== test_bootstrap_env.sh: $PASS passed, $FAIL failed ==="
 [[ "$FAIL" -eq 0 ]]

--- a/plugins/lean4/tests/test_bootstrap_env.sh
+++ b/plugins/lean4/tests/test_bootstrap_env.sh
@@ -159,6 +159,32 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Degraded: CLAUDE_ENV_FILE writable but NON-PERSISTENT (symlink to
+# /dev/null, or an existing directory). Persistence there silently no-ops;
+# the regular-file check in preflight --bootstrap must catch it at input
+# validation so the bootstrap is loud, not silently degraded. exit 0.
+# ---------------------------------------------------------------------------
+ln -s /dev/null "$SCRATCH/devnull_link"
+run_bootstrap "$PLUGIN_ROOT" "$SCRATCH/devnull_link"
+if [[ "$BS_EXIT" -eq 0 ]] \
+   && ! grep -qF "Lean4 v4 ready" <<<"$BS_OUT" \
+   && grep -qF "Run /lean4:doctor env for a full diagnosis." <<<"$BS_OUT"; then
+    pass "degraded: CLAUDE_ENV_FILE → /dev/null symlink → canonical warning, exit 0"
+else
+    fail "degraded CLAUDE_ENV_FILE → /dev/null symlink (exit=$BS_EXIT): $BS_OUT"
+fi
+
+mkdir -p "$SCRATCH/envdir"
+run_bootstrap "$PLUGIN_ROOT" "$SCRATCH/envdir"
+if [[ "$BS_EXIT" -eq 0 ]] \
+   && ! grep -qF "Lean4 v4 ready" <<<"$BS_OUT" \
+   && grep -qF "not a regular file" <<<"$BS_OUT"; then
+    pass "degraded: CLAUDE_ENV_FILE → directory → canonical warning, exit 0"
+else
+    fail "degraded CLAUDE_ENV_FILE → directory (exit=$BS_EXIT): $BS_OUT"
+fi
+
+# ---------------------------------------------------------------------------
 echo ""
 echo "=== test_bootstrap_env.sh: $PASS passed, $FAIL failed ==="
 [[ "$FAIL" -eq 0 ]]

--- a/plugins/lean4/tests/test_guardrails.sh
+++ b/plugins/lean4/tests/test_guardrails.sh
@@ -42,7 +42,7 @@ run_test_policy() {
     policy_env=(LEAN4_GUARDRAILS_COLLAB_POLICY="$policy")
   fi
   echo "{\"tool_input\":{\"command\":$(printf '%s' "$cmd" | jq -Rs .)}}" \
-    | env LEAN4_GUARDRAILS_FORCE=1 "${policy_env[@]}" bash "$HOOK" >/dev/null 2>&1 || actual=$?
+    | env LEAN4_GUARDRAILS_FORCE=1 "${policy_env[@]+"${policy_env[@]}"}" bash "$HOOK" >/dev/null 2>&1 || actual=$?
   if [[ "$actual" -eq "$expected" ]]; then
     echo "  PASS: $desc"
     (( ++PASS ))
@@ -68,7 +68,7 @@ run_test_op_policy() {
     policy_env=("LEAN4_GUARDRAILS_${var_name}=${value}")
   fi
   echo "{\"tool_input\":{\"command\":$(printf '%s' "$cmd" | jq -Rs .)}}" \
-    | env LEAN4_GUARDRAILS_FORCE=1 "${policy_env[@]}" bash "$HOOK" >/dev/null 2>&1 || actual=$?
+    | env LEAN4_GUARDRAILS_FORCE=1 "${policy_env[@]+"${policy_env[@]}"}" bash "$HOOK" >/dev/null 2>&1 || actual=$?
   if [[ "$actual" -eq "$expected" ]]; then
     echo "  PASS: $desc"
     (( ++PASS ))
@@ -88,7 +88,7 @@ run_test_destructive_policy() {
     policy_env=(LEAN4_GUARDRAILS_DESTRUCTIVE_POLICY="$policy")
   fi
   echo "{\"tool_input\":{\"command\":$(printf '%s' "$cmd" | jq -Rs .)}}" \
-    | env LEAN4_GUARDRAILS_FORCE=1 "${policy_env[@]}" bash "$HOOK" >/dev/null 2>&1 || actual=$?
+    | env LEAN4_GUARDRAILS_FORCE=1 "${policy_env[@]+"${policy_env[@]}"}" bash "$HOOK" >/dev/null 2>&1 || actual=$?
   if [[ "$actual" -eq "$expected" ]]; then
     echo "  PASS: $desc"
     (( ++PASS ))

--- a/plugins/lean4/tests/test_preflight_env.sh
+++ b/plugins/lean4/tests/test_preflight_env.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression tests for lib/scripts/preflight_env.sh (#108).
+# Exercises --runtime and --bootstrap modes, and guards that doctor.md
+# still carries the three canonical recovery lines byte-for-byte (the
+# helper is the single source of that wording).
+#
+# Runs under $BASH_FOR_COMPAT (default /bin/bash) so it exercises macOS
+# Bash 3.2 in CI. SKIPs gracefully if that shell is unavailable.
+
+BASH_FOR_COMPAT="${BASH_FOR_COMPAT:-/bin/bash}"
+if [[ ! -x "$BASH_FOR_COMPAT" ]]; then
+    echo "SKIP: $BASH_FOR_COMPAT not found — cannot run preflight self-test"
+    exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PREFLIGHT="$PLUGIN_ROOT/lib/scripts/preflight_env.sh"
+DOCTOR="$PLUGIN_ROOT/commands/doctor.md"
+
+PASS=0
+FAIL=0
+
+# Canonical recovery lines — MUST match preflight_env.sh's emit_recovery
+# and doctor.md's inline fallback exactly.
+CANON1="1. Run /lean4:doctor env for a full diagnosis."
+CANON2="2. Restart the Claude Code session (re-runs the SessionStart bootstrap hook)."
+CANON3="3. If it persists, check the plugin hook/bootstrap state (hooks.json, bootstrap.sh)."
+
+pass() { echo "  PASS: $1"; (( ++PASS )) || true; }
+fail() { echo "  FAIL: $1"; (( ++FAIL )) || true; }
+
+# ---------------------------------------------------------------------------
+# --runtime mode
+# ---------------------------------------------------------------------------
+
+# Valid session env → exit 0.
+out=0
+env LEAN4_PLUGIN_ROOT="$PLUGIN_ROOT" \
+    LEAN4_SCRIPTS="$PLUGIN_ROOT/lib/scripts" \
+    LEAN4_REFS="$PLUGIN_ROOT/skills/lean4/references" \
+    PATH="$PLUGIN_ROOT/bin:$PATH" \
+    "$BASH_FOR_COMPAT" "$PREFLIGHT" --runtime >/dev/null 2>&1 || out=$?
+[[ "$out" -eq 0 ]] && pass "runtime: valid env → exit 0" || fail "runtime: valid env → exit 0 (got $out)"
+
+# Missing LEAN4_* → canonical block + exit 2.
+out=0
+runtime_out=$(env -u LEAN4_PLUGIN_ROOT -u LEAN4_SCRIPTS -u LEAN4_REFS \
+    "$BASH_FOR_COMPAT" "$PREFLIGHT" --runtime 2>&1) || out=$?
+if [[ "$out" -eq 2 ]] && grep -qF "$CANON1" <<<"$runtime_out"; then
+    pass "runtime: missing env → canonical block + exit 2"
+else
+    fail "runtime: missing env → canonical block + exit 2 (got exit $out)"
+fi
+
+# ---------------------------------------------------------------------------
+# --bootstrap mode
+# ---------------------------------------------------------------------------
+
+# Valid tree + writable env-file parent (file absent) → exit 0.
+tmp=$(mktemp -d)
+out=0
+CLAUDE_ENV_FILE="$tmp/env" "$BASH_FOR_COMPAT" "$PREFLIGHT" --bootstrap "$PLUGIN_ROOT" >/dev/null 2>&1 || out=$?
+[[ "$out" -eq 0 ]] && pass "bootstrap: valid tree + writable parent (file absent) → exit 0" \
+    || fail "bootstrap: valid tree → exit 0 (got $out)"
+
+# CLAUDE_ENV_FILE unset → exit 2 naming it.
+out=0
+bs_out=$(env -u CLAUDE_ENV_FILE "$BASH_FOR_COMPAT" "$PREFLIGHT" --bootstrap "$PLUGIN_ROOT" 2>&1) || out=$?
+if [[ "$out" -eq 2 ]] && grep -qF "CLAUDE_ENV_FILE is not set" <<<"$bs_out"; then
+    pass "bootstrap: CLAUDE_ENV_FILE unset → exit 2 naming it"
+else
+    fail "bootstrap: CLAUDE_ENV_FILE unset → exit 2 (got $out)"
+fi
+
+# Empty plugin root → exit 2 naming CLAUDE_PLUGIN_ROOT.
+out=0
+bs_out=$(CLAUDE_ENV_FILE="$tmp/env" "$BASH_FOR_COMPAT" "$PREFLIGHT" --bootstrap "" 2>&1) || out=$?
+if [[ "$out" -eq 2 ]] && grep -qF "CLAUDE_PLUGIN_ROOT is not set" <<<"$bs_out"; then
+    pass "bootstrap: empty root → exit 2 naming CLAUDE_PLUGIN_ROOT"
+else
+    fail "bootstrap: empty root → exit 2 (got $out)"
+fi
+
+# Tree missing bin/ → exit 2.
+baddir=$(mktemp -d)
+mkdir -p "$baddir/lib/scripts" "$baddir/skills/lean4/references"
+out=0
+bs_out=$(CLAUDE_ENV_FILE="$tmp/env" "$BASH_FOR_COMPAT" "$PREFLIGHT" --bootstrap "$baddir" 2>&1) || out=$?
+if [[ "$out" -eq 2 ]] && grep -qF "bin does not exist" <<<"$bs_out"; then
+    pass "bootstrap: tree missing bin/ → exit 2"
+else
+    fail "bootstrap: tree missing bin/ → exit 2 (got $out)"
+fi
+
+rm -rf "$tmp" "$baddir"
+
+# ---------------------------------------------------------------------------
+# Wording agreement: doctor.md must contain the three canonical lines.
+# Substring (grep -F) not whole-block diff — doctor wraps them in a code
+# block; only the exact recovery lines need to match.
+# ---------------------------------------------------------------------------
+for canon in "$CANON1" "$CANON2" "$CANON3"; do
+    if grep -qF "$canon" "$DOCTOR"; then
+        pass "doctor.md contains canonical line: ${canon%% *}…"
+    else
+        fail "doctor.md MISSING canonical line: $canon"
+    fi
+done
+
+# Same three lines are what preflight_env.sh actually emits.
+emitted=$(env -u LEAN4_PLUGIN_ROOT -u LEAN4_SCRIPTS -u LEAN4_REFS \
+    "$BASH_FOR_COMPAT" "$PREFLIGHT" --runtime 2>&1 || true)
+for canon in "$CANON1" "$CANON2" "$CANON3"; do
+    grep -qF "$canon" <<<"$emitted" || fail "preflight did not emit canonical line: $canon"
+done
+pass "preflight_env.sh emits all three canonical lines"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== test_preflight_env.sh: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/plugins/lean4/tools/lint_docs.sh
+++ b/plugins/lean4/tools/lint_docs.sh
@@ -67,7 +67,7 @@ check_commands() {
             autoprove)  max_lines=290 ;;
             checkpoint) max_lines=90 ;;
             disprove)   max_lines=300 ;;
-            doctor)     max_lines=225 ;;
+            doctor)     max_lines=265 ;;
             draft)      max_lines=160 ;;
             formalize)  max_lines=195 ;;
             golf)       max_lines=170 ;;


### PR DESCRIPTION
## Summary

**Closes #108** (scope narrowed — see below) and **cuts v4.5.3**, folding in the six PRs merged since v4.5.2.

Off `fix/bootstrap-env-108` from `origin/main` (`e63d072`, post-#147). Eight commits (five substantive + three review-fix follow-ups: Bash-3.2 fix for a wired-in orphan test, `persist_path` coexistence, and the non-persistent-`CLAUDE_ENV_FILE` silent-degraded hole).

## Premise correction (why the scope narrowed)

#108 says seven commands invoke `"$LEAN4_SCRIPTS/foo.py"` and produce `/foo.py` root-path errors when the bootstrap env is missing. **That's mostly stale:** those 7 commands were migrated to self-locating `lean4-skills-*` wrappers in #117/#130 (they resolve `PLUGIN_ROOT` from `BASH_SOURCE`, don't read `$LEAN4_SCRIPTS`). `rg '\$LEAN4_SCRIPTS' plugins/lean4/commands/` now matches only `disprove.md` and `doctor.md`. A per-command bin-wrapper preflight also can't run in the scenario it targets (bin/ off PATH).

**Still a live bug** — the bootstrap/PATH truthfulness gap:
- `hooks/bootstrap.sh` printed `Lean4 v4 ready` + exit 0 **unconditionally**, even when `CLAUDE_ENV_FILE` was empty so `persist_env` silently wrote nothing → a failed bootstrap masqueraded as success.
- It never persisted `PATH`, despite `INSTALLATION.md:6` claiming "bootstrap … adds `plugins/lean4/bin/` to the Bash tool's PATH." Wrappers being off PATH is the actual missing-env symptom.
- No shared env-validation helper existed; doctor's recovery wording was weaker than a real diagnosis.

Per the reframe, the central choke points are **bootstrap + doctor**, not per-command checks.

## What this PR does

**`0ff32b8` — shared preflight helper.** New `lib/scripts/preflight_env.sh` — single source of the env checks AND the canonical recovery wording. `--bootstrap` mode validates a SessionStart's inputs (tree layout + `CLAUDE_ENV_FILE` usability: nonempty var, writable parent dir, file-writable-if-exists — doesn't require the file to pre-exist); `--runtime` mode diagnoses the live session (LEAN4_* → real dirs, bin/ on PATH, wrappers resolve). New `bin/lean4-skills-preflight` wrapper runs it as a manual diagnostic.

**`a45b146` — bootstrap honesty + PATH persistence.** Ordering now enforces "ready means the environment was written": validate inputs → persist LEAN4_* **and PATH** (`:$PATH` kept literal, deduped idempotently) → re-check persistence took effect → print "ready" only then. Every degraded path prints the canonical block to stderr (warn + exit 0, non-disruptive). Removed the `: "${CLAUDE_PLUGIN_ROOT:?…}"` hard-require that used to abort *before* the honest path could run.

**`1a939b1` — doctor alignment.** `/lean4:doctor env` runs the preflight for a live diagnosis, resolved **without depending on PATH** (tiered: PATH wrapper → `$LEAN4_PLUGIN_ROOT/bin/…` → inline canonical block — doctor is exactly where a broken PATH must stay diagnosable). Troubleshooting rows now give the same three canonical steps. Also converted `lib/scripts/README.md`'s raw `$LEAN4_SCRIPTS/sorry_analyzer.py` example (the literal symptom source) to wrappers, and bumped doctor's `max_lines` target for the new diagnostic block (#143 precedent).

**`acaded0` — tests + CI.** `test_bootstrap_env.sh` (7 probes: honesty, PATH persistence, **PATH idempotency**, all degraded paths) and `test_preflight_env.sh` (10 probes + the doctor/preflight wording-agreement guard). Also wires in `test_guardrails.sh` (327) and `test_validate_user_prompt.sh` (33) — hook suites that existed but ran in **no** workflow (same silent-coverage-gap class #146/#147 fixed).

**`abec990` — release v4.5.3.** CHANGELOG section (primary = this fix; folds in #141, #142, #143, #145, #146, #147). Version bump in `.claude-plugin/marketplace.json` + `plugins/lean4/.claude-plugin/plugin.json`.

## Verification (all local, pre-push)

- shellcheck CI-exact (hooks + lib/scripts + tools + bin wrappers): clean
- New suites: bootstrap 11/11, preflight 10/10. Newly-wired: guardrails 327/327, validate_user_prompt 33/33.
- Existing suites unaffected: axiom-inline 30/30, unused-decls 10/10, sorry-analyzer 38 tests.
- `lint_docs.sh` exit 0; `test_contracts.sh` 29/29 (Check 27 green). Both version JSONs valid; no stray plugin-version `4.5.2` remains.
- Manual bootstrap matrix: happy path persists all 5 exports incl. PATH; two runs → one `export PATH=` line; `CLAUDE_ENV_FILE`-unset and `CLAUDE_PLUGIN_ROOT`-unset both warn canonically (no "ready"), exit 0.
- [x] CI — all 5 checks green; bash3-compat log confirms the new/newly-wired suites actually executed on the macOS Bash 3.2 runner (bootstrap 11/11, preflight 10/10, guardrails 327/327, validate_user_prompt 33/33), per the #146 "read the log" rule.

## Out of scope (deferred)

- Migrating `disprove.md`'s raw `$LEAN4_SCRIPTS/disprove_*.py` invocations (needs 5 new `disprove_*` wrappers) — tracked as follow-up **#149**.
- Per-command preflight steps (reframed away); a PreToolUse env-guard (touches guardrails, risks false positives); SessionStart hard-fail (warn+exit-0 chosen for non-disruptiveness).

## Note for #108
This PR keeps `Closes #108` — it fixes the still-live bootstrap/PATH truthfulness bug, which is what #108 is really about. The original "seven commands invoke `$LEAN4_SCRIPTS/...`" premise is mostly stale after the #117/#130 wrapper migration. The one remaining raw-invocation surface (`/lean4:disprove`, 9 references + 5 unwrapped `disprove_*` scripts) is tracked as a dedicated follow-up: **#149**. On merge I'll post the scope-narrowing closure comment on #108 linking #149.


