### PR TITLE
feat(bin): self-locating disprove wrappers; migrate raw $LEAN4_SCRIPTS invocations (v4.5.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Lean 4 theorem proving with guided + autonomous proving, LSP-first workflows, guardrails, and contribution helpers",
-    "version": "4.5.3"
+    "version": "4.5.4"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v4.5.4 (July 2026)
+
+Completes the wrapper migration that v4.5.3 deferred: `/lean4:disprove` was the last command whose docs invoked scripts via raw `"$LEAN4_SCRIPTS/disprove_*.py"` — the form that expands to `/disprove_*.py` with a confusing root-path error when the bootstrap env is missing (#108's original symptom). Closes #149.
+
+### `bin/` wrappers (disprove runtime)
+
+- 5 new self-locating executables under `plugins/lean4/bin/`, mirroring the existing wrapper template (`PLUGIN_ROOT` via `BASH_SOURCE`, delegate through `${LEAN4_PYTHON_BIN:-python3}`):
+  - `lean4-skills-disprove-artifact-txn` (transactional append / drop-role / rollback — the Phase 3 hot path)
+  - `lean4-skills-disprove-emit-artifact` (collision-safe non-transactional writer)
+  - `lean4-skills-disprove-method-probe`, `lean4-skills-disprove-target-profile`, `lean4-skills-disprove-target-resolve` (Phase 1 profiling/resolution + method applicability)
+- The Python 3.11+ requirement is unchanged — wrappers honor `LEAN4_PYTHON_BIN`, and only the registry-loading path (`disprove_method_probe.py` via `lib/disprove_methods.py`) enforces 3.11.
+
+### Docs
+
+- `commands/disprove.md` and `references/disprove-engine.md`: all 9 raw `$LEAN4_SCRIPTS/disprove_*.py` invocations rewritten to bare wrapper names; bare-basename mentions in the Safety sections and the Target Resolution Flow diagram aligned to the wrapper names.
+- SKILL.md's curated wrapper list extended with the five disprove wrappers.
+
+### Lint & contracts
+
+- `test_contracts.sh` Check 26 (wrapper→doc coverage) and Check 27 (no stale `$LEAN4_SCRIPTS/<wrapped>` forms) now cover the disprove wrappers automatically — Check 27 derives its wrapper→script mapping from each wrapper's delegation line, so future raw-invocation drift in `disprove` docs fails the suite.
+
 ## v4.5.3 (July 2026)
 
 Bootstrap now fails honestly and persists the wrapper `PATH`, plus a shared env-preflight so bootstrap and doctor agree on one recovery message. Also folds in six docs/lint/bugfix PRs that landed on `main` after v4.5.2 without their own version bumps.

--- a/plugins/lean4/.claude-plugin/plugin.json
+++ b/plugins/lean4/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lean4",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "description": "Unified Lean 4 plugin (draft, formalize, autoformalize, prove, autoprove, disprove, checkpoint, review, refactor, golf, learn, doctor) — LSP-first, scripts fallback",
   "author": {"name": "Cameron Freer", "email": "cameronfreer@gmail.com"}
 }

--- a/plugins/lean4/bin/lean4-skills-disprove-artifact-txn
+++ b/plugins/lean4/bin/lean4-skills-disprove-artifact-txn
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lean4-skills-disprove-artifact-txn — model-facing wrapper around lib/scripts/disprove_artifact_txn.py.
+# See lean4-skills-cycle-tracker for the rationale.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+exec "${LEAN4_PYTHON_BIN:-python3}" "$PLUGIN_ROOT/lib/scripts/disprove_artifact_txn.py" "$@"

--- a/plugins/lean4/bin/lean4-skills-disprove-emit-artifact
+++ b/plugins/lean4/bin/lean4-skills-disprove-emit-artifact
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lean4-skills-disprove-emit-artifact — model-facing wrapper around lib/scripts/disprove_emit_artifact.py.
+# See lean4-skills-cycle-tracker for the rationale.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+exec "${LEAN4_PYTHON_BIN:-python3}" "$PLUGIN_ROOT/lib/scripts/disprove_emit_artifact.py" "$@"

--- a/plugins/lean4/bin/lean4-skills-disprove-method-probe
+++ b/plugins/lean4/bin/lean4-skills-disprove-method-probe
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lean4-skills-disprove-method-probe — model-facing wrapper around lib/scripts/disprove_method_probe.py.
+# See lean4-skills-cycle-tracker for the rationale.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+exec "${LEAN4_PYTHON_BIN:-python3}" "$PLUGIN_ROOT/lib/scripts/disprove_method_probe.py" "$@"

--- a/plugins/lean4/bin/lean4-skills-disprove-target-profile
+++ b/plugins/lean4/bin/lean4-skills-disprove-target-profile
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lean4-skills-disprove-target-profile — model-facing wrapper around lib/scripts/disprove_target_profile.py.
+# See lean4-skills-cycle-tracker for the rationale.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+exec "${LEAN4_PYTHON_BIN:-python3}" "$PLUGIN_ROOT/lib/scripts/disprove_target_profile.py" "$@"

--- a/plugins/lean4/bin/lean4-skills-disprove-target-resolve
+++ b/plugins/lean4/bin/lean4-skills-disprove-target-resolve
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lean4-skills-disprove-target-resolve — model-facing wrapper around lib/scripts/disprove_target_resolve.py.
+# See lean4-skills-cycle-tracker for the rationale.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+exec "${LEAN4_PYTHON_BIN:-python3}" "$PLUGIN_ROOT/lib/scripts/disprove_target_resolve.py" "$@"

--- a/plugins/lean4/commands/disprove.md
+++ b/plugins/lean4/commands/disprove.md
@@ -126,7 +126,7 @@ See [disprove-engine.md § Phase 2 — Work](../skills/lean4/references/disprove
 
 ### Phase 3: Checkpoint
 
-See [disprove-engine.md § Phase 3 — Checkpoint](../skills/lean4/references/disprove-engine.md#phase-3--checkpoint). On a **pre-screen-passing candidate**, open a transaction (`txn=$(${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/disprove_artifact_txn.py" begin)`) and append `T_counterexample` via its `append --txn=$txn --role=artifact` subcommand (witness shapes also append the gate-only `*_negates_target` with `--role=gate`), run `lake env lean <target-file>` from the project root, then **inspect the axioms of the declaration carrying `¬ TARGET`** (`T_counterexample` for direct shapes, `T_counterexample_negates_target` for witness shapes) via `lean_verify` / `#print axioms`. Report `REFUTED` only if it typechecks **and** that declaration's axioms ⊆ `{propext, Classical.choice, Quot.sound}` (plus `Lean.ofReduceBool` only under an explicit `native_decide` opt-in this cycle): on `REFUTED`, `drop-role --txn=$txn --role=gate` (witness shapes) and commit only `T_counterexample`. Otherwise `rollback --txn=$txn` (reverts every declaration appended this cycle), distinguishing the non-REFUTED outcomes: a **typecheck failure** is a `near-miss` cycle outcome (capture the error signature for the next cycle), while a **non-whitelisted axiom or inconclusive axiom inspection** is `WITNESS_UNCERTIFIED`. `<target-file>` is the resolved source file — for a qualified-name target, the declaration's **writable** source file from Phase 1 (disprove refuses if it resolves only to a read-only dependency).
+See [disprove-engine.md § Phase 3 — Checkpoint](../skills/lean4/references/disprove-engine.md#phase-3--checkpoint). On a **pre-screen-passing candidate**, open a transaction (`txn=$(lean4-skills-disprove-artifact-txn begin)`) and append `T_counterexample` via its `append --txn=$txn --role=artifact` subcommand (witness shapes also append the gate-only `*_negates_target` with `--role=gate`), run `lake env lean <target-file>` from the project root, then **inspect the axioms of the declaration carrying `¬ TARGET`** (`T_counterexample` for direct shapes, `T_counterexample_negates_target` for witness shapes) via `lean_verify` / `#print axioms`. Report `REFUTED` only if it typechecks **and** that declaration's axioms ⊆ `{propext, Classical.choice, Quot.sound}` (plus `Lean.ofReduceBool` only under an explicit `native_decide` opt-in this cycle): on `REFUTED`, `drop-role --txn=$txn --role=gate` (witness shapes) and commit only `T_counterexample`. Otherwise `rollback --txn=$txn` (reverts every declaration appended this cycle), distinguishing the non-REFUTED outcomes: a **typecheck failure** is a `near-miss` cycle outcome (capture the error signature for the next cycle), while a **non-whitelisted axiom or inconclusive axiom inspection** is `WITNESS_UNCERTIFIED`. `<target-file>` is the resolved source file — for a qualified-name target, the declaration's **writable** source file from Phase 1 (disprove refuses if it resolves only to a read-only dependency).
 
 **Commit prompt** (when `--commit=ask`):
 
@@ -246,8 +246,8 @@ of the originating Step 0 finding); all other cycles show `—`. See
 
 - **Append-only, transactional.** Never rewrite an existing
   `theorem T : P := by sorry` declaration to `: ¬ P`. Cycle artifacts are written
-  through `$LEAN4_SCRIPTS/disprove_artifact_txn.py` (over the collision-safe
-  `$LEAN4_SCRIPTS/disprove_emit_artifact.py`): each append is wrapped in txn-id markers and
+  through `lean4-skills-disprove-artifact-txn` (over the collision-safe
+  `lean4-skills-disprove-emit-artifact`): each append is wrapped in txn-id markers and
   refuses to modify or clobber an existing declaration; the cycle's writes are
   reverted as a unit via `rollback` / `drop-role` on failure or wrapper drop.
 - **No `native_decide` without opt-in (any method).** `native_decide`

--- a/plugins/lean4/skills/lean4/SKILL.md
+++ b/plugins/lean4/skills/lean4/SKILL.md
@@ -219,7 +219,10 @@ See [sorry-filling.md](references/sorry-filling.md) for the full scratch-work pr
   `lean4-skills-find-golfable`, `lean4-skills-find-exact-candidates`,
   `lean4-skills-analyze-let-usage`, `lean4-skills-find-usages`,
   `lean4-skills-search-mathlib`, `lean4-skills-smart-search`,
-  `lean4-skills-cycle-tracker`). These are bare commands on PATH —
+  `lean4-skills-cycle-tracker`, `lean4-skills-disprove-artifact-txn`,
+  `lean4-skills-disprove-emit-artifact`, `lean4-skills-disprove-method-probe`,
+  `lean4-skills-disprove-target-profile`,
+  `lean4-skills-disprove-target-resolve`). These are bare commands on PATH —
   no `$LEAN4_SCRIPTS`, no `${LEAN4_PYTHON_BIN:-python3}`, no `~`, no
   command substitution. Stable invocation surface that sandboxed hosts
   can statically allowlist.

--- a/plugins/lean4/skills/lean4/SKILL.md
+++ b/plugins/lean4/skills/lean4/SKILL.md
@@ -224,8 +224,10 @@ See [sorry-filling.md](references/sorry-filling.md) for the full scratch-work pr
   `lean4-skills-disprove-target-profile`,
   `lean4-skills-disprove-target-resolve`). These are bare commands on PATH —
   no `$LEAN4_SCRIPTS`, no `${LEAN4_PYTHON_BIN:-python3}`, no `~`, no
-  command substitution. Stable invocation surface that sandboxed hosts
-  can statically allowlist.
+  env-var expansion or command substitution **to locate the executable**.
+  Ordinary output capture around a wrapper is fine (e.g.
+  `txn=$(lean4-skills-disprove-artifact-txn begin)`). Stable invocation
+  surface that sandboxed hosts can statically allowlist.
 - **Report-only calls**: add `--report-only` to
   `lean4-skills-sorry-analyzer`, `lean4-skills-check-axioms-inline`
   (and `unused_declarations.sh` if invoked via env-var fallback) —

--- a/plugins/lean4/skills/lean4/references/disprove-engine.md
+++ b/plugins/lean4/skills/lean4/references/disprove-engine.md
@@ -129,7 +129,7 @@ cross-cycle digest is cached so only new evidence is re-integrated.
 ```text
 target = (validated-invocation block) | positional argument
         ↓
-disprove_target_resolve.py → {kind, file?, line?, name?}
+lean4-skills-disprove-target-resolve → {kind, file?, line?, name?}
         ↓
    file-line ──→ lean_diagnostic_messages(file)
               → lean_goal(file, line)         ← extracts the Prop
@@ -169,7 +169,7 @@ The **deterministic** half of this — target classification, best-effort grep
 resolution of a qualified name to a *single unambiguous* project source location
 (0 or ≥2 hits → `needs_lsp_resolution`; grep is non-authoritative), `path_class`
 (project vs read-only `dependency`) + `writable`, and the dependency-path refusal
-— is produced by `$LEAN4_SCRIPTS/disprove_target_profile.py` as one JSON envelope.
+— is produced by `lean4-skills-disprove-target-profile` as one JSON envelope.
 The cycling LLM then fills the LSP/kernel fields it lists under `_lsp_filled`
 (`shape`, `decidable`, `type`, `free_vars`, `candidate_grid`) and confirms an
 ambiguous/unresolved name via `lean_declaration_file`. (A merely read-only
@@ -420,7 +420,7 @@ future estimates.
   approval-gated (generic Python/bash scripts) and stays selectable; solver-backed
   configs additionally need z3/cvc5 on `$PATH` (reported, not gated).
 
-`${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/disprove_method_probe.py" --profile=<profile.json>` computes this
+`lean4-skills-disprove-method-probe --profile=<profile.json>` computes this
 deterministically — `{method: {selectable, reason}}` from the registry's
 `applies_to_shapes` (vs `profile.shape`), the profile's `decidable`/`sampleable`
 hints, and a `shutil.which` solver check that is **advisory** for `external`
@@ -658,14 +658,14 @@ the qualified-name target resolved to in Phase 1):
    wrapper>` (see the Per-Shape Recipes intro) — this is the declaration that
    actually carries the `¬ TARGET` type.
 2. Append within a **transaction** so the cycle's writes are revertible by id.
-   Open one with `txn=$(${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/disprove_artifact_txn.py" begin)`,
+   Open one with `txn=$(lean4-skills-disprove-artifact-txn begin)`,
    then append the artifact (snippet on stdin):
-   `${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/disprove_artifact_txn.py" append --scope-file=<target-file> --txn=$txn --role=artifact --decl=T_counterexample --cycle=<N>`.
+   `lean4-skills-disprove-artifact-txn append --scope-file=<target-file> --txn=$txn --role=artifact --decl=T_counterexample --cycle=<N>`.
    For witness shapes, append the gate-only declaration under the same txn with
    `--role=gate --decl=T_counterexample_negates_target`. Each append is wrapped in
    `-- lean4:disprove-begin/-end txn=… role=…` markers and refuses to clobber a decl
    already declared outside the txn. (The standalone collision-safe writer
-   `disprove_emit_artifact.py` remains for non-transactional appends.)
+   `lean4-skills-disprove-emit-artifact` remains for non-transactional appends.)
 3. Run `lake env lean <target-file>` from the project root (typecheck gate).
 4. **Axiom gate.** Inspect the axioms via `lean_verify` (or `#print axioms`) of the
    declaration that carries the `¬ TARGET` type — `T_counterexample` for direct
@@ -676,13 +676,13 @@ the qualified-name target resolved to in Phase 1):
 5. License the outcome:
    - **`certified` (→ `REFUTED`)** only if the `¬ TARGET`-typed declaration
      typechecked (no `sorry`/`admit`) **and** its axiom set ⊆ the allowed whitelist.
-     For witness shapes, `${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/disprove_artifact_txn.py" drop-role --scope-file=<target-file> --txn=$txn --role=gate`
+     For witness shapes, `lean4-skills-disprove-artifact-txn drop-role --scope-file=<target-file> --txn=$txn --role=gate`
      **before** the commit, then from the project root re-run
      `lake env lean <target-file>` on the wrapper-free file, so the committed state
      (`T_counterexample` alone, which still typechecks) is itself gate-verified — the
      committed file equals the gate-checked file. Commit only `T_counterexample`;
      proceed to Review.
-   - **Typecheck fails** → `${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/disprove_artifact_txn.py" rollback --scope-file=<target-file> --txn=$txn`
+   - **Typecheck fails** → `lean4-skills-disprove-artifact-txn rollback --scope-file=<target-file> --txn=$txn`
      (removes the artifact and, for witness shapes, the gate-only wrapper — only this
      txn's marker blocks); downgrade to `near-miss`, capture the error signature.
    - **A non-whitelisted axiom appears, or axiom inspection is unavailable /
@@ -983,8 +983,8 @@ finding). For all other cycles the column is `—`.
 
 - **Append-only, transactional.** Never rewrite an existing
   `theorem T : P := by sorry` declaration to `: ¬ P`. Cycle artifacts are
-  written through `disprove_artifact_txn.py` (over the collision-safe
-  `disprove_emit_artifact.py`): each append is wrapped in txn-id markers and
+  written through `lean4-skills-disprove-artifact-txn` (over the collision-safe
+  `lean4-skills-disprove-emit-artifact`): each append is wrapped in txn-id markers and
   refuses to modify or duplicate an existing declaration; the cycle's writes
   are reverted as a unit via `rollback` (failure) or `drop-role` (gate-only
   wrapper before commit), never touching pre-existing or other-txn declarations.

--- a/plugins/lean4/tools/test_contracts.sh
+++ b/plugins/lean4/tools/test_contracts.sh
@@ -553,14 +553,17 @@ DOC_SURFACES=(
 )
 if [[ -d "$BIN_DIR" ]]; then
     while IFS= read -r wrapper; do
-        # Derive underlying script basename by parsing the wrapper body.
-        # Anchored to the .py / .sh extension so we don't accidentally
-        # pick up trailing punctuation from a docstring (e.g.,
-        # `wrapper around lib/scripts/foo.py.` would otherwise yield
-        # `foo.py.`). Prefer the exec/invocation line over any docstring.
-        script=$(grep -oE 'lib/scripts/[a-zA-Z0-9_-]+\.(py|sh)' "$wrapper" 2>/dev/null \
+        # Derive underlying script basename from the wrapper's exec line
+        # only — header comments also name lib/scripts/<basename>, and
+        # parsing them could mask a malformed exec line. The extension
+        # anchor avoids trailing docstring punctuation. `|| true` keeps
+        # a no-match pipeline from tripping set -euo pipefail; the
+        # unparseable-wrapper case is Check 28's explicit failure, so
+        # Check 27 just skips it.
+        script=$(grep -E '^exec ' "$wrapper" 2>/dev/null \
+            | grep -oE 'lib/scripts/[a-zA-Z0-9_-]+\.(py|sh)' \
             | tail -1 \
-            | sed 's|lib/scripts/||')
+            | sed 's|lib/scripts/||' || true)
         [[ -z "$script" ]] && continue
         # Escape for grep regex.
         sc_re=$(printf '%s' "$script" | sed 's/[][\/.^$*+?{}|()]/\\&/g')
@@ -595,11 +598,15 @@ check28_ok=1
 if [[ -d "$BIN_DIR" ]]; then
     while IFS= read -r wrapper; do
         name=$(basename "$wrapper")
-        script=$(grep -oE 'lib/scripts/[a-zA-Z0-9_-]+\.(py|sh)' "$wrapper" 2>/dev/null \
+        # Same exec-line-only parse as Check 27 (comments could mask a
+        # malformed exec line); `|| true` so a no-match reaches the
+        # explicit failure below instead of tripping set -euo pipefail.
+        script=$(grep -E '^exec ' "$wrapper" 2>/dev/null \
+            | grep -oE 'lib/scripts/[a-zA-Z0-9_-]+\.(py|sh)' \
             | tail -1 \
-            | sed 's|lib/scripts/||')
+            | sed 's|lib/scripts/||' || true)
         if [[ -z "$script" ]]; then
-            fail "Check 28: wrapper $name has no parseable lib/scripts/<basename> delegation"
+            fail "Check 28: wrapper $name has no parseable exec-line lib/scripts/<basename> delegation"
             check28_ok=0
             continue
         fi

--- a/plugins/lean4/tools/test_contracts.sh
+++ b/plugins/lean4/tools/test_contracts.sh
@@ -582,6 +582,41 @@ if [[ "$check27_ok" -eq 1 ]]; then
     ok "Check 27: no stale \$LEAN4_SCRIPTS/<wrapped> invocations in model-facing docs"
 fi
 
+# ---------------------------------------------------------------------------
+# Check 28: every wrapper's parsed delegation target exists and is
+# executable. Check 27 parses the `lib/scripts/<basename>` delegation to
+# build its doc-drift mapping but silently skips a wrapper whose body
+# doesn't parse, and never verifies the target file — so a wrapper could
+# ship pointing at a renamed or deleted script and only fail at runtime.
+# This check makes the delegation itself a tested contract: parseable,
+# present, executable.
+# ---------------------------------------------------------------------------
+check28_ok=1
+if [[ -d "$BIN_DIR" ]]; then
+    while IFS= read -r wrapper; do
+        name=$(basename "$wrapper")
+        script=$(grep -oE 'lib/scripts/[a-zA-Z0-9_-]+\.(py|sh)' "$wrapper" 2>/dev/null \
+            | tail -1 \
+            | sed 's|lib/scripts/||')
+        if [[ -z "$script" ]]; then
+            fail "Check 28: wrapper $name has no parseable lib/scripts/<basename> delegation"
+            check28_ok=0
+            continue
+        fi
+        target="$PLUGIN_ROOT/lib/scripts/$script"
+        if [[ ! -f "$target" ]]; then
+            fail "Check 28: wrapper $name delegates to missing script lib/scripts/$script"
+            check28_ok=0
+        elif [[ ! -x "$target" ]]; then
+            fail "Check 28: wrapper $name delegates to non-executable script lib/scripts/$script"
+            check28_ok=0
+        fi
+    done < <(find "$BIN_DIR" -mindepth 1 -maxdepth 1 -name 'lean4-skills-*' -type f 2>/dev/null | sort)
+fi
+if [[ "$check28_ok" -eq 1 ]]; then
+    ok "Check 28: every bin/ wrapper's delegation target exists and is executable"
+fi
+
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #149.

Completes the wrapper migration that v4.5.3 (#148) deliberately deferred: `/lean4:disprove` was the last command whose docs invoked scripts via raw `"$LEAN4_SCRIPTS/disprove_*.py"` — the form that expands to `/disprove_*.py` with a confusing root-path failure when the bootstrap env is missing (#108's original symptom).

## Changes

- **5 new curated wrappers** under `plugins/lean4/bin/`, mirroring the existing self-locating template (`PLUGIN_ROOT` via `BASH_SOURCE`, delegate through `${LEAN4_PYTHON_BIN:-python3}`, mode 100755):
  `lean4-skills-disprove-artifact-txn`, `lean4-skills-disprove-emit-artifact`, `lean4-skills-disprove-method-probe`, `lean4-skills-disprove-target-profile`, `lean4-skills-disprove-target-resolve`
- **Docs migrated**: all 9 raw `$LEAN4_SCRIPTS/disprove_*.py` invocations in `commands/disprove.md` (3) and `references/disprove-engine.md` (6) rewritten to bare wrapper names; bare-basename mentions in both Safety sections and the Target Resolution Flow diagram aligned; SKILL.md's curated wrapper list extended (Check 26 coverage).
- **Release**: v4.5.4 (plugin.json + marketplace.json + CHANGELOG entry).

The Python 3.11+ requirement is unchanged — wrappers honor `LEAN4_PYTHON_BIN`, and only the registry-loading path (`disprove_method_probe.py`) enforces it.

## Verification

- `tools/test_contracts.sh`: 29/29 (Check 26 wrapper→doc coverage and Check 27 stale-invocation scan both cover the new wrappers automatically)
- `tools/lint_runtime_portability.sh`: all 25 shell + 18 Python files pass (Check 10: 15 curated wrappers)
- `tools/lint_docs.sh`: all checks pass (incl. Check 23 version sync)
- `tests/test_guardrails.sh`: 327/327; `tests/test_lint_runtime_portability.sh`: 62/62
- `shellcheck` on the 5 new wrappers: clean
- Functional smoke from outside the repo (self-location proof): `--help` → 0 with usage for the four argparse scripts; no-args → 2 (usage error, expected); `target-resolve` exits 2 with a clear message on any non-target string (its real no-argparse contract); `artifact-txn begin` from `/tmp` → prints txn id, rc 0; `method-probe --profile=<minimal>` → correct JSON verdicts end-to-end. (No Python < 3.11 available locally; that graceful-failure path lives in untouched `lib/disprove_methods.py`.)