### PR TITLE
Rename /lean4:doctor → /lean4:diagnose (avoids collision with built-in /doctor)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "Lean 4 theorem proving with guided + autonomous proving, LSP-first workflows, guardrails, and contribution helpers",
-    "version": "4.5.4"
+    "version": "4.6.0"
   },
   "plugins": [
     {
       "name": "lean4",
-      "description": "Unified Lean 4 plugin (draft, formalize, autoformalize, prove, autoprove, disprove, checkpoint, review, refactor, golf, learn, doctor) — LSP-first, scripts fallback",
+      "description": "Unified Lean 4 plugin (draft, formalize, autoformalize, prove, autoprove, disprove, checkpoint, review, refactor, golf, learn, diagnose) — LSP-first, scripts fallback",
       "source": "./plugins/lean4"
     },
     {

--- a/.github/workflows/bash3-compat.yml
+++ b/.github/workflows/bash3-compat.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Self-test — bootstrap env honesty + PATH persistence (#108)
         run: /bin/bash plugins/lean4/tests/test_bootstrap_env.sh
 
-      - name: Self-test — preflight_env + doctor wording agreement (#108)
+      - name: Self-test — preflight_env + diagnose wording agreement (#108)
         run: /bin/bash plugins/lean4/tests/test_preflight_env.sh
 
       # These hook self-tests existed but ran in NO workflow (the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v4.6.0 (July 2026)
+
+Renames the `/lean4:doctor` command to `/lean4:diagnose`. The `doctor` name collided with Claude Code's built-in `/doctor` command, so the plugin diagnostic is now `/lean4:diagnose` (same modes: bare, `env`, `migrate`, `cleanup`).
+
+### Breaking
+
+- **`/lean4:doctor` → `/lean4:diagnose`.** `commands/doctor.md` is renamed to `commands/diagnose.md` (frontmatter `name: diagnose`); all subcommands are unchanged (`/lean4:diagnose env|migrate|cleanup`). Any muscle-memory, scripts, or docs invoking `/lean4:doctor` must switch to `/lean4:diagnose`.
+
+### Canonical recovery wording
+
+- The single-source recovery block in `lib/scripts/preflight_env.sh` (`emit_recovery`) and its byte-identical copy in `hooks/bootstrap.sh` now say `Run /lean4:diagnose env for a full diagnosis.` `commands/diagnose.md` reproduces the three canonical lines; `test_preflight_env.sh` and `test_bootstrap_env.sh` assert the new wording.
+
+### Lint & docs
+
+- `tools/lint_docs.sh`: `KNOWN_COMMANDS`, the per-command `max_lines` table, and the two `diagnose.md` special-cases (stale-plugin-path skip, host-agnostic skip) updated for the new name.
+- All surfaces realigned: root `README.md`, `INSTALLATION.md`, `MIGRATION.md`, `plugins/lean4/README.md`, `SKILL.md`, and the `command-examples.md` / `command-invocation.md` / `subagent-workflows.md` references. Both plugin descriptions (`plugin.json`, `marketplace.json`) list `diagnose`. Historical CHANGELOG entries keep the old `doctor` name (accurate for the releases they describe).
+
 ## v4.5.4 (July 2026)
 
 Completes the wrapper migration that v4.5.3 deferred: `/lean4:disprove` was the last command whose docs invoked scripts via raw `"$LEAN4_SCRIPTS/disprove_*.py"` — the form that expands to `/disprove_*.py` with a confusing root-path error when the bootstrap env is missing (#108's original symptom). Closes #149.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -35,7 +35,7 @@ That's it! The skill activates automatically when working with `.lean` files.
 ### Verify
 
 ```
-/lean4:doctor
+/lean4:diagnose
 ```
 
 ### Platform Notes
@@ -60,7 +60,7 @@ No special setup required.
 
 1. Check installation: `/plugin list`
 2. Restart Claude Code
-3. Run `/lean4:doctor`
+3. Run `/lean4:diagnose`
 
 #### LSP Server Not Working
 
@@ -73,7 +73,7 @@ No special setup required.
 
 The `LEAN4_SCRIPTS` etc. variables are set by the bootstrap hook. If missing:
 1. Restart Claude Code session
-2. Check `/lean4:doctor env`
+2. Check `/lean4:diagnose env`
 
 #### Scripts Not Executable
 
@@ -347,7 +347,7 @@ If you have the old 3-plugin system:
 /plugin install lean4
 
 # Verify
-/lean4:doctor
+/lean4:diagnose
 ```
 
 ### What Changed
@@ -371,7 +371,7 @@ If you have the old 3-plugin system:
 
 ## Getting Help
 
-- **Plugin diagnostics (Claude Code):** `/lean4:doctor` — checks environment, plugin, and project
+- **Plugin diagnostics (Claude Code):** `/lean4:diagnose` — checks environment, plugin, and project
 - **Issues:** https://github.com/cameronfreer/lean4-skills/issues
 - **LSP server:** https://github.com/oOo0oOo/lean-lsp-mcp/issues
 - **Claude Code:** `/help`

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ others all use the same core skill; only the invocation surface differs.
 | refactor | Leverage mathlib, extract helpers, simplify proof strategies |
 | golf | Improve proofs for directness, clarity, performance, and brevity |
 | learn | Interactive teaching and mathlib exploration |
-| doctor | Diagnostics and migration help |
+| diagnose | Diagnostics and migration help |
 
 **Claude Code:** invoke as `/lean4:<name>`. **Other hosts:** follow the corresponding workflow in [SKILL.md](plugins/lean4/skills/lean4/SKILL.md).
 

--- a/plugins/lean4/.claude-plugin/plugin.json
+++ b/plugins/lean4/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lean4",
-  "version": "4.5.4",
-  "description": "Unified Lean 4 plugin (draft, formalize, autoformalize, prove, autoprove, disprove, checkpoint, review, refactor, golf, learn, doctor) — LSP-first, scripts fallback",
+  "version": "4.6.0",
+  "description": "Unified Lean 4 plugin (draft, formalize, autoformalize, prove, autoprove, disprove, checkpoint, review, refactor, golf, learn, diagnose) — LSP-first, scripts fallback",
   "author": {"name": "Cameron Freer", "email": "cameronfreer@gmail.com"}
 }

--- a/plugins/lean4/MIGRATION.md
+++ b/plugins/lean4/MIGRATION.md
@@ -26,7 +26,7 @@ This guide helps you upgrade from the legacy 3-plugin system (v3.x) to the unifi
 | `/lean4-theorem-proving:search-mathlib` | Use LSP `lean_leansearch` or scripts |
 | (no equivalent) | `/lean4:review` (NEW) |
 | (no equivalent) | `/lean4:refactor` (NEW) |
-| (no equivalent) | `/lean4:doctor` (NEW) |
+| (no equivalent) | `/lean4:diagnose` (NEW) |
 | (no equivalent) | `/lean4:disprove` (NEW) |
 
 ### Environment Variables
@@ -57,7 +57,7 @@ This guide helps you upgrade from the legacy 3-plugin system (v3.x) to the unifi
 ### Step 3: Verify Installation
 
 ```bash
-/lean4:doctor
+/lean4:diagnose
 ```
 
 This runs diagnostics to ensure everything is working.
@@ -77,7 +77,7 @@ These are now inert (unused) but can be removed:
 rm -rf .claude/tools/lean4 .claude/docs/lean4
 ```
 
-Or run `/lean4:doctor cleanup` for guided removal.
+Or run `/lean4:diagnose cleanup` for guided removal.
 
 ## Workflow Changes
 
@@ -156,7 +156,7 @@ If you need the old 3-plugin version:
 
 The bootstrap hook didn't run. Try:
 1. Restart Claude Code session
-2. Run `/lean4:doctor` to check environment
+2. Run `/lean4:diagnose` to check environment
 
 ### Commands not found
 
@@ -176,7 +176,7 @@ Both `lib/scripts/` and `scripts/` (compat alias) resolve to the same directory.
 
 ### Need help?
 
-Run `/lean4:doctor` for full diagnostics.
+Run `/lean4:diagnose` for full diagnostics.
 
 ## V4.5.1 → V4.5.2
 

--- a/plugins/lean4/README.md
+++ b/plugins/lean4/README.md
@@ -22,7 +22,7 @@ Unified Lean 4 plugin for theorem proving, interactive learning, and formalizati
 | `/lean4:refactor` | Leverage mathlib, extract helpers, simplify proof strategies |
 | `/lean4:golf` | Improve Lean proofs for directness, clarity, performance, and brevity |
 | `/lean4:learn` | Interactive teaching and mathlib exploration |
-| `/lean4:doctor` | Diagnostics, cleanup, and migration help |
+| `/lean4:diagnose` | Diagnostics, cleanup, and migration help |
 
 ## Quick Start
 
@@ -38,7 +38,7 @@ Unified Lean 4 plugin for theorem proving, interactive learning, and formalizati
 /lean4:refactor            # Simplify proof strategies
 /lean4:golf                # Optimize proofs
 /lean4:learn               # Explore repo or mathlib
-/lean4:doctor              # Diagnostics and migration help
+/lean4:diagnose              # Diagnostics and migration help
 git push                   # Manual, after review
 ```
 
@@ -180,7 +180,7 @@ Usually run after proving, either prompted at the end of a `prove` session or ex
 
 Two modes: `--mode=repo` explores your project structure, `--mode=mathlib` navigates mathlib for a topic. Adapts to `--level=beginner|intermediate|expert` and supports `--style=tour|socratic|exercise|game`. Conversational by default; use `--output=scratch` or `--output=file` to write artifacts. For formalization, learn suggests `/lean4:formalize`.
 
-### `/lean4:doctor` — Diagnostics
+### `/lean4:diagnose` — Diagnostics
 
 Checks your environment (lean, lake, python, git), plugin structure, project health, and detects legacy v3 artifacts. Run this first if something isn't working.
 
@@ -344,7 +344,7 @@ command -v lean4-skills-sorry-analyzer       # wrapper resolves on PATH
 lean4-skills-sorry-analyzer . --format=summary --report-only
 ```
 
-If `$LEAN4_SCRIPTS` is unset, run `/lean4:doctor` to reinitialize.
+If `$LEAN4_SCRIPTS` is unset, run `/lean4:diagnose` to reinitialize.
 
 ## File Structure
 

--- a/plugins/lean4/commands/diagnose.md
+++ b/plugins/lean4/commands/diagnose.md
@@ -1,22 +1,22 @@
 ---
-name: doctor
+name: diagnose
 description: Diagnostics, cleanup, and migration help
 user_invocable: true
 ---
 
-# Lean4 Doctor
+# Lean4 Diagnostics
 
 Diagnostics, troubleshooting, and migration assistance for the Lean4 plugin.
 
 ## Usage
 
 ```
-/lean4:doctor                    # Full diagnostic (plugin + workspace)
-/lean4:doctor env                # Environment only
-/lean4:doctor migrate            # Detect legacy installs (read-only)
-/lean4:doctor migrate --global   # Include user-level ~/.claude scan
-/lean4:doctor cleanup            # Show stale files + removal commands
-/lean4:doctor cleanup --apply    # Actually remove stale files
+/lean4:diagnose                    # Full diagnostic (plugin + workspace)
+/lean4:diagnose env                # Environment only
+/lean4:diagnose migrate            # Detect legacy installs (read-only)
+/lean4:diagnose migrate --global   # Include user-level ~/.claude scan
+/lean4:diagnose cleanup            # Show stale files + removal commands
+/lean4:diagnose cleanup --apply    # Actually remove stale files
 ```
 
 ## Inputs
@@ -42,7 +42,7 @@ Diagnostics, troubleshooting, and migration assistance for the Lean4 plugin.
 Environment variables: `LEAN4_PLUGIN_ROOT`, `LEAN4_SCRIPTS`, `LEAN4_REFS`, `LEAN4_PYTHON_BIN`
 
 Run the shared env preflight for a live diagnosis. Resolve it **without
-depending on PATH** — `doctor env` is exactly where a broken PATH must
+depending on PATH** — `diagnose env` is exactly where a broken PATH must
 still be diagnosable, so a bare `lean4-skills-preflight` alone could fail
 command-not-found:
 
@@ -54,7 +54,7 @@ elif [[ -n "${LEAN4_PLUGIN_ROOT:-}" && -x "$LEAN4_PLUGIN_ROOT/bin/lean4-skills-p
 else
     echo "Lean4 bootstrap environment is not fully set up in this Claude Code session." >&2
     echo "  Recovery:" >&2
-    echo "    1. Run /lean4:doctor env for a full diagnosis." >&2
+    echo "    1. Run /lean4:diagnose env for a full diagnosis." >&2
     echo "    2. Restart the Claude Code session (re-runs the SessionStart bootstrap hook)." >&2
     echo "    3. If it persists, check the plugin hook/bootstrap state (hooks.json, bootstrap.sh)." >&2
 fi
@@ -162,7 +162,7 @@ Keys: y=remove this, n=keep this, a=remove all remaining, q=quit now
 
 **Full diagnostic:**
 ```markdown
-## Lean4 Doctor Report
+## Lean4 Diagnostics Report
 
 ### Environment
 ✓ lean 4.x.x
@@ -196,7 +196,7 @@ Keys: y=remove this, n=keep this, a=remove all remaining, q=quit now
 ✓ LEAN4_PLUGIN_ROOT points to current plugin
 
 ### Summary
-Found 1 stale item. Run `/lean4:doctor cleanup` to see removal commands.
+Found 1 stale item. Run `/lean4:diagnose cleanup` to see removal commands.
 ```
 
 **Cleanup report:**
@@ -211,15 +211,15 @@ Found 1 stale item. Run `/lean4:doctor cleanup` to see removal commands.
 rm -rf .claude/tools/lean4/
 rm -rf .claude/docs/lean4/
 
-No changes made. Run `/lean4:doctor cleanup --apply` to remove.
+No changes made. Run `/lean4:diagnose cleanup --apply` to remove.
 ```
 
 ## Troubleshooting
 
 | Issue | Fix |
 |-------|-----|
-| LEAN4_SCRIPTS not set | 1. Run `/lean4:doctor env` for a full diagnosis. 2. Restart the Claude Code session (re-runs the SessionStart bootstrap hook). 3. If it persists, check the plugin hook/bootstrap state (hooks.json, bootstrap.sh). |
-| `lean4-skills-*` wrapper not found on PATH | 1. Run `/lean4:doctor env` for a full diagnosis. 2. Restart the Claude Code session (re-runs the SessionStart bootstrap hook). 3. If it persists, check the plugin hook/bootstrap state (hooks.json, bootstrap.sh). |
+| LEAN4_SCRIPTS not set | 1. Run `/lean4:diagnose env` for a full diagnosis. 2. Restart the Claude Code session (re-runs the SessionStart bootstrap hook). 3. If it persists, check the plugin hook/bootstrap state (hooks.json, bootstrap.sh). |
+| `lean4-skills-*` wrapper not found on PATH | 1. Run `/lean4:diagnose env` for a full diagnosis. 2. Restart the Claude Code session (re-runs the SessionStart bootstrap hook). 3. If it persists, check the plugin hook/bootstrap state (hooks.json, bootstrap.sh). |
 | lake not found | Install via elan |
 | Scripts not executable | Wrappers should be shipped executable — check `command -v lean4-skills-sorry-analyzer`. For unwrapped internals: `chmod +x $LEAN4_SCRIPTS/*.sh $LEAN4_SCRIPTS/*.py` |
 | Build fails | `lake update && lake clean && lake build` |
@@ -244,4 +244,4 @@ No changes made. Run `/lean4:doctor cleanup --apply` to remove.
 
 - `/lean4:prove` - Guided cycle-by-cycle proving
 - `/lean4:checkpoint` - Save progress
-- [Examples](../skills/lean4/references/command-examples.md#doctor)
+- [Examples](../skills/lean4/references/command-examples.md#diagnose)

--- a/plugins/lean4/hooks/bootstrap.sh
+++ b/plugins/lean4/hooks/bootstrap.sh
@@ -64,7 +64,7 @@ warn_degraded_and_exit() {
     echo "Lean4 bootstrap environment is not fully set up in this Claude Code session."
     echo "  Problem: ${problem}"
     echo "  Recovery:"
-    echo "    1. Run /lean4:doctor env for a full diagnosis."
+    echo "    1. Run /lean4:diagnose env for a full diagnosis."
     echo "    2. Restart the Claude Code session (re-runs the SessionStart bootstrap hook)."
     echo "    3. If it persists, check the plugin hook/bootstrap state (hooks.json, bootstrap.sh)."
   } >&2

--- a/plugins/lean4/lib/scripts/preflight_env.sh
+++ b/plugins/lean4/lib/scripts/preflight_env.sh
@@ -11,16 +11,16 @@
 #   --runtime     (default) Validate the SESSION state a later Bash tool call
 #                 depends on: LEAN4_* vars point at real dirs, bin/ is on
 #                 PATH, and the lean4-skills-* wrappers resolve. Used for
-#                 on-demand diagnosis (e.g. /lean4:doctor env, or manual run
+#                 on-demand diagnosis (e.g. /lean4:diagnose env, or manual run
 #                 via the lean4-skills-preflight wrapper).
 #
 # Exit 0 when the checked mode passes; exit 2 with the canonical recovery
 # block on stderr when it fails. Self-locating (BASH_SOURCE) so it never
 # depends on $LEAN4_SCRIPTS being set.
 #
-# The three numbered recovery steps below are CANONICAL: doctor.md
-# reproduces them byte-for-byte. If you change them here, update doctor.md
-# (test_preflight_env.sh asserts doctor.md still contains each line).
+# The three numbered recovery steps below are CANONICAL: diagnose.md
+# reproduces them byte-for-byte. If you change them here, update diagnose.md
+# (test_preflight_env.sh asserts diagnose.md still contains each line).
 
 set -euo pipefail
 
@@ -33,7 +33,7 @@ emit_recovery() {
         echo "Lean4 bootstrap environment is not fully set up in this Claude Code session."
         echo "  Problem: ${problem}"
         echo "  Recovery:"
-        echo "    1. Run /lean4:doctor env for a full diagnosis."
+        echo "    1. Run /lean4:diagnose env for a full diagnosis."
         echo "    2. Restart the Claude Code session (re-runs the SessionStart bootstrap hook)."
         echo "    3. If it persists, check the plugin hook/bootstrap state (hooks.json, bootstrap.sh)."
     } >&2

--- a/plugins/lean4/skills/lean4/SKILL.md
+++ b/plugins/lean4/skills/lean4/SKILL.md
@@ -36,7 +36,7 @@ Use this skill whenever you're editing Lean 4 proofs, debugging Lean builds, for
 | `/lean4:refactor` | Leverage mathlib, extract helpers, simplify proof strategies |
 | `/lean4:golf` | Improve Lean proofs for directness, clarity, performance, and brevity |
 | `/lean4:learn` | Interactive teaching and mathlib exploration |
-| `/lean4:doctor` | Diagnostics, cleanup, and migration help |
+| `/lean4:diagnose` | Diagnostics, cleanup, and migration help |
 
 This plugin ships a host-agnostic parser (`lib/command_args/`) that covers the
 parser-decidable startup rules of the seven parameter-heavy commands (`draft`,
@@ -44,7 +44,7 @@ parser-decidable startup rules of the seven parameter-heavy commands (`draft`,
 documented startup rules in these commands depend on runtime context (repo-
 level search, interactive prompting) and are applied by the command after
 reading the parser's output. The other commands (`checkpoint`, `review`,
-`refactor`, `golf`, `doctor`) remain model-parsed.
+`refactor`, `golf`, `diagnose`) remain model-parsed.
 When a host adapter installs the `UserPromptSubmit` hook, the parser runs
 before the model sees a `/lean4:*` prompt matching one of the seven covered
 commands, injects a `validated-invocation` block into context, and rejects
@@ -71,7 +71,7 @@ best-effort.
 | Optimizing compiled proofs | `/lean4:golf` |
 | New to this project / exploring | `/lean4:learn --mode=repo` |
 | Navigating mathlib for a topic | `/lean4:learn --mode=mathlib` |
-| Something not working | `/lean4:doctor` |
+| Something not working | `/lean4:diagnose` |
 | Formalize + prove end-to-end (unattended) | `/lean4:autoformalize --source=... --claim-select=first --out=...` |
 
 ## Contributing (lean4-contribute plugin)
@@ -125,7 +125,7 @@ Use `/lean4:learn` at any point to explore repo structure or navigate mathlib. T
 - `/lean4:autoformalize` wraps draft+autoprove in a single command (source → claims → skeletons → proofs); replaces `autoprove --formalize=auto`
 - Proof engines (`prove`/`autoprove`) never modify declaration headers (header fence)
 - `/lean4:disprove` reports `REFUTED` only when Lean typechecks the negation; otherwise `WITNESS_UNCERTIFIED` or `INCONCLUSIVE`
-- If you hit environment issues, run `/lean4:doctor` to diagnose
+- If you hit environment issues, run `/lean4:diagnose` to diagnose
 
 ## LSP Tools (Preferred)
 
@@ -151,9 +151,9 @@ lean_code_actions(file, line)                   # Resolve "Try this" suggestions
 
 | Capability | Required | Check | Fallback |
 |-----------|----------|-------|----------|
-| Lean / Lake | yes | `lean --version`, `lake --version` | none — run `/lean4:doctor` |
+| Lean / Lake | yes | `lean --version`, `lake --version` | none — run `/lean4:diagnose` |
 | Python 3 | yes (scripts) | `$LEAN4_PYTHON_BIN` set by bootstrap | none for script-dependent operations |
-| `$LEAN4_SCRIPTS` | yes (set by bootstrap) | `echo "$LEAN4_SCRIPTS"` | run `/lean4:doctor` |
+| `$LEAN4_SCRIPTS` | yes (set by bootstrap) | `echo "$LEAN4_SCRIPTS"` | run `/lean4:diagnose` |
 | Lean LSP MCP | no | try `lean_goal` on any `.lean` file | scripts + `lake env lean` (file-level only) |
 | `lean_run_code` | no | try calling it | `lake env lean` on temp file |
 | `lean_code_actions` | no | try calling it | manual "Try this" application |
@@ -247,7 +247,7 @@ Compatibility fallback (when a wrapper is unavailable):
   env-var form: `bash "$LEAN4_SCRIPTS/script.sh" …` or
   `${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/script.py" …`.
 
-If `$LEAN4_SCRIPTS` is unset or missing, run `/lean4:doctor` and stay
+If `$LEAN4_SCRIPTS` is unset or missing, run `/lean4:diagnose` and stay
 LSP-only until resolved.
 
 ## Automation
@@ -320,7 +320,7 @@ Note: `exact?`/`apply?` query mathlib (slow). `grind` and `aesop` are powerful b
 
 ## Troubleshooting
 
-If LSP tools aren't responding, check your operating profile above. In `scripts_only` mode, `$LEAN4_SCRIPTS` provides search and `lake env lean` provides file-level compilation feedback, but live goal inspection, tactic testing, and line-level diagnostics are unavailable. If environment variables (`LEAN4_SCRIPTS`, `LEAN4_REFS`) are missing, run `/lean4:doctor` to diagnose.
+If LSP tools aren't responding, check your operating profile above. In `scripts_only` mode, `$LEAN4_SCRIPTS` provides search and `lake env lean` provides file-level compilation feedback, but live goal inspection, tactic testing, and line-level diagnostics are unavailable. If environment variables (`LEAN4_SCRIPTS`, `LEAN4_REFS`) are missing, run `/lean4:diagnose` to diagnose.
 
 **Script environment check:**
 ```bash

--- a/plugins/lean4/skills/lean4/references/command-examples.md
+++ b/plugins/lean4/skills/lean4/references/command-examples.md
@@ -1656,25 +1656,25 @@ Want to see this formalized in Lean to make it concrete?
 
 ---
 
-## doctor
+## diagnose
 
 ### Basic Usage
 
 ```
-/lean4:doctor              # Full diagnostic
-/lean4:doctor env          # Environment only
-/lean4:doctor migrate      # Migration assistance
-/lean4:doctor cleanup      # Remove obsolete files
+/lean4:diagnose              # Full diagnostic
+/lean4:diagnose env          # Environment only
+/lean4:diagnose migrate      # Migration assistance
+/lean4:diagnose cleanup      # Remove obsolete files
 ```
 
 ### Full Diagnostic Example
 
 ```
-User: /lean4:doctor
+User: /lean4:diagnose
 
 Claude: Running diagnostics...
 
-## Lean4 Doctor Report
+## Lean4 Diagnostics Report
 
 ### Environment
 ✓ lean 4.15.0
@@ -1710,7 +1710,7 @@ Run /lean4:prove to fill the 3 remaining sorries.
 ### Migration Example
 
 ```
-User: /lean4:doctor migrate
+User: /lean4:diagnose migrate
 
 Claude: Checking for v3 artifacts...
 
@@ -1738,7 +1738,7 @@ Proceed with migration? (yes/no)
 ### Cleanup Example
 
 ```
-User: /lean4:doctor cleanup
+User: /lean4:diagnose cleanup
 
 Claude: Scanning for obsolete files...
 

--- a/plugins/lean4/skills/lean4/references/command-invocation.md
+++ b/plugins/lean4/skills/lean4/references/command-invocation.md
@@ -10,7 +10,7 @@ in these commands depend on runtime context the parser cannot evaluate (e.g.
 local-declaration resolution in learn); those are listed in the forward-
 exclusions and are applied by the command at runtime after reading the parser's
 output. Other commands in this plugin (`checkpoint`, `review`, `refactor`,
-`golf`, `doctor`) are not parameter-heavy and are not covered by
+`golf`, `diagnose`) are not parameter-heavy and are not covered by
 `lib/command_args/`; they remain model-parsed on every host.
 
 For the seven covered commands, whether the parser actually runs before the

--- a/plugins/lean4/skills/lean4/references/subagent-workflows.md
+++ b/plugins/lean4/skills/lean4/references/subagent-workflows.md
@@ -542,7 +542,7 @@ The lean4 plugin provides these main commands:
 | `/lean4:refactor` | Strategy-level proof simplification |
 | `/lean4:golf` | Optimize proofs |
 | `/lean4:learn` | Interactive teaching and mathlib exploration |
-| `/lean4:doctor` | Diagnostics and migration |
+| `/lean4:diagnose` | Diagnostics and migration |
 
 **Note:** Individual operations like "search mathlib" or "analyze sorries" are now internal workflows within `/lean4:prove` (or `/lean4:autoprove`) rather than separate commands. This simplifies the UX while preserving all functionality.
 

--- a/plugins/lean4/tests/test_bootstrap_env.sh
+++ b/plugins/lean4/tests/test_bootstrap_env.sh
@@ -84,7 +84,7 @@ fi
 run_bootstrap "$PLUGIN_ROOT" ""
 if [[ "$BS_EXIT" -eq 0 ]] \
    && ! grep -qF "Lean4 v4 ready" <<<"$BS_OUT" \
-   && grep -qF "Run /lean4:doctor env for a full diagnosis." <<<"$BS_OUT"; then
+   && grep -qF "Run /lean4:diagnose env for a full diagnosis." <<<"$BS_OUT"; then
     pass "degraded: CLAUDE_ENV_FILE unset → no 'ready', canonical block, exit 0"
 else
     fail "degraded CLAUDE_ENV_FILE unset (exit=$BS_EXIT)"
@@ -152,7 +152,7 @@ mkdir -p "$nohelper/lib/scripts" "$nohelper/skills/lean4/references" "$nohelper/
 run_bootstrap "$nohelper" "$SCRATCH/nohelper_env"
 if [[ "$BS_EXIT" -eq 0 ]] \
    && ! grep -qF "Lean4 v4 ready" <<<"$BS_OUT" \
-   && grep -qF "Run /lean4:doctor env for a full diagnosis." <<<"$BS_OUT"; then
+   && grep -qF "Run /lean4:diagnose env for a full diagnosis." <<<"$BS_OUT"; then
     pass "missing preflight helper → canonical block, exit 0"
 else
     fail "missing preflight helper (exit=$BS_EXIT): $BS_OUT"
@@ -168,7 +168,7 @@ ln -s /dev/null "$SCRATCH/devnull_link"
 run_bootstrap "$PLUGIN_ROOT" "$SCRATCH/devnull_link"
 if [[ "$BS_EXIT" -eq 0 ]] \
    && ! grep -qF "Lean4 v4 ready" <<<"$BS_OUT" \
-   && grep -qF "Run /lean4:doctor env for a full diagnosis." <<<"$BS_OUT"; then
+   && grep -qF "Run /lean4:diagnose env for a full diagnosis." <<<"$BS_OUT"; then
     pass "degraded: CLAUDE_ENV_FILE → /dev/null symlink → canonical warning, exit 0"
 else
     fail "degraded CLAUDE_ENV_FILE → /dev/null symlink (exit=$BS_EXIT): $BS_OUT"

--- a/plugins/lean4/tests/test_preflight_env.sh
+++ b/plugins/lean4/tests/test_preflight_env.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Regression tests for lib/scripts/preflight_env.sh (#108).
-# Exercises --runtime and --bootstrap modes, and guards that doctor.md
+# Exercises --runtime and --bootstrap modes, and guards that diagnose.md
 # still carries the three canonical recovery lines byte-for-byte (the
 # helper is the single source of that wording).
 #
@@ -18,14 +18,14 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PREFLIGHT="$PLUGIN_ROOT/lib/scripts/preflight_env.sh"
-DOCTOR="$PLUGIN_ROOT/commands/doctor.md"
+DIAGNOSE="$PLUGIN_ROOT/commands/diagnose.md"
 
 PASS=0
 FAIL=0
 
 # Canonical recovery lines — MUST match preflight_env.sh's emit_recovery
-# and doctor.md's inline fallback exactly.
-CANON1="1. Run /lean4:doctor env for a full diagnosis."
+# and diagnose.md's inline fallback exactly.
+CANON1="1. Run /lean4:diagnose env for a full diagnosis."
 CANON2="2. Restart the Claude Code session (re-runs the SessionStart bootstrap hook)."
 CANON3="3. If it persists, check the plugin hook/bootstrap state (hooks.json, bootstrap.sh)."
 
@@ -98,15 +98,15 @@ fi
 rm -rf "$tmp" "$baddir"
 
 # ---------------------------------------------------------------------------
-# Wording agreement: doctor.md must contain the three canonical lines.
-# Substring (grep -F) not whole-block diff — doctor wraps them in a code
+# Wording agreement: diagnose.md must contain the three canonical lines.
+# Substring (grep -F) not whole-block diff — diagnose wraps them in a code
 # block; only the exact recovery lines need to match.
 # ---------------------------------------------------------------------------
 for canon in "$CANON1" "$CANON2" "$CANON3"; do
-    if grep -qF "$canon" "$DOCTOR"; then
-        pass "doctor.md contains canonical line: ${canon%% *}…"
+    if grep -qF "$canon" "$DIAGNOSE"; then
+        pass "diagnose.md contains canonical line: ${canon%% *}…"
     else
-        fail "doctor.md MISSING canonical line: $canon"
+        fail "diagnose.md MISSING canonical line: $canon"
     fi
 done
 

--- a/plugins/lean4/tests/test_validate_user_prompt.sh
+++ b/plugins/lean4/tests/test_validate_user_prompt.sh
@@ -171,8 +171,8 @@ run_test_empty \
   '{"prompt":"/lean4: foo"}'
 
 run_test_empty \
-  "9. Uncovered command (doctor)" \
-  '{"prompt":"/lean4:doctor"}'
+  "9. Uncovered command (diagnose)" \
+  '{"prompt":"/lean4:diagnose"}'
 
 run_test_empty \
   "10. Uncovered command (checkpoint)" \

--- a/plugins/lean4/tools/lint_docs.sh
+++ b/plugins/lean4/tools/lint_docs.sh
@@ -19,7 +19,7 @@ PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ISSUES=0
 
 # Single source of truth for known commands (used by check_commands and check_cross_refs)
-KNOWN_COMMANDS="autoformalize autoprove checkpoint disprove doctor draft formalize golf learn prove refactor review"
+KNOWN_COMMANDS="autoformalize autoprove checkpoint diagnose disprove draft formalize golf learn prove refactor review"
 
 log() {
     echo "$1"
@@ -34,7 +34,7 @@ ok() {
     echo "✓ $1"
 }
 
-# Check 1: Commands in doctor.md match actual command files
+# Check 1: Commands in diagnose.md match actual command files
 check_commands() {
     log ""
     log "Checking commands..."
@@ -66,8 +66,8 @@ check_commands() {
             autoformalize) max_lines=180 ;;
             autoprove)  max_lines=290 ;;
             checkpoint) max_lines=90 ;;
+            diagnose)   max_lines=265 ;;
             disprove)   max_lines=300 ;;
-            doctor)     max_lines=265 ;;
             draft)      max_lines=160 ;;
             formalize)  max_lines=195 ;;
             golf)       max_lines=170 ;;
@@ -484,7 +484,7 @@ check_bare_scripts() {
 # only — locks in the always-loaded surface so future edits can't
 # strip the rule out and re-introduce the parse-error footgun.
 # NOT a Lean parse test; not CI-enforced (lint_docs.sh runs
-# locally / via /lean4:doctor).
+# locally / via /lean4:diagnose).
 check_skill_omit_rule() {
     log ""
     log "Checking SKILL.md teaches omit [Inst] in ordering rule..."
@@ -602,7 +602,7 @@ check_python_script_interpreters() {
 # usages exist in references). For new `fun ... =>` introductions
 # in unrelated files, rely on review.
 #
-# Guard strength is local/doctor only, same as Check 8a from #136.
+# Guard strength is local/diagnose only, same as Check 8a from #136.
 # Unlike Checks 8c/8e, this invariant has no dedicated CI self-test;
 # test_lint_docs.sh (added in #138) invokes lint_docs.sh incidentally
 # in CI, but it only asserts the Check 8c/8e fixture behavior.
@@ -1236,8 +1236,8 @@ check_stale_plugin_paths() {
     while IFS= read -r file; do
         _sp_base=$(basename "$file")
 
-        # Skip MIGRATION.md (historical mentions OK) and doctor.md (detects old plugins)
-        if [[ "$_sp_base" == "MIGRATION.md" ]] || [[ "$_sp_base" == "doctor.md" ]]; then
+        # Skip MIGRATION.md (historical mentions OK) and diagnose.md (detects old plugins)
+        if [[ "$_sp_base" == "MIGRATION.md" ]] || [[ "$_sp_base" == "diagnose.md" ]]; then
             continue
         fi
 
@@ -1497,7 +1497,7 @@ check_description_alignment() {
 # Check 25: Host-agnostic language in core surfaces
 # SKILL.md and commands are loaded into any host's context, so they must not
 # reference "Claude" by name.  Allowed exceptions:
-#   - doctor.md (contains .claude/ paths and `claude mcp` product commands)
+#   - diagnose.md (contains .claude/ paths and `claude mcp` product commands)
 #   - .claude-plugin/ path fragments (directory name, not prose)
 check_host_agnostic() {
     log ""
@@ -1515,11 +1515,11 @@ check_host_agnostic() {
         fi
     fi
 
-    # Command files (skip doctor.md — it has legitimate .claude/ paths)
+    # Command files (skip diagnose.md — it has legitimate .claude/ paths)
     while IFS= read -r file; do
         local _ha_base
         _ha_base=$(basename "$file")
-        [[ "$_ha_base" == "doctor.md" ]] && continue
+        [[ "$_ha_base" == "diagnose.md" ]] && continue
         if grep -inE 'claude' "$file" | grep -ivE '\.claude[-/]' | grep -q .; then
             warn "$_ha_base mentions 'Claude' — commands must be host-agnostic"
             _ha_fail=1


### PR DESCRIPTION
## What

Renames the `/lean4:doctor` command to `/lean4:diagnose`.

## Why

`doctor` collides with Claude Code's built-in `/doctor` command. Renaming the
plugin diagnostic to `/lean4:diagnose` removes the ambiguity while keeping the
command's behavior and all subcommands (`env`, `migrate`, `cleanup`) identical.

## Changes

- `commands/doctor.md` → `commands/diagnose.md` (frontmatter `name: diagnose`,
  git-tracked as a rename). Subcommands unchanged: `/lean4:diagnose env|migrate|cleanup`.
- **Canonical recovery wording** (single-sourced): `lib/scripts/preflight_env.sh`
  `emit_recovery` and its byte-identical copy in `hooks/bootstrap.sh` now emit
  `Run /lean4:diagnose env for a full diagnosis.` `diagnose.md` reproduces the
  three canonical lines; `test_preflight_env.sh` / `test_bootstrap_env.sh` assert
  the new wording.
- **`tools/lint_docs.sh`**: `KNOWN_COMMANDS`, the per-command `max_lines` table,
  and both `diagnose.md` special-cases (stale-plugin-path skip, host-agnostic skip).
- **Docs**: root `README.md`, `INSTALLATION.md`, `MIGRATION.md`,
  `plugins/lean4/README.md`, `SKILL.md`, and the `command-examples.md` /
  `command-invocation.md` / `subagent-workflows.md` references.
- **Manifests**: `plugin.json` and `marketplace.json` descriptions list `diagnose`;
  version bumped `4.5.4` → `4.6.0`.
- **Tests**: `test_validate_user_prompt.sh` uncovered-command case.
- Historical CHANGELOG entries keep the old `doctor` name (accurate for the
  releases they describe); a new `v4.6.0` entry documents the rename.

## Breaking change

`/lean4:doctor` no longer exists — use `/lean4:diagnose`. Muscle-memory, scripts,
or docs invoking `/lean4:doctor` must switch.

## Testing

All local suites pass under macOS Bash 3.2 (`/bin/bash`):

- `test_preflight_env.sh` 10/0, `test_bootstrap_env.sh` 11/0,
  `test_validate_user_prompt.sh` 33/0, `test_guardrails.sh` 327/0,
  `test_contracts.sh` 30/0, `test_lint_docs.sh` 4/0.
- `lint_docs.sh` is **lint-neutral**: identical 117 pre-existing warnings before
  and after (the three `doctor.md` anchor warnings simply became `diagnose.md`).

The changed shell files (`bootstrap.sh`, `preflight_env.sh`, `lint_docs.sh`) touch
only comments and `echo` string content — no logic — so shellcheck is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
