### PR TITLE
feat(codex): add native in-place plugin adapter (v4.5.10)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "lean4-skills",
+  "interface": {
+    "displayName": "Lean 4 Skills"
+  },
+  "plugins": [
+    {
+      "name": "lean4",
+      "source": {
+        "source": "local",
+        "path": "./plugins/lean4"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Lean 4 theorem proving with guided + autonomous proving, LSP-first workflows, guardrails, and contribution helpers",
-    "version": "4.5.5"
+    "version": "4.5.6"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Lean 4 theorem proving with guided + autonomous proving, LSP-first workflows, guardrails, and contribution helpers",
-    "version": "4.5.9"
+    "version": "4.5.10"
   },
   "plugins": [
     {

--- a/.github/workflows/bash3-compat.yml
+++ b/.github/workflows/bash3-compat.yml
@@ -57,5 +57,8 @@ jobs:
       - name: Self-test — validate_user_prompt hook
         run: /bin/bash plugins/lean4/tests/test_validate_user_prompt.sh
 
+      - name: Self-test — native Codex plugin adapter
+        run: /bin/bash plugins/lean4/tests/test_codex_adapter.sh
+
       - name: Runtime smoke — cycle_tracker.sh under /bin/bash
         run: /bin/bash plugins/lean4/tests/test_bash3_smoke.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,6 +52,9 @@ jobs:
           python3 plugins/lean4/lib/scripts/tests/test_ordering.py
           python3 plugins/lean4/lib/scripts/tests/test_sorry_analyzer.py
 
+      - name: Native Codex adapter contract (Python 3.10)
+        run: /bin/bash plugins/lean4/tests/test_codex_adapter.sh
+
   mypy:
     runs-on: ubuntu-latest
     steps:
@@ -122,4 +125,5 @@ jobs:
             plugins/lean4/hooks/*.sh \
             plugins/lean4/lib/scripts/*.sh \
             plugins/lean4/tools/*.sh \
+            plugins/lean4/tests/test_codex_adapter.sh \
             plugins/lean4/bin/lean4-skills-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v4.5.6 (July 2026)
+
+Native in-place Codex plugin packaging and host adapter (Closes #157; supersedes #89). The canonical `plugins/lean4` tree is installed directly — no mirrored package or generated Codex-specific skills.
+
+### Native Codex plugin
+
+- Adds `.codex-plugin/plugin.json`, a thin `.agents/plugins/marketplace.json` exposing only `lean4`, and a manifest-selected `hooks/codex-hooks.json` for SessionStart, UserPromptSubmit, and advisory Bash PreToolUse handling.
+- SessionStart covers `startup`, `resume`, `clear`, and `compact`. It injects the installed root and absolute wrapper paths as context; it does not claim persistent `LEAN4_*` variables or PATH mutation, which Codex does not document.
+- Shared bootstrap, preflight, doctor, and prompt validation are host-aware. Claude Code keeps its existing `CLAUDE_ENV_FILE` persistence contract; native Codex uses `lean4-skills-preflight --codex` and literal absolute wrapper paths.
+- Codex hooks require explicit first-run review in `/hooks`. Until trusted, the core skill remains discoverable but plugin bootstrap and guardrail behavior are unavailable. PreToolUse interception is advisory, not a security boundary.
+
+### Validation and release hygiene
+
+- New Bash 3.2-compatible adapter tests cover metadata, lifecycle matching, truthful bootstrap context, absolute-path preflight, Codex-shaped UserPromptSubmit payloads, and PreToolUse exit-2 blocking.
+- Release-metadata Check 23 now parses and validates both Claude and Codex manifests/marketplaces and fails on Codex version drift.
+- Codex Tier-3 installation, trust, verification, update, and fallback behavior are documented without claiming `/lean4:*` slash-command parity.
+
 ## v4.5.5 (July 2026)
 
 Native Agent Skills metadata and multi-host installation docs (Refs #153). Every major host (Codex, Cursor, Windsurf, OpenCode, Gemini CLI / Antigravity CLI, GitHub Copilot) now discovers Agent Skills natively from `.agents/skills`, so the old per-host adapter instructions (`AGENTS.md`, `GEMINI.md`, `.cursor/rules`, oh-my-opencode) were stale. No runtime changes.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -13,17 +13,18 @@ Three install shapes, referenced throughout this guide:
   the instructions and references: the skill's LSP-first workflows
   operate when your host separately provides Lean LSP tools (see
   [Lean LSP MCP Server](#lean-lsp-mcp-server-all-hosts)); script-backed
-  steps need Tier 2.
+  steps need Tier 2 or Tier 3.
 - **Tier 2 — Portable checkout + helper runtime.** One cloned checkout,
   an `.agents/skills` symlink for native discovery, and one environment
   block. Adds the helper runtime (wrappers on PATH, `$LEAN4_SCRIPTS`) to
   the core skill. Does not recreate host-specific commands, hooks, or
   subagent definitions. See
   [Portable Checkout + Helper Runtime](#portable-checkout--helper-runtime-all-hosts).
-- **Tier 3 — Native plugin.** The complete experience — commands, hooks,
-  guardrails, subagents. Claude Code today (next section); a native
-  Codex plugin is tracked in
-  [#153](https://github.com/cameronfreer/lean4-skills/issues/153).
+- **Tier 3 — Native plugin.** Host-native discovery plus the bundled helper
+  runtime and hooks. Claude Code registers `/lean4:*` commands and subagents;
+  Codex discovers `$lean4`, injects absolute helper paths through trusted
+  SessionStart context, and registers advisory hooks. Host command surfaces
+  are not assumed to be identical.
 
 ## Claude Code (Native Plugin)
 
@@ -96,7 +97,9 @@ chmod +x $LEAN4_SCRIPTS/*.sh $LEAN4_SCRIPTS/*.py
 
 ## Portable Checkout + Helper Runtime (All Hosts)
 
-The recommended full setup (Tier 2) for every host except Claude Code.
+The portable full-runtime fallback for hosts without a native plugin, or for
+users who prefer an explicit checkout. Claude Code and Codex have Tier-3
+native plugins; the remaining hosts use this Tier-2 path.
 Codex, Cursor, Windsurf, OpenCode, GitHub Copilot, and Gemini CLI all
 discover Agent Skills from `~/.agents/skills` (and its project-level
 `.agents/skills` counterpart); Codex documents symlink support — for a
@@ -204,20 +207,86 @@ Then remove the environment block from your shell profile.
 
 ## OpenAI Codex CLI
 
-**Quick install (Tier 1 — core skill only).** Run this in Codex chat,
-not in your shell:
+### Native plugin (Tier 3 — recommended)
+
+Add the Git marketplace and install the in-place `lean4` plugin:
+
+```bash
+codex plugin marketplace add cameronfreer/lean4-skills --ref main
+codex plugin add lean4@lean4-skills
+```
+
+The marketplace contains a Codex adapter pointing directly at
+`plugins/lean4`; it does not install a mirrored package tree and does not
+include `lean4-contribute`.
+
+#### First-run hook trust
+
+Codex does not automatically trust installed plugin hooks. Before trust:
+
+- `$lean4` remains discoverable as a core skill.
+- SessionStart does not inject helper paths.
+- UserPromptSubmit validation and Bash PreToolUse guardrails are skipped.
+
+Open `/hooks`, review the exact installed `lean4` hook commands, and trust the
+hook hash. Then start a new Codex task so SessionStart runs again. Trusted
+SessionStart supplies the installed `plugin_root`, `bin_dir`, `scripts_dir`,
+`refs_dir`, and absolute preflight path as context. These are not persistent
+shell variables: invoke helpers with literal paths such as
+`/installed/plugin/bin/lean4-skills-sorry-analyzer`, not as bare commands.
+
+The PreToolUse Bash hook is advisory. Codex interception does not cover every
+specialized or hosted execution path, so this hook is not a security or
+enforcement boundary. The plugin also does not register Claude Code's
+`/lean4:*` slash commands; invoke `$lean4` and ask for the named workflow.
+
+#### Verify
+
+```bash
+codex plugin list
+```
+
+In Codex:
+
+1. Type `$` and confirm `lean4` appears.
+2. Open `/hooks` and confirm the installed hook is trusted.
+3. Start a new task and inspect the SessionStart context.
+4. Run the literal absolute preflight path from that context:
+
+```bash
+/installed/plugin/bin/lean4-skills-preflight --codex
+```
+
+The preflight must succeed even when `LEAN4_*` are unset and the plugin's
+`bin/` directory is absent from PATH.
+
+#### Update or uninstall
+
+```bash
+codex plugin marketplace upgrade lean4-skills
+codex plugin add lean4@lean4-skills
+```
+
+Review the new hook hash after an update, then start a new task. To remove the
+plugin:
+
+```bash
+codex plugin remove lean4@lean4-skills
+```
+
+### Core skill only (Tier 1 fallback)
+
+Run this in Codex chat, not in your shell:
 
 ```text
 $skill-installer Install the `lean4` skill from
 https://github.com/cameronfreer/lean4-skills/tree/main/plugins/lean4/skills/lean4
 ```
 
-On your next turn, invoke it explicitly with `$lean4`, or let Codex
-activate it automatically for Lean 4 tasks. (If the skill does not
-appear, restart Codex.) This installs the core
-skill instructions, references, and metadata only — not the
-`lean4-skills-*` helper executables, plugin hooks, subagent
-definitions, or the Claude Code `/lean4:*` command surface.
+On your next turn, invoke it explicitly with `$lean4`, or let Codex activate
+it automatically for Lean 4 tasks. If it does not appear, restart Codex. This
+installs instructions, references, and metadata only — not helper executables,
+plugin hooks, subagent definitions, or a `/lean4:*` command surface.
 
 > `$skill-installer` manages its own install location under
 > `$CODEX_HOME/skills` (`~/.codex/skills` by default), while manual
@@ -225,7 +294,9 @@ definitions, or the Claude Code `/lean4:*` command surface.
 > prescribe the installer's destination — after installing, verify that
 > `$lean4` is discovered (type `$` or run `/skills`).
 
-**Full setup (Tier 2, recommended).** Use the
+### Portable checkout (Tier 2 fallback)
+
+Use the
 [Portable Checkout + Helper Runtime](#portable-checkout--helper-runtime-all-hosts)
 — Codex discovers `.agents/skills` in your project and home directory
 and follows symlinked skill directories.
@@ -236,7 +307,9 @@ and follows symlinked skill directories.
 > link can both appear. Remove the installer copy
 > (`rm -rf "${CODEX_HOME:-$HOME/.codex}/skills/lean4"`) when you switch.
 
-**Optional `AGENTS.md` pointer.** `AGENTS.md` is for durable project
+### Optional integrations
+
+**`AGENTS.md` pointer.** `AGENTS.md` is for durable project
 guidance, not installation. If your project uses one, a single line is
 enough:
 
@@ -249,16 +322,6 @@ for the exact command — e.g.:
 
 ```bash
 codex mcp add lean-lsp -- uvx lean-lsp-mcp
-```
-
-### Verify
-
-In Codex chat, type `$` — `lean4` should appear in the skill list. With
-the full setup, also:
-
-```bash
-command -v lean4-skills-sorry-analyzer
-lean4-skills-sorry-analyzer . --format=summary --report-only
 ```
 
 ## Gemini CLI
@@ -551,6 +614,7 @@ If you have the old 3-plugin system:
 ## Getting Help
 
 - **Plugin diagnostics (Claude Code):** `/lean4:doctor` — checks environment, plugin, and project
+- **Plugin diagnostics (Codex):** run the absolute `preflight` path from trusted SessionStart context with `--codex`; use `/hooks` if context is missing
 - **Issues:** https://github.com/cameronfreer/lean4-skills/issues
 - **LSP server:** https://github.com/oOo0oOo/lean-lsp-mcp/issues
 - **Claude Code:** `/help`

--- a/README.md
+++ b/README.md
@@ -67,17 +67,28 @@ Optionally, install the contribution helper to draft bug reports, feature reques
 
 ### Codex
 
-Quick install — run this in Codex chat, not in your shell:
+Native plugin install (Tier 3) — run in your shell:
+
+```bash
+codex plugin marketplace add cameronfreer/lean4-skills --ref main
+codex plugin add lean4@lean4-skills
+```
+
+Review the installed hook in `/hooks`, then start a new Codex task. Invoke the
+skill with `$lean4`; trusted SessionStart context supplies absolute helper
+paths without modifying your shell profile or PATH. The Bash PreToolUse hook
+is advisory, and Codex does not register the Claude `/lean4:*` commands.
+
+Core-skill-only fallback — run this in Codex chat, not in your shell:
 
 ```text
 $skill-installer Install the `lean4` skill from
 https://github.com/cameronfreer/lean4-skills/tree/main/plugins/lean4/skills/lean4
 ```
 
-Then invoke it with `$lean4`, or let Codex activate it automatically
-for Lean 4 tasks (if it does not appear, restart Codex). This installs the core skill only (instructions +
-references, no helper scripts) — see
-[INSTALLATION.md → Codex](INSTALLATION.md#openai-codex-cli) for the full setup.
+This fallback installs instructions and references without helper scripts or
+hooks. See [INSTALLATION.md → Codex](INSTALLATION.md#openai-codex-cli) for
+trust, verification, update, and portable-checkout details.
 
 ### Other Hosts
 
@@ -146,7 +157,8 @@ claude mcp add --transport stdio --scope project lean-lsp -- uvx lean-lsp-mcp
 | Host | Status | Workflow |
 |---|---|---|
 | Claude Code | Full native | SKILL.md + scripts + `/lean4:*` commands, hooks, guardrails, subagents |
-| Codex / Gemini / Antigravity / OpenCode / Copilot | Documented\* | Native Agent Skills discovery (+ scripts via portable checkout) |
+| Codex | Native plugin | SKILL.md + absolute-path helper runtime + trusted hooks; no `/lean4:*` command parity |
+| Gemini / Antigravity / OpenCode / Copilot | Documented\* | Native Agent Skills discovery (+ scripts via portable checkout) |
 | Cursor / Windsurf | Documented\* | Native Agent Skills discovery (+ scripts via portable checkout) |
 
 \*Documented setup patterns, not CI-verified.

--- a/plugins/lean4/.claude-plugin/plugin.json
+++ b/plugins/lean4/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lean4",
-  "version": "4.5.5",
+  "version": "4.5.6",
   "description": "Unified Lean 4 plugin (draft, formalize, autoformalize, prove, autoprove, disprove, checkpoint, review, refactor, golf, learn, doctor) — LSP-first, scripts fallback",
   "author": {"name": "Cameron Freer", "email": "cameronfreer@gmail.com"}
 }

--- a/plugins/lean4/.claude-plugin/plugin.json
+++ b/plugins/lean4/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lean4",
-  "version": "4.5.9",
+  "version": "4.5.10",
   "description": "Unified Lean 4 plugin (draft, formalize, autoformalize, prove, autoprove, disprove, checkpoint, review, refactor, golf, learn, doctor) — LSP-first, scripts fallback",
   "author": {"name": "Cameron Freer", "email": "cameronfreer@gmail.com"}
 }

--- a/plugins/lean4/.codex-plugin/plugin.json
+++ b/plugins/lean4/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "lean4",
+  "version": "4.5.6",
+  "description": "Unified Lean 4 plugin (draft, formalize, autoformalize, prove, autoprove, disprove, checkpoint, review, refactor, golf, learn, doctor) — LSP-first, scripts fallback",
+  "author": {
+    "name": "Cameron Freer",
+    "email": "cameronfreer@gmail.com",
+    "url": "https://github.com/cameronfreer"
+  },
+  "homepage": "https://github.com/cameronfreer/lean4-skills",
+  "repository": "https://github.com/cameronfreer/lean4-skills",
+  "license": "MIT",
+  "keywords": [
+    "lean4",
+    "mathlib",
+    "theorem-proving",
+    "formalization",
+    "codex"
+  ],
+  "skills": "./skills",
+  "hooks": "./hooks/codex-hooks.json",
+  "interface": {
+    "displayName": "Lean 4 Skills",
+    "shortDescription": "Structured Lean 4 proving workflows for Codex.",
+    "longDescription": "Lean 4 and mathlib workflows for drafting, proving, refuting, reviewing, refactoring, golfing, and diagnosing formalizations.",
+    "developerName": "Cameron Freer",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read",
+      "Write",
+      "Shell"
+    ],
+    "websiteURL": "https://github.com/cameronfreer/lean4-skills",
+    "defaultPrompt": [
+      "Use $lean4 to prove this theorem with explicit validation.",
+      "Use $lean4 to review this Lean proof and suggest refactors.",
+      "Use $lean4 to diagnose these Lean build errors."
+    ]
+  }
+}

--- a/plugins/lean4/.codex-plugin/plugin.json
+++ b/plugins/lean4/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lean4",
-  "version": "4.5.9",
+  "version": "4.5.10",
   "description": "Unified Lean 4 plugin (draft, formalize, autoformalize, prove, autoprove, disprove, checkpoint, review, refactor, golf, learn, doctor) — LSP-first, scripts fallback",
   "author": {
     "name": "Cameron Freer",

--- a/plugins/lean4/README.md
+++ b/plugins/lean4/README.md
@@ -1,9 +1,10 @@
 # Lean 4 Plugin
 
-> **Claude Code adapter.** This directory implements the native Claude Code plugin
-> (hooks, guardrails, slash commands). The underlying skill content — SKILL.md,
-> references, and scripts — is host-agnostic.
-> See the [root README](../../README.md) for setup on other hosts.
+> **Native host adapters.** This directory implements the Claude Code plugin
+> (hooks, guardrails, slash commands) and the Codex plugin (skill discovery,
+> absolute-path SessionStart context, prompt validation, advisory guardrails).
+> The underlying SKILL.md, references, wrappers, and scripts remain canonical
+> and host-agnostic. See the [root README](../../README.md) for installation.
 
 Unified Lean 4 plugin for theorem proving, interactive learning, and formalization.
 
@@ -315,9 +316,9 @@ lean_multi_attempt(file, line, snippets=[...])  # Test multiple tactics
 
 Scripts provide sorry analysis, axiom checking, and search fallback when LSP is unavailable or LSP budget is exhausted. Compiler-guided repair is escalation-only — it triggers when compiler errors resist LSP-first tactics, not on first failure.
 
-## Environment Variables
+## Helper Runtime Discovery
 
-Set by `bootstrap.sh` at session start:
+Claude Code persists these variables through `CLAUDE_ENV_FILE` at SessionStart:
 
 | Variable | Purpose |
 |----------|---------|
@@ -325,6 +326,12 @@ Set by `bootstrap.sh` at session start:
 | `LEAN4_SCRIPTS` | Scripts directory |
 | `LEAN4_REFS` | References directory |
 | `LEAN4_PYTHON_BIN` | Python interpreter |
+
+Native Codex does not document a persistent plugin environment or PATH
+channel. After the hook is reviewed in `/hooks`, SessionStart instead injects
+absolute `plugin_root`, `bin_dir`, `scripts_dir`, `refs_dir`, and `preflight`
+context. Invoke wrappers with literal absolute paths under `bin_dir`; do not
+assume the values are shell exports or that bare wrappers resolve on PATH.
 
 Optional user overrides (not set by bootstrap):
 
@@ -339,24 +346,30 @@ Optional user overrides (not set by bootstrap):
 
 **Script troubleshooting:**
 ```bash
+# Native Codex: substitute the literal path from SessionStart.
+/absolute/plugin/root/bin/lean4-skills-preflight --codex
+# Persistent environment (including Claude Code):
 echo "$LEAN4_SCRIPTS"                       # bootstrap set the env var
 command -v lean4-skills-sorry-analyzer       # wrapper resolves on PATH
 lean4-skills-sorry-analyzer . --format=summary --report-only
 ```
 
-If `$LEAN4_SCRIPTS` is unset, run `/lean4:doctor` to reinitialize.
+If neither trusted Codex context nor `$LEAN4_SCRIPTS` is available, follow the
+doctor workflow. Under Codex, review `/hooks` and start a new task; under
+Claude Code, run `/lean4:doctor` and restart the session.
 
 ## File Structure
 
 ```
 plugins/lean4/
 ├── .claude-plugin/plugin.json
+├── .codex-plugin/plugin.json
 ├── commands/           # User-invocable commands
 ├── skills/lean4/
 │   ├── SKILL.md        # Core skill reference
 │   └── references/     # Reference docs
 ├── agents/             # 4 specialized agents
-├── hooks/              # Bootstrap and guardrails
+├── hooks/              # Claude/Codex configs, bootstrap, prompt validation, guardrails
 ├── scripts/            # Compat alias → lib/scripts
 └── lib/scripts/        # 12 hard-primitive scripts
 ```

--- a/plugins/lean4/bin/lean4-skills-preflight
+++ b/plugins/lean4/bin/lean4-skills-preflight
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 # lean4-skills-preflight — model-facing wrapper around lib/scripts/preflight_env.sh.
-# Runs the runtime env diagnosis (LEAN4_* vars, bin/ on PATH, wrappers
-# resolvable) and prints the canonical recovery block on failure.
+# Runs the persistent-env diagnosis by default. `--codex` validates the
+# installed absolute-wrapper contract without requiring LEAN4_* or PATH.
 # See lean4-skills-cycle-tracker for the bin/-wrapper rationale.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+if [[ "${1:-}" == "--codex" ]]; then
+  shift
+  exec bash "$PLUGIN_ROOT/lib/scripts/preflight_env.sh" --codex "$PLUGIN_ROOT" "$@"
+fi
 exec bash "$PLUGIN_ROOT/lib/scripts/preflight_env.sh" --runtime "$@"

--- a/plugins/lean4/commands/doctor.md
+++ b/plugins/lean4/commands/doctor.md
@@ -39,12 +39,27 @@ Diagnostics, troubleshooting, and migration assistance for the Lean4 plugin.
 | `git` | `git --version` | For commits |
 | `rg` | `rg --version` | Optional (faster search) |
 
-Environment variables: `LEAN4_PLUGIN_ROOT`, `LEAN4_SCRIPTS`, `LEAN4_REFS`, `LEAN4_PYTHON_BIN`
+Persistent-environment hosts use `LEAN4_PLUGIN_ROOT`, `LEAN4_SCRIPTS`,
+`LEAN4_REFS`, and `LEAN4_PYTHON_BIN`. Trusted native Codex installs instead
+receive absolute SessionStart paths; those values are not shell exports.
 
-Run the shared env preflight for a live diagnosis. Resolve it **without
-depending on PATH** — `doctor env` is exactly where a broken PATH must
-still be diagnosable, so a bare `lean4-skills-preflight` alone could fail
-command-not-found:
+Run the shared preflight **without depending on PATH**, which may be absent.
+
+**Native Codex plugin:** use the literal absolute SessionStart `preflight` value:
+
+```bash
+/absolute/plugin/root/bin/lean4-skills-preflight --codex
+```
+
+If trusted context is missing, report this canonical recovery block:
+
+```text
+1. Review and trust the lean4 plugin hooks in /hooks.
+2. Start a new Codex task (re-runs the SessionStart hook).
+3. Run the absolute <plugin-root>/bin/lean4-skills-preflight --codex command; if it is missing, reinstall the plugin.
+```
+
+**Persistent environment (including Claude Code):**
 
 ```bash
 if command -v lean4-skills-preflight >/dev/null 2>&1; then
@@ -60,9 +75,8 @@ else
 fi
 ```
 
-The preflight validates that `LEAN4_*` point at real dirs, that
-`$LEAN4_PLUGIN_ROOT/bin` is on `PATH`, and that the `lean4-skills-*`
-wrappers resolve; on failure it prints the canonical recovery block.
+The persistent preflight checks `LEAN4_*`, PATH, and wrappers. Codex checks the
+installed tree and absolute wrappers. Each has a canonical recovery block.
 
 ### 1b. MCP Tools
 
@@ -77,11 +91,12 @@ Verify structure and permissions:
 ```
 plugins/lean4/
 ├── .claude-plugin/plugin.json
+├── .codex-plugin/plugin.json
 ├── commands/     (*.md command files)
-├── hooks/        (executable .sh)
+├── hooks/        (Claude + Codex hook configs; executable hooks)
 ├── skills/lean4/ (SKILL.md + references/)
 ├── agents/       (4 files)
-├── bin/          (lean4-skills-* wrappers; verify on PATH: `command -v lean4-skills-cycle-tracker`)
+├── bin/          (lean4-skills-* wrappers; absolute under Codex, on PATH under Claude)
 └── lib/scripts/  (executable .py / .sh internals)
 ```
 
@@ -218,6 +233,7 @@ No changes made. Run `/lean4:doctor cleanup --apply` to remove.
 
 | Issue | Fix |
 |-------|-----|
+| Native Codex bare wrapper not found on PATH | Expected: invoke the literal absolute `bin_dir/lean4-skills-*` path supplied by trusted SessionStart. Codex does not document persistent plugin PATH mutation. |
 | LEAN4_SCRIPTS not set | 1. Run `/lean4:doctor env` for a full diagnosis. 2. Restart the Claude Code session (re-runs the SessionStart bootstrap hook). 3. If it persists, check the plugin hook/bootstrap state (hooks.json, bootstrap.sh). |
 | `lean4-skills-*` wrapper not found on PATH | 1. Run `/lean4:doctor env` for a full diagnosis. 2. Restart the Claude Code session (re-runs the SessionStart bootstrap hook). 3. If it persists, check the plugin hook/bootstrap state (hooks.json, bootstrap.sh). |
 | lake not found | Install via elan |
@@ -230,6 +246,8 @@ No changes made. Run `/lean4:doctor cleanup --apply` to remove.
 | Commands not found after migration | Check `/lean4:*` not `/lean4-theorem-proving:*` |
 | `rg` not found | Install via package manager — see [ripgrep](../../../INSTALLATION.md#optional-ripgrep) |
 | Lean LSP MCP tools unavailable | Check `claude mcp list` (Claude Code); if missing, `claude mcp add --transport stdio --scope user lean-lsp -- uvx lean-lsp-mcp` or see [INSTALLATION.md](../../../INSTALLATION.md#lean-lsp-mcp-server-all-hosts) |
+
+Under Codex, PreToolUse is advisory and is not a security boundary.
 
 ## Safety
 

--- a/plugins/lean4/hooks/bootstrap.sh
+++ b/plugins/lean4/hooks/bootstrap.sh
@@ -1,16 +1,38 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Resolve the plugin root. CLAUDE_PLUGIN_ROOT is set by Claude Code at hook
-# time; if it's missing the hook was invoked abnormally. We do NOT hard-fail
-# on that (a `:?` abort would bypass the honest degraded-warning path below);
-# instead we self-locate a fallback root from BASH_SOURCE purely so we can
-# still emit the canonical recovery message, and treat missing
-# CLAUDE_PLUGIN_ROOT as a degraded state (no persistence, no "ready").
+# Claude Code invokes this script with no arguments. Codex's dedicated hook
+# config passes `--host codex`, making the persistence contract explicit
+# instead of trying to infer it from compatibility environment variables.
+HOST_MODE="claude"
+if [[ $# -gt 0 ]]; then
+  if [[ "$1" == "--host" && $# -eq 2 ]]; then
+    HOST_MODE="$2"
+  else
+    echo "Usage: bootstrap.sh [--host claude|codex]" >&2
+    exit 64
+  fi
+fi
+case "$HOST_MODE" in
+  claude|codex) ;;
+  *)
+    echo "Usage: bootstrap.sh [--host claude|codex]" >&2
+    exit 64
+    ;;
+esac
+
+# Resolve the plugin root. Claude Code supplies CLAUDE_PLUGIN_ROOT. Codex
+# supplies PLUGIN_ROOT. BASH_SOURCE is only a diagnostic fallback so a missing
+# host variable can still produce the canonical warning rather than a raw
+# file-not-found error.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FALLBACK_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
-PREFLIGHT="${PLUGIN_ROOT:-$FALLBACK_ROOT}/lib/scripts/preflight_env.sh"
+if [[ "$HOST_MODE" == "codex" ]]; then
+  RUNTIME_ROOT="${PLUGIN_ROOT:-}"
+else
+  RUNTIME_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+fi
+PREFLIGHT="${RUNTIME_ROOT:-$FALLBACK_ROOT}/lib/scripts/preflight_env.sh"
 
 ENV_OUT="${CLAUDE_ENV_FILE:-}"
 
@@ -58,7 +80,7 @@ persist_path() {
 # to /dev/null) and emit nothing, silently swallowing the warning. The
 # canonical wording here is kept byte-identical to preflight_env.sh's
 # emit_recovery (test_preflight_env.sh asserts the shared lines).
-warn_degraded_and_exit() {
+warn_claude_degraded_and_exit() {
   local problem="$1"
   {
     echo "Lean4 bootstrap environment is not fully set up in this Claude Code session."
@@ -71,22 +93,64 @@ warn_degraded_and_exit() {
   exit 0
 }
 
+warn_codex_degraded_and_exit() {
+  local problem="$1"
+  {
+    echo "Lean4 native Codex helper runtime is not ready."
+    echo "  Problem: ${problem}"
+    echo "  Recovery:"
+    echo "    1. Review and trust the lean4 plugin hooks in /hooks."
+    echo "    2. Start a new Codex task (re-runs the SessionStart hook)."
+    echo "    3. Run the absolute <plugin-root>/bin/lean4-skills-preflight --codex command; if it is missing, reinstall the plugin."
+  } >&2
+  exit 0
+}
+
+# Codex has no documented persistent environment-file or PATH channel.
+# Validate the installed tree, then return absolute paths as SessionStart
+# developer context. These values describe the runtime; they are deliberately
+# not shell exports.
+if [[ "$HOST_MODE" == "codex" ]]; then
+  if [[ -z "$RUNTIME_ROOT" ]]; then
+    warn_codex_degraded_and_exit "PLUGIN_ROOT is not set (Codex hook invoked without a plugin root)"
+  fi
+  if [[ ! -f "$PREFLIGHT" ]]; then
+    warn_codex_degraded_and_exit "preflight helper not found at $PREFLIGHT"
+  fi
+  if ! bash "$PREFLIGHT" --codex "$RUNTIME_ROOT"; then
+    exit 0  # preflight already emitted the canonical Codex recovery block
+  fi
+
+  printf '%s\n' \
+    "lean4_plugin_runtime=codex" \
+    "plugin_root=$RUNTIME_ROOT" \
+    "bin_dir=$RUNTIME_ROOT/bin" \
+    "scripts_dir=$RUNTIME_ROOT/lib/scripts" \
+    "lib_dir=$RUNTIME_ROOT/lib" \
+    "refs_dir=$RUNTIME_ROOT/skills/lean4/references" \
+    "preflight=$RUNTIME_ROOT/bin/lean4-skills-preflight" \
+    "wrapper_invocation=$RUNTIME_ROOT/bin/<wrapper-name>" \
+    "shell_env_persistent=false" \
+    "Use the literal absolute paths above; do not rely on LEAN4_* shell variables or PATH for plugin helpers."
+  exit 0
+fi
+
 # Missing CLAUDE_PLUGIN_ROOT: degraded — warn via the canonical block and
 # exit 0 without persisting off a guessed root.
-if [[ -z "$PLUGIN_ROOT" ]]; then
-  warn_degraded_and_exit "CLAUDE_PLUGIN_ROOT is not set (bootstrap hook invoked without it)"
+if [[ -z "$RUNTIME_ROOT" ]]; then
+  warn_claude_degraded_and_exit "CLAUDE_PLUGIN_ROOT is not set (bootstrap hook invoked without it)"
 fi
 
 # Guard: if the preflight helper itself is missing, don't let a raw
 # "No such file" error stand in for the diagnosis — emit the canonical
 # block (warn_degraded_and_exit falls back to an inline copy).
 if [[ ! -f "$PREFLIGHT" ]]; then
-  warn_degraded_and_exit "preflight helper not found at $PREFLIGHT"
+  warn_claude_degraded_and_exit "preflight helper not found at $PREFLIGHT"
 fi
 
 # Step 1: validate INPUTS (tree layout + CLAUDE_ENV_FILE usability) before
 # persisting anything. If they don't hold, nothing gets written — warn.
-if ! bash "$PREFLIGHT" --bootstrap "$PLUGIN_ROOT"; then
+if ! bash "$PREFLIGHT" --bootstrap "$RUNTIME_ROOT"; then
   exit 0  # preflight already emitted the canonical block on stderr
 fi
 
@@ -98,10 +162,10 @@ fi
 # calls (and makes INSTALLATION.md's "bootstrap adds bin/ to PATH" true).
 PYTHON_BIN="$(command -v python3 || command -v python || true)"
 
-persist_env "export LEAN4_PLUGIN_ROOT=\"${PLUGIN_ROOT}\""
-persist_env "export LEAN4_SCRIPTS=\"${PLUGIN_ROOT}/lib/scripts\""
-persist_env "export LEAN4_REFS=\"${PLUGIN_ROOT}/skills/lean4/references\""
-persist_path "export PATH=\"${PLUGIN_ROOT}/bin:\$PATH\""
+persist_env "export LEAN4_PLUGIN_ROOT=\"${RUNTIME_ROOT}\""
+persist_env "export LEAN4_SCRIPTS=\"${RUNTIME_ROOT}/lib/scripts\""
+persist_env "export LEAN4_REFS=\"${RUNTIME_ROOT}/skills/lean4/references\""
+persist_path "export PATH=\"${RUNTIME_ROOT}/bin:\$PATH\""
 [[ -n "${PYTHON_BIN}" ]] && persist_env "export LEAN4_PYTHON_BIN=\"${PYTHON_BIN}\""
 
 # Step 3: re-validate that persistence actually happened — "ready" must mean
@@ -120,8 +184,8 @@ for expected in \
 done
 
 if [[ "$persisted_ok" != true ]]; then
-  warn_degraded_and_exit "env persistence to CLAUDE_ENV_FILE did not take effect"
+  warn_claude_degraded_and_exit "env persistence to CLAUDE_ENV_FILE did not take effect"
 fi
 
-echo "Lean4 v4 ready: PLUGIN_ROOT=${PLUGIN_ROOT}"
+echo "Lean4 v4 ready: PLUGIN_ROOT=${RUNTIME_ROOT}"
 exit 0

--- a/plugins/lean4/hooks/codex-hooks.json
+++ b/plugins/lean4/hooks/codex-hooks.json
@@ -1,0 +1,40 @@
+{
+  "description": "Lean4 v4: native Codex lifecycle adapter with advisory guardrails",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$PLUGIN_ROOT/hooks/bootstrap.sh\" --host codex",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$PLUGIN_ROOT/hooks/validate_user_prompt.py\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$PLUGIN_ROOT/hooks/guardrails.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/lean4/hooks/validate_user_prompt.py
+++ b/plugins/lean4/hooks/validate_user_prompt.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Claude UserPromptSubmit hook for /lean4:* slash commands.
+UserPromptSubmit hook for /lean4:* workflow-shaped prompts.
 
 Validates slash-command inputs before the model sees the prompt.
 Hard parse errors block the prompt; successful parses inject a
@@ -17,11 +17,14 @@ import os
 import sys
 import tempfile
 
-# Resolve plugin root from CLAUDE_PLUGIN_ROOT (set by Claude Code at hook time)
-# or fall back to the script's own location when invoked directly.
+# Resolve the plugin root from Codex's native PLUGIN_ROOT first, then the
+# Claude-compatible variable, then the script's own location when invoked
+# directly. Codex may set both variables; the native value must win.
 # hooks/validate_user_prompt.py -> dirname = hooks -> parent = plugin root.
-_PLUGIN_ROOT = os.environ.get("CLAUDE_PLUGIN_ROOT") or os.path.dirname(
-    os.path.dirname(os.path.abspath(__file__))
+_PLUGIN_ROOT = (
+    os.environ.get("PLUGIN_ROOT")
+    or os.environ.get("CLAUDE_PLUGIN_ROOT")
+    or os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 )
 _LIB_ROOT = os.path.join(_PLUGIN_ROOT, "lib")
 if _LIB_ROOT not in sys.path:

--- a/plugins/lean4/lib/scripts/preflight_env.sh
+++ b/plugins/lean4/lib/scripts/preflight_env.sh
@@ -3,7 +3,7 @@
 # preflight_env.sh — single source of the Lean4 env validation checks AND
 # the canonical "bootstrap environment not set up" recovery message.
 #
-# Two modes:
+# Three modes:
 #   --bootstrap   Validate the INPUTS a SessionStart bootstrap needs, given
 #                 CLAUDE_PLUGIN_ROOT (passed as $2, or read from env): the
 #                 plugin tree layout exists and CLAUDE_ENV_FILE is usable.
@@ -13,6 +13,9 @@
 #                 PATH, and the lean4-skills-* wrappers resolve. Used for
 #                 on-demand diagnosis (e.g. /lean4:doctor env, or manual run
 #                 via the lean4-skills-preflight wrapper).
+#   --codex       Validate the installed native Codex plugin layout and its
+#                 absolute wrapper contract. Does not require LEAN4_* shell
+#                 variables, an environment file, or bin/ on PATH.
 #
 # Exit 0 when the checked mode passes; exit 2 with the canonical recovery
 # block on stderr when it fails. Self-locating (BASH_SOURCE) so it never
@@ -24,10 +27,10 @@
 
 set -euo pipefail
 
-# emit_recovery <problem-description>
+# emit_claude_recovery <problem-description>
 # Prints the canonical recovery block to stderr. $1 is a mode-specific,
 # one-line description of what was wrong (interpolated into "Problem:").
-emit_recovery() {
+emit_claude_recovery() {
     local problem="$1"
     {
         echo "Lean4 bootstrap environment is not fully set up in this Claude Code session."
@@ -39,6 +42,21 @@ emit_recovery() {
     } >&2
 }
 
+# emit_codex_recovery <problem-description>
+# Canonical native-Codex recovery block. doctor.md carries these same three
+# numbered lines and test_preflight_env.sh guards the agreement.
+emit_codex_recovery() {
+    local problem="$1"
+    {
+        echo "Lean4 native Codex helper runtime is not ready."
+        echo "  Problem: ${problem}"
+        echo "  Recovery:"
+        echo "    1. Review and trust the lean4 plugin hooks in /hooks."
+        echo "    2. Start a new Codex task (re-runs the SessionStart hook)."
+        echo "    3. Run the absolute <plugin-root>/bin/lean4-skills-preflight --codex command; if it is missing, reinstall the plugin."
+    } >&2
+}
+
 # check_bootstrap <plugin-root>
 # Validates the tree layout + CLAUDE_ENV_FILE usability. Returns 0 on
 # success; on failure emits the canonical block and returns 2.
@@ -47,7 +65,7 @@ check_bootstrap() {
     local problems=()
 
     if [[ -z "$root" ]]; then
-        emit_recovery "CLAUDE_PLUGIN_ROOT is not set (bootstrap hook invoked without it)"
+        emit_claude_recovery "CLAUDE_PLUGIN_ROOT is not set (bootstrap hook invoked without it)"
         return 2
     fi
     [[ -d "$root/lib/scripts" ]] || problems+=("$root/lib/scripts does not exist")
@@ -81,7 +99,7 @@ check_bootstrap() {
     if [[ ${#problems[@]} -gt 0 ]]; then
         local joined
         joined="$(printf '%s; ' "${problems[@]}")"
-        emit_recovery "${joined%; }"
+        emit_claude_recovery "${joined%; }"
         return 2
     fi
     return 0
@@ -123,7 +141,38 @@ check_runtime() {
     if [[ ${#problems[@]} -gt 0 ]]; then
         local joined
         joined="$(printf '%s; ' "${problems[@]}")"
-        emit_recovery "${joined%; }"
+        emit_claude_recovery "${joined%; }"
+        return 2
+    fi
+    return 0
+}
+
+# check_codex <plugin-root>
+# Validates the installed in-place Codex plugin and representative absolute
+# wrappers. It intentionally makes no assertions about the caller's shell
+# environment or PATH.
+check_codex() {
+    local root="$1"
+    local problems=()
+
+    if [[ -z "$root" ]]; then
+        emit_codex_recovery "PLUGIN_ROOT is not set (Codex hook invoked without a plugin root)"
+        return 2
+    fi
+    [[ -d "$root" ]] || problems+=("$root is not a directory")
+    [[ -f "$root/.codex-plugin/plugin.json" ]] || problems+=("$root/.codex-plugin/plugin.json does not exist")
+    [[ -f "$root/hooks/codex-hooks.json" ]] || problems+=("$root/hooks/codex-hooks.json does not exist")
+    [[ -d "$root/lib/scripts" ]] || problems+=("$root/lib/scripts does not exist")
+    [[ -f "$root/skills/lean4/SKILL.md" ]] || problems+=("$root/skills/lean4/SKILL.md does not exist")
+    [[ -d "$root/skills/lean4/references" ]] || problems+=("$root/skills/lean4/references does not exist")
+    [[ -d "$root/bin" ]] || problems+=("$root/bin does not exist")
+    [[ -x "$root/bin/lean4-skills-preflight" ]] || problems+=("$root/bin/lean4-skills-preflight is missing or not executable")
+    [[ -x "$root/bin/lean4-skills-sorry-analyzer" ]] || problems+=("$root/bin/lean4-skills-sorry-analyzer is missing or not executable")
+
+    if [[ ${#problems[@]} -gt 0 ]]; then
+        local joined
+        joined="$(printf '%s; ' "${problems[@]}")"
+        emit_codex_recovery "${joined%; }"
         return 2
     fi
     return 0
@@ -140,8 +189,13 @@ main() {
         --runtime)
             check_runtime
             ;;
+        --codex)
+            # Prefer an explicitly-passed root. PLUGIN_ROOT is Codex's native
+            # hook variable; CLAUDE_PLUGIN_ROOT is its compatibility fallback.
+            check_codex "${2:-${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}}"
+            ;;
         *)
-            echo "Usage: preflight_env.sh [--bootstrap [PLUGIN_ROOT] | --runtime]" >&2
+            echo "Usage: preflight_env.sh [--bootstrap [PLUGIN_ROOT] | --runtime | --codex [PLUGIN_ROOT]]" >&2
             exit 64
             ;;
     esac

--- a/plugins/lean4/skills/lean4/SKILL.md
+++ b/plugins/lean4/skills/lean4/SKILL.md
@@ -158,8 +158,8 @@ lean_code_actions(file, line)                   # Resolve "Try this" suggestions
 | Capability | Required | Check | Fallback |
 |-----------|----------|-------|----------|
 | Lean / Lake | yes | `lean --version`, `lake --version` | none — run `/lean4:doctor` |
-| Python 3 | yes (scripts) | `$LEAN4_PYTHON_BIN` set by bootstrap | none for script-dependent operations |
-| `$LEAN4_SCRIPTS` | yes (set by bootstrap) | `echo "$LEAN4_SCRIPTS"` | run `/lean4:doctor` |
+| Python 3 | yes (scripts) | `python3 --version` or persistent `$LEAN4_PYTHON_BIN` | none for script-dependent operations |
+| Helper runtime path | yes (scripts) | trusted Codex `bin_dir`/`scripts_dir`, or persistent `$LEAN4_SCRIPTS` | use the doctor workflow; stay LSP-only if unresolved |
 | Lean LSP MCP | no | try `lean_goal` on any `.lean` file | scripts + `lake env lean` (file-level only) |
 | `lean_run_code` | no | try calling it | `lake env lean` on temp file |
 | `lean_code_actions` | no | try calling it | manual "Try this" application |
@@ -169,6 +169,25 @@ lean_code_actions(file, line)                   # Resolve "Try this" suggestions
 ## Operating Profiles
 
 The skill adapts to what's available. Determine your profile by checking capabilities above, then follow the corresponding guidance.
+
+### Runtime path resolution
+
+Resolve the helper runtime in this order:
+
+1. **Trusted native Codex plugin:** SessionStart context contains
+   `lean4_plugin_runtime=codex`, absolute `bin_dir` / `scripts_dir` paths,
+   and `shell_env_persistent=false`. Substitute those literal absolute paths
+   into helper commands. They are context values, not shell variables: invoke
+   `/absolute/bin/lean4-skills-…`, never `$bin_dir/…`, and do not expect bare
+   wrappers on PATH.
+2. **Persistent environment:** use `$LEAN4_PLUGIN_ROOT`, `$LEAN4_SCRIPTS`,
+   `$LEAN4_REFS`, and bare wrappers verified on PATH.
+3. **No helper runtime:** remain in the LSP-backed core skill and skip
+   script-dependent steps until the installation is repaired or upgraded.
+
+Do not emit `$LEAN4_BIN/...` or `$LEAN4_SCRIPTS/...` commands when those shell
+variables are unset. A trusted Codex absolute path is a complete alternative,
+not evidence that persistent variables exist.
 
 ### full (all capabilities)
 
@@ -180,7 +199,9 @@ MCP works in the main thread. Run all proof work directly — do not delegate to
 
 ### scripts_only (no MCP, no subagents)
 
-Use `$LEAN4_SCRIPTS` for search and `lake env lean` / `lake build` for validation. **Key limitations in this mode:**
+Use the resolved helper runtime (`scripts_dir` under native Codex,
+`$LEAN4_SCRIPTS` under a persistent environment) for search and use
+`lake env lean` / `lake build` for validation. **Key limitations in this mode:**
 - **No live goal inspection** — `lean_goal` is unavailable; you can read the file and check compilation output, but cannot see proof state at a specific line
 - **No tactic testing** — `lean_multi_attempt` is unavailable; edits must be validated by compiling the file (`lake env lean`)
 - **No real-time diagnostics** — `lean_diagnostic_messages` is unavailable; use `lake env lean <file>` (from project root) for compilation errors, but feedback is file-level, not line-level
@@ -228,9 +249,12 @@ See [sorry-filling.md](references/sorry-filling.md) for the full scratch-work pr
   `lean4-skills-cycle-tracker`, `lean4-skills-disprove-artifact-txn`,
   `lean4-skills-disprove-emit-artifact`, `lean4-skills-disprove-method-probe`,
   `lean4-skills-disprove-target-profile`,
-  `lean4-skills-disprove-target-resolve`). These are bare commands on PATH —
-  no `$LEAN4_SCRIPTS`, no `${LEAN4_PYTHON_BIN:-python3}`, no `~`, no
-  env-var expansion or command substitution **to locate the executable**.
+  `lean4-skills-disprove-target-resolve`). In a persistent environment these
+  are bare commands on PATH. In a trusted native Codex plugin, prefix the
+  wrapper name with the literal absolute `bin_dir` from SessionStart (for
+  example `/installed/plugin/bin/lean4-skills-sorry-analyzer`). Do not use
+  `$LEAN4_SCRIPTS`, `${LEAN4_PYTHON_BIN:-python3}`, `~`, or command
+  substitution **to locate a wrapped executable**.
   Ordinary output capture around a wrapper is fine (e.g.
   `txn=$(lean4-skills-disprove-artifact-txn begin)`). Stable invocation
   surface that sandboxed hosts can statically allowlist.
@@ -245,17 +269,18 @@ See [sorry-filling.md](references/sorry-filling.md) for the full scratch-work pr
 
 Compatibility fallback (when a wrapper is unavailable):
 
-- If `lean4-skills-*` isn't resolvable on PATH, use the host's
-  documented setup to add `$LEAN4_PLUGIN_ROOT/bin` to PATH. Some plugin
-  hosts add this automatically; otherwise see the repository's
-  [INSTALLATION.md](https://github.com/cameronfreer/lean4-skills/blob/main/INSTALLATION.md).
+- Under trusted native Codex, use the literal absolute `bin_dir` path supplied
+  by SessionStart; lack of a bare PATH entry is expected, not a failure.
+- For persistent-environment hosts, if `lean4-skills-*` is not resolvable on
+  PATH, repair the documented `$LEAN4_PLUGIN_ROOT/bin` setup; see the
+  repository's [INSTALLATION.md](https://github.com/cameronfreer/lean4-skills/blob/main/INSTALLATION.md).
 - Only as a last resort for an unwrapped script, use the explicit
   env-var form: `bash "$LEAN4_SCRIPTS/script.sh" …` or
   `${LEAN4_PYTHON_BIN:-python3} "$LEAN4_SCRIPTS/script.py" …`.
 
-If `$LEAN4_SCRIPTS` is unset or missing, run `/lean4:doctor` where the
-plugin's commands are installed; on a skill-only install follow the
-repository's
+If neither trusted Codex absolute paths nor `$LEAN4_SCRIPTS` are available,
+run the doctor workflow (`/lean4:doctor` where that command is installed); on
+a skill-only install follow the repository's
 [INSTALLATION.md](https://github.com/cameronfreer/lean4-skills/blob/main/INSTALLATION.md).
 Stay LSP-only until resolved.
 
@@ -332,10 +357,17 @@ Note: `exact?`/`apply?` query mathlib (slow). `grind` and `aesop` are powerful b
 
 ## Troubleshooting
 
-If LSP tools aren't responding, check your operating profile above. In `scripts_only` mode, `$LEAN4_SCRIPTS` provides search and `lake env lean` provides file-level compilation feedback, but live goal inspection, tactic testing, and line-level diagnostics are unavailable. If environment variables (`LEAN4_SCRIPTS`, `LEAN4_REFS`) are missing, run `/lean4:doctor` to diagnose.
+If LSP tools aren't responding, check your operating profile above. In
+`scripts_only` mode, the resolved helper runtime provides search and
+`lake env lean` provides file-level compilation feedback, but live goal
+inspection, tactic testing, and line-level diagnostics are unavailable. If no
+helper runtime path is available, run the doctor workflow to diagnose it.
 
 **Script environment check:**
 ```bash
+# Trusted native Codex: use the absolute path from SessionStart.
+/absolute/plugin/root/bin/lean4-skills-preflight --codex
+# Persistent environment:
 echo "$LEAN4_SCRIPTS"
 command -v lean4-skills-sorry-analyzer
 # One-pass discovery for troubleshooting (human-readable default text):

--- a/plugins/lean4/tests/test_bootstrap_env.sh
+++ b/plugins/lean4/tests/test_bootstrap_env.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Regression tests for hooks/bootstrap.sh (#108): honest reporting, PATH
-# persistence, and PATH idempotency. Drives the hook with a fabricated
-# CLAUDE_PLUGIN_ROOT (the real tree) and a CLAUDE_ENV_FILE in a tempdir.
+# Regression tests for hooks/bootstrap.sh (#108, #157): honest Claude
+# persistence plus truthful native-Codex absolute-path context.
 #
 # Runs under $BASH_FOR_COMPAT (default /bin/bash) so it exercises macOS
 # Bash 3.2 in CI. SKIPs gracefully if that shell is unavailable.
@@ -40,6 +39,25 @@ run_bootstrap() {
     BS_EXIT=0
     BS_OUT=$(env "${unset_flags[@]+"${unset_flags[@]}"}" "${assigns[@]+"${assigns[@]}"}" \
         "$BASH_FOR_COMPAT" "$BOOTSTRAP" 2>&1) || BS_EXIT=$?
+}
+
+# run_codex_bootstrap: native Codex invocation. Sets BS_OUT and BS_EXIT.
+#   $1 = PLUGIN_ROOT value ("" to leave unset)
+#   $2 = CLAUDE_PLUGIN_ROOT compatibility value ("" to leave unset)
+#   $3 = CLAUDE_ENV_FILE sentinel (must never be written by Codex mode)
+run_codex_bootstrap() {
+    local root="$1" compat_root="$2" envfile="$3"
+    local -a unset_flags=(
+        "-u" "LEAN4_PLUGIN_ROOT" "-u" "LEAN4_SCRIPTS" "-u" "LEAN4_REFS"
+        "-u" "PLUGIN_ROOT" "-u" "CLAUDE_PLUGIN_ROOT" "-u" "CLAUDE_ENV_FILE"
+    )
+    local -a assigns=()
+    [[ -n "$root" ]] && assigns+=("PLUGIN_ROOT=$root")
+    [[ -n "$compat_root" ]] && assigns+=("CLAUDE_PLUGIN_ROOT=$compat_root")
+    [[ -n "$envfile" ]] && assigns+=("CLAUDE_ENV_FILE=$envfile")
+    BS_EXIT=0
+    BS_OUT=$(env "${unset_flags[@]}" "${assigns[@]+"${assigns[@]}"}" \
+        "$BASH_FOR_COMPAT" "$BOOTSTRAP" --host codex 2>&1) || BS_EXIT=$?
 }
 
 # ---------------------------------------------------------------------------
@@ -182,6 +200,75 @@ if [[ "$BS_EXIT" -eq 0 ]] \
     pass "degraded: CLAUDE_ENV_FILE → directory → canonical warning, exit 0"
 else
     fail "degraded CLAUDE_ENV_FILE → directory (exit=$BS_EXIT): $BS_OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# Native Codex: absolute context, no persistent env/PATH claims or writes.
+# ---------------------------------------------------------------------------
+codex_env_sentinel="$SCRATCH/codex_must_not_write_env"
+run_codex_bootstrap "$PLUGIN_ROOT" "" "$codex_env_sentinel"
+codex_ok=1
+[[ "$BS_EXIT" -eq 0 ]] || codex_ok=0
+grep -qF "lean4_plugin_runtime=codex" <<<"$BS_OUT" || codex_ok=0
+grep -qF "plugin_root=$PLUGIN_ROOT" <<<"$BS_OUT" || codex_ok=0
+grep -qF "bin_dir=$PLUGIN_ROOT/bin" <<<"$BS_OUT" || codex_ok=0
+grep -qF "preflight=$PLUGIN_ROOT/bin/lean4-skills-preflight" <<<"$BS_OUT" || codex_ok=0
+grep -qF "wrapper_invocation=$PLUGIN_ROOT/bin/<wrapper-name>" <<<"$BS_OUT" || codex_ok=0
+grep -qF "shell_env_persistent=false" <<<"$BS_OUT" || codex_ok=0
+! grep -qF "Lean4 v4 ready" <<<"$BS_OUT" || codex_ok=0
+[[ ! -e "$codex_env_sentinel" ]] || codex_ok=0
+if [[ $codex_ok -eq 1 ]]; then
+    pass "Codex: absolute runtime context, no env-file write or false PATH readiness"
+else
+    fail "Codex absolute runtime context (exit=$BS_EXIT): $BS_OUT"
+fi
+
+# The same trusted root produces byte-identical context on every lifecycle
+# event; source matching belongs to codex-hooks.json and is tested separately.
+codex_first="$BS_OUT"
+run_codex_bootstrap "$PLUGIN_ROOT" "" "$codex_env_sentinel"
+if [[ "$BS_OUT" == "$codex_first" ]]; then
+    pass "Codex: SessionStart context is idempotent"
+else
+    fail "Codex: SessionStart context changed across identical runs"
+fi
+
+# Native PLUGIN_ROOT wins over the Claude compatibility variable.
+run_codex_bootstrap "$PLUGIN_ROOT" "$SCRATCH/not-the-plugin" ""
+if [[ "$BS_EXIT" -eq 0 ]] && grep -qF "plugin_root=$PLUGIN_ROOT" <<<"$BS_OUT"; then
+    pass "Codex: PLUGIN_ROOT takes precedence over CLAUDE_PLUGIN_ROOT"
+else
+    fail "Codex root precedence (exit=$BS_EXIT): $BS_OUT"
+fi
+
+# A compatibility variable alone must not mask a missing native Codex root.
+run_codex_bootstrap "" "$PLUGIN_ROOT" ""
+if [[ "$BS_EXIT" -eq 0 ]] \
+   && grep -qF "PLUGIN_ROOT is not set" <<<"$BS_OUT" \
+   && ! grep -qF "lean4_plugin_runtime=codex" <<<"$BS_OUT"; then
+    pass "Codex: CLAUDE_PLUGIN_ROOT does not replace native PLUGIN_ROOT"
+else
+    fail "Codex compatibility-only root handling (exit=$BS_EXIT): $BS_OUT"
+fi
+
+# Missing host root and corrupt roots degrade loudly without injecting a
+# misleading runtime context or disrupting SessionStart.
+run_codex_bootstrap "" "" ""
+if [[ "$BS_EXIT" -eq 0 ]] \
+   && grep -qF "PLUGIN_ROOT is not set" <<<"$BS_OUT" \
+   && ! grep -qF "lean4_plugin_runtime=codex" <<<"$BS_OUT"; then
+    pass "Codex: missing root emits canonical recovery without context"
+else
+    fail "Codex missing-root recovery (exit=$BS_EXIT): $BS_OUT"
+fi
+
+run_codex_bootstrap "$nohelper" "" ""
+if [[ "$BS_EXIT" -eq 0 ]] \
+   && grep -qF "preflight helper not found" <<<"$BS_OUT" \
+   && ! grep -qF "lean4_plugin_runtime=codex" <<<"$BS_OUT"; then
+    pass "Codex: corrupt plugin tree emits recovery without context"
+else
+    fail "Codex corrupt-root recovery (exit=$BS_EXIT): $BS_OUT"
 fi
 
 # ---------------------------------------------------------------------------

--- a/plugins/lean4/tests/test_codex_adapter.sh
+++ b/plugins/lean4/tests/test_codex_adapter.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deterministic native-Codex adapter contract tests (#157). Real Codex
+# install/trust behavior is smoke-tested separately; this suite stays
+# dependency-free and runs under macOS Bash 3.2 in CI.
+
+BASH_FOR_COMPAT="${BASH_FOR_COMPAT:-/bin/bash}"
+if [[ ! -x "$BASH_FOR_COMPAT" ]]; then
+    echo "SKIP: $BASH_FOR_COMPAT not found — cannot run Codex adapter self-test"
+    exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$PLUGIN_ROOT/../.." && pwd)"
+
+CODEX_MANIFEST="$PLUGIN_ROOT/.codex-plugin/plugin.json"
+CLAUDE_MANIFEST="$PLUGIN_ROOT/.claude-plugin/plugin.json"
+CODEX_HOOKS="$PLUGIN_ROOT/hooks/codex-hooks.json"
+CODEX_MARKETPLACE="$REPO_ROOT/.agents/plugins/marketplace.json"
+BOOTSTRAP="$PLUGIN_ROOT/hooks/bootstrap.sh"
+PROMPT_HOOK="$PLUGIN_ROOT/hooks/validate_user_prompt.py"
+GUARDRAILS="$PLUGIN_ROOT/hooks/guardrails.sh"
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS: $1"; (( ++PASS )) || true; }
+fail() { echo "  FAIL: $1"; (( ++FAIL )) || true; }
+
+SCRATCH=$(mktemp -d)
+trap 'rm -rf "$SCRATCH"' EXIT
+
+echo "=== native Codex adapter contract tests ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# Metadata contracts: in-place plugin, thin marketplace, dedicated hooks.
+# ---------------------------------------------------------------------------
+if python3 - "$CODEX_MANIFEST" "$CLAUDE_MANIFEST" "$CODEX_MARKETPLACE" "$CODEX_HOOKS" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+codex_path, claude_path, market_path, hooks_path = map(Path, sys.argv[1:])
+codex = json.loads(codex_path.read_text())
+claude = json.loads(claude_path.read_text())
+market = json.loads(market_path.read_text())
+hooks = json.loads(hooks_path.read_text())
+
+assert codex["name"] == "lean4"
+assert codex["version"] == claude["version"]
+assert re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", codex["version"])
+assert codex["description"] == claude["description"]
+assert codex["skills"] == "./skills"
+assert codex["hooks"] == "./hooks/codex-hooks.json"
+assert codex["license"] == "MIT"
+interface = codex["interface"]
+for key in (
+    "displayName",
+    "shortDescription",
+    "longDescription",
+    "developerName",
+    "category",
+    "capabilities",
+    "websiteURL",
+    "defaultPrompt",
+):
+    assert interface[key]
+assert "privacyPolicyURL" not in interface
+assert "termsOfServiceURL" not in interface
+
+assert market["name"] == "lean4-skills"
+assert market["interface"]["displayName"] == "Lean 4 Skills"
+assert len(market["plugins"]) == 1
+entry = market["plugins"][0]
+assert entry["name"] == "lean4"
+assert entry["source"] == {"source": "local", "path": "./plugins/lean4"}
+assert entry["policy"] == {
+    "installation": "AVAILABLE",
+    "authentication": "ON_INSTALL",
+}
+assert entry["category"] == "Coding"
+
+events = hooks["hooks"]
+assert set(events) == {"SessionStart", "UserPromptSubmit", "PreToolUse"}
+session = events["SessionStart"][0]
+assert session["matcher"] == "startup|resume|clear|compact"
+assert session["hooks"][0]["command"] == '"$PLUGIN_ROOT/hooks/bootstrap.sh" --host codex'
+prompt = events["UserPromptSubmit"][0]
+assert "matcher" not in prompt
+assert prompt["hooks"][0]["command"] == '"$PLUGIN_ROOT/hooks/validate_user_prompt.py"'
+pretool = events["PreToolUse"][0]
+assert pretool["matcher"] == "Bash"
+assert pretool["hooks"][0]["command"] == '"$PLUGIN_ROOT/hooks/guardrails.sh"'
+for event in events.values():
+    for group in event:
+        for hook in group["hooks"]:
+            assert "CLAUDE_PLUGIN_ROOT" not in hook["command"]
+PY
+then
+    pass "manifest, marketplace, and Codex hook contracts are valid"
+else
+    fail "manifest, marketplace, or Codex hook contract"
+fi
+
+if [[ -f "$CODEX_MANIFEST" && ! -L "$CODEX_MANIFEST" \
+   && -f "$CODEX_HOOKS" && ! -L "$CODEX_HOOKS" \
+   && ! -e "$PLUGIN_ROOT/packages" \
+   && ! -e "$PLUGIN_ROOT/codex-package" ]]; then
+    pass "adapter is in place with no mirrored package tree"
+else
+    fail "adapter introduced a symlinked or mirrored package surface"
+fi
+
+# ---------------------------------------------------------------------------
+# Codex-shaped hook invocations.
+# ---------------------------------------------------------------------------
+session_payload='{"session_id":"session-1","cwd":"/tmp","source":"startup","hook_event_name":"SessionStart"}'
+bootstrap_exit=0
+bootstrap_out=$(printf '%s' "$session_payload" | env \
+    -u LEAN4_PLUGIN_ROOT -u LEAN4_SCRIPTS -u LEAN4_REFS \
+    PLUGIN_ROOT="$PLUGIN_ROOT" CLAUDE_PLUGIN_ROOT="$SCRATCH/wrong-root" \
+    CLAUDE_ENV_FILE="$SCRATCH/must-not-exist" PATH="/usr/bin:/bin" \
+    "$BASH_FOR_COMPAT" "$BOOTSTRAP" --host codex 2>&1) || bootstrap_exit=$?
+if [[ "$bootstrap_exit" -eq 0 ]] \
+   && grep -qF "plugin_root=$PLUGIN_ROOT" <<<"$bootstrap_out" \
+   && grep -qF "shell_env_persistent=false" <<<"$bootstrap_out" \
+   && [[ ! -e "$SCRATCH/must-not-exist" ]]; then
+    pass "SessionStart emits truthful absolute context and writes no env file"
+else
+    fail "SessionStart Codex context (exit=$bootstrap_exit): $bootstrap_out"
+fi
+
+prompt_payload='{"session_id":"session-1","turn_id":"turn-1","cwd":"/tmp","permission_mode":"default","hook_event_name":"UserPromptSubmit","prompt":"/lean4:prove Foo.lean"}'
+prompt_exit=0
+prompt_out=$(printf '%s' "$prompt_payload" | env PLUGIN_ROOT="$PLUGIN_ROOT" "$PROMPT_HOOK" 2>&1) || prompt_exit=$?
+if [[ "$prompt_exit" -eq 0 ]] && printf '%s' "$prompt_out" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+assert data["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+assert data["hookSpecificOutput"]["additionalContext"]
+'; then
+    pass "UserPromptSubmit accepts Codex input and emits additionalContext"
+else
+    fail "UserPromptSubmit Codex round-trip (exit=$prompt_exit): $prompt_out"
+fi
+
+skill_prompt='{"cwd":"/tmp","hook_event_name":"UserPromptSubmit","prompt":"$lean4 prove Foo.lean"}'
+skill_prompt_exit=0
+skill_prompt_out=$(printf '%s' "$skill_prompt" | env PLUGIN_ROOT="$PLUGIN_ROOT" "$PROMPT_HOOK" 2>&1) || skill_prompt_exit=$?
+if [[ "$skill_prompt_exit" -eq 0 && -z "$skill_prompt_out" ]]; then
+    pass "UserPromptSubmit passes an ordinary Codex \$lean4 prompt unchanged"
+else
+    fail "UserPromptSubmit ordinary \$lean4 prompt (exit=$skill_prompt_exit): $skill_prompt_out"
+fi
+
+blocked_prompt='{"cwd":"/tmp","hook_event_name":"UserPromptSubmit","prompt":"/lean4:draft --mode=banana x"}'
+blocked_prompt_out=$(printf '%s' "$blocked_prompt" | env PLUGIN_ROOT="$PLUGIN_ROOT" "$PROMPT_HOOK" 2>/dev/null)
+if printf '%s' "$blocked_prompt_out" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+assert data["decision"] == "block"
+assert data["reason"]
+'; then
+    pass "UserPromptSubmit preserves legacy decision:block semantics"
+else
+    fail "UserPromptSubmit block response: $blocked_prompt_out"
+fi
+
+lean_project="$SCRATCH/lean-project"
+mkdir -p "$lean_project"
+touch "$lean_project/lean-toolchain"
+
+safe_payload=$(printf '{"session_id":"session-1","turn_id":"turn-1","cwd":"%s","tool_name":"Bash","hook_event_name":"PreToolUse","tool_input":{"command":"git status"}}' "$lean_project")
+safe_exit=0
+printf '%s' "$safe_payload" | "$GUARDRAILS" >/dev/null 2>&1 || safe_exit=$?
+if [[ "$safe_exit" -eq 0 ]]; then
+    pass "PreToolUse allows a safe Codex Bash payload"
+else
+    fail "PreToolUse safe payload returned $safe_exit"
+fi
+
+blocked_payload=$(printf '{"session_id":"session-1","turn_id":"turn-1","cwd":"%s","tool_name":"Bash","hook_event_name":"PreToolUse","tool_input":{"command":"git reset --hard"}}' "$lean_project")
+blocked_exit=0
+blocked_out=$(printf '%s' "$blocked_payload" | "$GUARDRAILS" 2>&1) || blocked_exit=$?
+if [[ "$blocked_exit" -eq 2 ]] && grep -qF "BLOCKED" <<<"$blocked_out"; then
+    pass "PreToolUse blocks a destructive Codex Bash payload with exit 2"
+else
+    fail "PreToolUse destructive payload (exit=$blocked_exit): $blocked_out"
+fi
+
+echo ""
+echo "=== test_codex_adapter.sh: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/plugins/lean4/tests/test_lint_docs.sh
+++ b/plugins/lean4/tests/test_lint_docs.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Self-test for lint_docs.sh Check 8c (Python helper interpreter prefix,
-# closes #135) and Check 8e (compilation-errors.md heading uniqueness).
+# Self-test for lint_docs.sh Check 8c (Python helper interpreter prefix),
+# Check 8e (compilation-errors.md heading uniqueness), and Check 23
+# (Claude/Codex release-metadata consistency).
 # For each check, verify it fires on a planted violation and emits its
 # clean-run OK line once the violation is removed.
 #
@@ -174,6 +175,67 @@ if echo "$output4" | grep -qF "$warn_preamble_8e"; then
 fi
 if [[ $probe4_ok -eq 1 ]]; then
   echo "  PASS: Probe 4 — Check 8e clean on restored tree (OK line present, no WARN)"
+  ((PASS++)) || true
+else
+    ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
+# Probe 5 — Check 23: a Codex manifest version drift must be reported. The
+# real manifest is backed up and restored exactly like compilation-errors.md;
+# never use git checkout, which could clobber an in-progress edit.
+# ---------------------------------------------------------------------------
+CODEX_MANIFEST="$PLUGIN_ROOT/.codex-plugin/plugin.json"
+CODEX_BACKUP=$(mktemp)
+cp "$CODEX_MANIFEST" "$CODEX_BACKUP"
+trap 'cp "$CE_BACKUP" "$CE_FILE"; cp "$CODEX_BACKUP" "$CODEX_MANIFEST"; rm -f "$CE_BACKUP" "$CODEX_BACKUP" "$SCRATCH"' EXIT
+
+python3 - "$CODEX_MANIFEST" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as f:
+    data = json.load(f)
+data["version"] = "0.0.0"
+with open(path, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2, ensure_ascii=False)
+    f.write("\n")
+PY
+
+output5=$("$BASH_FOR_COMPAT" "$LINT" 2>&1 || true)
+
+if echo "$output5" | grep -qF "Codex plugin version (0.0.0) != plugin.json"; then
+  echo "  PASS: Probe 5 — Check 23 fires on Codex manifest version drift"
+  ((PASS++)) || true
+else
+  echo "  FAIL: Probe 5 — Check 23 did not flag Codex manifest version drift"
+  echo "         relevant output:"
+  echo "$output5" | grep -E "Codex plugin version|release metadata" | sed 's/^/           /' || true
+  ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
+# Probe 6 — restored Codex version: Check 23 emits its clean line and no drift
+# warning. Restore explicitly before the second linter invocation; the trap
+# remains as the interruption safety net.
+# ---------------------------------------------------------------------------
+cp "$CODEX_BACKUP" "$CODEX_MANIFEST"
+output6=$("$BASH_FOR_COMPAT" "$LINT" 2>&1 || true)
+
+ok_line_23='✓ Codex plugin version matches plugin.json'
+warn_preamble_23='Codex plugin version ('
+probe6_ok=1
+if ! echo "$output6" | grep -qF "$ok_line_23"; then
+  echo "  FAIL: Probe 6 — expected Check 23 OK line not found"
+  probe6_ok=0
+fi
+if echo "$output6" | grep -F "$warn_preamble_23" | grep -qF "!= plugin.json"; then
+  echo "  FAIL: Probe 6 — Codex version-drift warning remained after restore"
+  probe6_ok=0
+fi
+if [[ $probe6_ok -eq 1 ]]; then
+  echo "  PASS: Probe 6 — Check 23 clean after Codex manifest restore"
   ((PASS++)) || true
 else
   ((FAIL++)) || true

--- a/plugins/lean4/tests/test_preflight_env.sh
+++ b/plugins/lean4/tests/test_preflight_env.sh
@@ -2,9 +2,8 @@
 set -euo pipefail
 
 # Regression tests for lib/scripts/preflight_env.sh (#108).
-# Exercises --runtime and --bootstrap modes, and guards that doctor.md
-# still carries the three canonical recovery lines byte-for-byte (the
-# helper is the single source of that wording).
+# Exercises --runtime, --bootstrap, and --codex modes, and guards that
+# doctor.md still carries both canonical recovery blocks.
 #
 # Runs under $BASH_FOR_COMPAT (default /bin/bash) so it exercises macOS
 # Bash 3.2 in CI. SKIPs gracefully if that shell is unavailable.
@@ -28,6 +27,9 @@ FAIL=0
 CANON1="1. Run /lean4:doctor env for a full diagnosis."
 CANON2="2. Restart the Claude Code session (re-runs the SessionStart bootstrap hook)."
 CANON3="3. If it persists, check the plugin hook/bootstrap state (hooks.json, bootstrap.sh)."
+CODEX_CANON1="1. Review and trust the lean4 plugin hooks in /hooks."
+CODEX_CANON2="2. Start a new Codex task (re-runs the SessionStart hook)."
+CODEX_CANON3="3. Run the absolute <plugin-root>/bin/lean4-skills-preflight --codex command; if it is missing, reinstall the plugin."
 
 pass() { echo "  PASS: $1"; (( ++PASS )) || true; }
 fail() { echo "  FAIL: $1"; (( ++FAIL )) || true; }
@@ -95,7 +97,61 @@ else
     fail "bootstrap: tree missing bin/ → exit 2 (got $out)"
 fi
 
-rm -rf "$tmp" "$baddir"
+# ---------------------------------------------------------------------------
+# --codex mode: absolute installed-tree checks, no env/PATH dependency.
+# ---------------------------------------------------------------------------
+
+out=0
+env -u LEAN4_PLUGIN_ROOT -u LEAN4_SCRIPTS -u LEAN4_REFS \
+    PATH="/usr/bin:/bin" \
+    "$BASH_FOR_COMPAT" "$PREFLIGHT" --codex "$PLUGIN_ROOT" >/dev/null 2>&1 || out=$?
+[[ "$out" -eq 0 ]] && pass "codex: valid absolute runtime with no LEAN4_* or plugin PATH → exit 0" \
+    || fail "codex: valid absolute runtime → exit 0 (got $out)"
+
+out=0
+env -u LEAN4_PLUGIN_ROOT -u LEAN4_SCRIPTS -u LEAN4_REFS \
+    PATH="/usr/bin:/bin" \
+    "$PLUGIN_ROOT/bin/lean4-skills-preflight" --codex >/dev/null 2>&1 || out=$?
+[[ "$out" -eq 0 ]] && pass "codex: self-locating absolute preflight wrapper → exit 0" \
+    || fail "codex: absolute preflight wrapper → exit 0 (got $out)"
+
+out=0
+codex_out=$(env -u PLUGIN_ROOT -u CLAUDE_PLUGIN_ROOT \
+    "$BASH_FOR_COMPAT" "$PREFLIGHT" --codex "" 2>&1) || out=$?
+if [[ "$out" -eq 2 ]] && grep -qF "PLUGIN_ROOT is not set" <<<"$codex_out"; then
+    pass "codex: empty root → canonical recovery + exit 2"
+else
+    fail "codex: empty root → canonical recovery + exit 2 (got $out)"
+fi
+
+badcodex=$(mktemp -d)
+mkdir -p "$badcodex/.codex-plugin" "$badcodex/hooks" \
+    "$badcodex/lib/scripts" "$badcodex/skills/lean4/references" "$badcodex/bin"
+touch "$badcodex/.codex-plugin/plugin.json" "$badcodex/hooks/codex-hooks.json" \
+    "$badcodex/skills/lean4/SKILL.md"
+out=0
+codex_out=$("$BASH_FOR_COMPAT" "$PREFLIGHT" --codex "$badcodex" 2>&1) || out=$?
+if [[ "$out" -eq 2 ]] && grep -qF "lean4-skills-preflight is missing or not executable" <<<"$codex_out"; then
+    pass "codex: missing absolute wrapper → canonical recovery + exit 2"
+else
+    fail "codex: missing wrapper → canonical recovery + exit 2 (got $out)"
+fi
+
+badcodex_scripts=$(mktemp -d)
+mkdir -p "$badcodex_scripts/.codex-plugin" "$badcodex_scripts/hooks" \
+    "$badcodex_scripts/skills/lean4/references" "$badcodex_scripts/bin"
+touch "$badcodex_scripts/.codex-plugin/plugin.json" \
+    "$badcodex_scripts/hooks/codex-hooks.json" \
+    "$badcodex_scripts/skills/lean4/SKILL.md"
+out=0
+codex_out=$("$BASH_FOR_COMPAT" "$PREFLIGHT" --codex "$badcodex_scripts" 2>&1) || out=$?
+if [[ "$out" -eq 2 ]] && grep -qF "lib/scripts does not exist" <<<"$codex_out"; then
+    pass "codex: missing scripts directory → canonical recovery + exit 2"
+else
+    fail "codex: missing scripts directory → canonical recovery + exit 2 (got $out)"
+fi
+
+rm -rf "$tmp" "$baddir" "$badcodex" "$badcodex_scripts"
 
 # ---------------------------------------------------------------------------
 # Wording agreement: doctor.md must contain the three canonical lines.
@@ -117,6 +173,22 @@ for canon in "$CANON1" "$CANON2" "$CANON3"; do
     grep -qF "$canon" <<<"$emitted" || fail "preflight did not emit canonical line: $canon"
 done
 pass "preflight_env.sh emits all three canonical lines"
+
+# Codex recovery wording agreement and emitted behavior.
+for canon in "$CODEX_CANON1" "$CODEX_CANON2" "$CODEX_CANON3"; do
+    if grep -qF "$canon" "$DOCTOR"; then
+        pass "doctor.md contains Codex canonical line: ${canon%% *}…"
+    else
+        fail "doctor.md MISSING Codex canonical line: $canon"
+    fi
+done
+
+emitted=$(env -u PLUGIN_ROOT -u CLAUDE_PLUGIN_ROOT \
+    "$BASH_FOR_COMPAT" "$PREFLIGHT" --codex "" 2>&1 || true)
+for canon in "$CODEX_CANON1" "$CODEX_CANON2" "$CODEX_CANON3"; do
+    grep -qF "$canon" <<<"$emitted" || fail "preflight did not emit Codex canonical line: $canon"
+done
+pass "preflight_env.sh emits all three Codex canonical lines"
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/plugins/lean4/tests/test_validate_user_prompt.sh
+++ b/plugins/lean4/tests/test_validate_user_prompt.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 # the shebang line and executable bit are exercised end-to-end.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-HOOK="$(cd "$SCRIPT_DIR/.." && pwd)/hooks/validate_user_prompt.py"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$PLUGIN_ROOT/hooks/validate_user_prompt.py"
 
 PASS=0
 FAIL=0
@@ -365,6 +366,36 @@ run_test_json \
   "{\"prompt\":\"/lean4:draft\n\\\"x\\\"\",\"cwd\":\"/tmp\"}" \
   ".hookSpecificOutput.hookEventName" \
   "UserPromptSubmit"
+
+# ---------------------------------------------------------------------------
+# Native Codex payload + root precedence
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "-- Native Codex compatibility --"
+
+run_test_json \
+  "25. Codex extra input fields are ignored safely" \
+  '{"prompt":"/lean4:prove Foo.lean","cwd":"/tmp","turn_id":"turn-1","permission_mode":"default","hook_event_name":"UserPromptSubmit"}' \
+  ".hookSpecificOutput.hookEventName" \
+  "UserPromptSubmit"
+
+# A broken CLAUDE_PLUGIN_ROOT would make command_args unavailable. Successful
+# parsing therefore proves that native PLUGIN_ROOT wins when Codex supplies
+# both variables.
+FAKE_ROOT=$(mktemp -d)
+actual_exit=0
+output=$(echo '{"prompt":"/lean4:prove Foo.lean","cwd":"/tmp"}' \
+  | env PLUGIN_ROOT="$PLUGIN_ROOT" CLAUDE_PLUGIN_ROOT="$FAKE_ROOT" "$HOOK" 2>/dev/null) || actual_exit=$?
+rm -rf "$FAKE_ROOT"
+if [[ "$actual_exit" -eq 0 ]] \
+   && echo "$output" | python3 -c 'import json, sys; assert json.load(sys.stdin)["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"' 2>/dev/null; then
+  echo "  PASS: 26. PLUGIN_ROOT takes precedence over CLAUDE_PLUGIN_ROOT"
+  (( ++PASS ))
+else
+  echo "  FAIL: 26. PLUGIN_ROOT precedence (exit=$actual_exit, output='$output')"
+  (( ++FAIL ))
+fi
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/plugins/lean4/tools/lint_docs.sh
+++ b/plugins/lean4/tools/lint_docs.sh
@@ -1364,23 +1364,33 @@ check_advanced_reference_snippets() {
     fi
 }
 
-# Check 23: release metadata consistency (plugin.json ↔ marketplace.json ↔ CHANGELOG)
+# Check 23: release metadata consistency across Claude + Codex surfaces.
 check_release_metadata() {
     log ""
     log "Checking release metadata consistency..."
 
     local plugin_json="$PLUGIN_ROOT/.claude-plugin/plugin.json"
+    local codex_plugin_json="$PLUGIN_ROOT/.codex-plugin/plugin.json"
     local repo_root
     repo_root="$(cd "$PLUGIN_ROOT" && cd ../.. && pwd)"
     local marketplace_json="$repo_root/.claude-plugin/marketplace.json"
+    local codex_marketplace_json="$repo_root/.agents/plugins/marketplace.json"
     local changelog="$repo_root/CHANGELOG.md"
 
     if [[ ! -f "$plugin_json" ]]; then
         warn "plugin.json not found at $plugin_json"
         return
     fi
+    if [[ ! -f "$codex_plugin_json" ]]; then
+        warn "Codex plugin.json not found at $codex_plugin_json"
+        return
+    fi
     if [[ ! -f "$marketplace_json" ]]; then
         warn "marketplace.json not found at $marketplace_json"
+        return
+    fi
+    if [[ ! -f "$codex_marketplace_json" ]]; then
+        warn "Codex marketplace.json not found at $codex_marketplace_json"
         return
     fi
     if [[ ! -f "$changelog" ]]; then
@@ -1388,64 +1398,199 @@ check_release_metadata() {
         return
     fi
 
-    # Extract plugin.json fields
-    local plugin_version plugin_desc
-    plugin_version=$(grep -oE '"version": *"[^"]+"' "$plugin_json" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-    plugin_desc=$(sed -n 's/.*"description": *"\([^"]*\)".*/\1/p' "$plugin_json" | head -1)
+    # Parse every JSON surface in one stdlib-only pass. The tab-delimited
+    # output keeps Bash 3.2 compatibility without depending on jq.
+    local plugin_version="" plugin_desc="" market_version=""
+    local market_plugin_desc="" market_source="" market_plugin_count=""
+    local codex_version="" codex_desc="" codex_name="" codex_skills="" codex_hooks="" codex_semver=""
+    local codex_market_name="" codex_market_total="" codex_market_plugin_count="" codex_contribute_count=""
+    local codex_source_type="" codex_source_path="" codex_source_in_repo=""
+    local codex_installation="" codex_authentication="" codex_category=""
+    local key value
+    while IFS=$'\t' read -r key value; do
+        case "$key" in
+            plugin_version) plugin_version="$value" ;;
+            plugin_desc) plugin_desc="$value" ;;
+            market_version) market_version="$value" ;;
+            market_plugin_desc) market_plugin_desc="$value" ;;
+            market_source) market_source="$value" ;;
+            market_plugin_count) market_plugin_count="$value" ;;
+            codex_version) codex_version="$value" ;;
+            codex_desc) codex_desc="$value" ;;
+            codex_name) codex_name="$value" ;;
+            codex_skills) codex_skills="$value" ;;
+            codex_hooks) codex_hooks="$value" ;;
+            codex_semver) codex_semver="$value" ;;
+            codex_market_name) codex_market_name="$value" ;;
+            codex_market_total) codex_market_total="$value" ;;
+            codex_market_plugin_count) codex_market_plugin_count="$value" ;;
+            codex_contribute_count) codex_contribute_count="$value" ;;
+            codex_source_type) codex_source_type="$value" ;;
+            codex_source_path) codex_source_path="$value" ;;
+            codex_source_in_repo) codex_source_in_repo="$value" ;;
+            codex_installation) codex_installation="$value" ;;
+            codex_authentication) codex_authentication="$value" ;;
+            codex_category) codex_category="$value" ;;
+        esac
+    done < <(python3 - "$plugin_json" "$codex_plugin_json" "$marketplace_json" "$codex_marketplace_json" "$repo_root" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
 
-    if [[ -z "$plugin_version" ]]; then
-        warn "Could not extract version from plugin.json"
+plugin_path, codex_path, market_path, codex_market_path, repo_path = sys.argv[1:]
+with open(plugin_path, encoding="utf-8") as f:
+    plugin = json.load(f)
+with open(codex_path, encoding="utf-8") as f:
+    codex = json.load(f)
+with open(market_path, encoding="utf-8") as f:
+    market = json.load(f)
+with open(codex_market_path, encoding="utf-8") as f:
+    codex_market = json.load(f)
+
+def emit(key, value):
+    print(f"{key}\t{value}")
+
+legacy_plugins = [p for p in market.get("plugins", []) if p.get("name") == "lean4"]
+legacy = legacy_plugins[0] if legacy_plugins else {}
+codex_plugins = codex_market.get("plugins", [])
+lean4_entries = [p for p in codex_plugins if p.get("name") == "lean4"]
+contribute_entries = [p for p in codex_plugins if p.get("name") == "lean4-contribute"]
+entry = lean4_entries[0] if lean4_entries else {}
+source = entry.get("source") if isinstance(entry.get("source"), dict) else {}
+policy = entry.get("policy") if isinstance(entry.get("policy"), dict) else {}
+source_path = source.get("path", "")
+repo_root = Path(repo_path).resolve()
+try:
+    resolved_source = (repo_root / source_path).resolve()
+    source_in_repo = (
+        resolved_source.is_dir()
+        and (resolved_source == repo_root or repo_root in resolved_source.parents)
+    )
+except (OSError, RuntimeError):
+    source_in_repo = False
+
+emit("plugin_version", plugin.get("version", ""))
+emit("plugin_desc", plugin.get("description", ""))
+emit("market_version", market.get("metadata", {}).get("version", ""))
+emit("market_plugin_desc", legacy.get("description", ""))
+emit("market_source", legacy.get("source", ""))
+emit("market_plugin_count", len(legacy_plugins))
+emit("codex_version", codex.get("version", ""))
+emit("codex_desc", codex.get("description", ""))
+emit("codex_name", codex.get("name", ""))
+emit("codex_skills", codex.get("skills", ""))
+emit("codex_hooks", codex.get("hooks", ""))
+emit("codex_semver", "yes" if re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", codex.get("version", "")) else "no")
+emit("codex_market_name", codex_market.get("name", ""))
+emit("codex_market_total", len(codex_plugins))
+emit("codex_market_plugin_count", len(lean4_entries))
+emit("codex_contribute_count", len(contribute_entries))
+emit("codex_source_type", source.get("source", ""))
+emit("codex_source_path", source_path)
+emit("codex_source_in_repo", "yes" if source_in_repo else "no")
+emit("codex_installation", policy.get("installation", ""))
+emit("codex_authentication", policy.get("authentication", ""))
+emit("codex_category", entry.get("category", ""))
+PY
+)
+
+    if [[ -z "$plugin_version" || -z "$codex_version" || -z "$market_version" ]]; then
+        warn "Could not parse release versions from Claude/Codex metadata"
         return
     fi
 
-    # Extract marketplace.json fields via python3
-    local market_version market_plugin_desc market_source market_plugin_count
-    market_version=$(grep -oE '"version": *"[^"]+"' "$marketplace_json" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-    market_plugin_desc=$(python3 -c "
-import json, sys
-data = json.load(open(sys.argv[1]))
-for p in data.get('plugins', []):
-    if p.get('name') == 'lean4':
-        print(p.get('description', '')); break
-" "$marketplace_json")
-    market_source=$(python3 -c "
-import json, sys
-data = json.load(open(sys.argv[1]))
-for p in data.get('plugins', []):
-    if p.get('name') == 'lean4':
-        print(p.get('source', '')); break
-" "$marketplace_json")
-    market_plugin_count=$(grep -c '"name": *"lean4"' "$marketplace_json")
-
-    # 1. Version match
+    # 1. Legacy marketplace version match.
     if [[ "$plugin_version" == "$market_version" ]]; then
         ok "marketplace version matches plugin.json ($plugin_version)"
     else
         warn "marketplace version ($market_version) != plugin.json ($plugin_version)"
     fi
 
-    # 2. Plugin description match
+    # 2. Codex plugin version and semver.
+    if [[ "$plugin_version" == "$codex_version" ]]; then
+        ok "Codex plugin version matches plugin.json ($plugin_version)"
+    else
+        warn "Codex plugin version ($codex_version) != plugin.json ($plugin_version)"
+    fi
+    if [[ "$codex_semver" == "yes" ]]; then
+        ok "Codex plugin version is strict semver"
+    else
+        warn "Codex plugin version is not strict semver: $codex_version"
+    fi
+
+    # 3. Plugin descriptions match the canonical Claude manifest.
     if [[ "$plugin_desc" == "$market_plugin_desc" ]]; then
         ok "marketplace plugin description matches plugin.json"
     else
         warn "marketplace plugin description differs from plugin.json"
     fi
+    if [[ "$plugin_desc" == "$codex_desc" ]]; then
+        ok "Codex plugin description matches plugin.json"
+    else
+        warn "Codex plugin description differs from plugin.json"
+    fi
 
-    # 3. Source path
+    # 4. Legacy marketplace source and count.
     if [[ "$market_source" == "./plugins/lean4" ]]; then
         ok "marketplace plugin source is ./plugins/lean4"
     else
         warn "unexpected marketplace plugin source: $market_source"
     fi
 
-    # 4. Single lean4 entry
     if [[ "$market_plugin_count" -eq 1 ]]; then
         ok "marketplace has exactly one lean4 plugin entry"
     else
         warn "expected 1 lean4 plugin entry in marketplace, found $market_plugin_count"
     fi
 
-    # 5. CHANGELOG entry
+    # 5. Codex manifest paths and identity.
+    if [[ "$codex_name" == "lean4" ]]; then
+        ok "Codex plugin name is lean4"
+    else
+        warn "unexpected Codex plugin name: $codex_name"
+    fi
+    if [[ "$codex_skills" == "./skills" ]]; then
+        ok "Codex plugin reuses ./skills"
+    else
+        warn "unexpected Codex skills path: $codex_skills"
+    fi
+    if [[ "$codex_hooks" == "./hooks/codex-hooks.json" ]]; then
+        ok "Codex plugin selects codex-hooks.json"
+    else
+        warn "unexpected Codex hooks path: $codex_hooks"
+    fi
+
+    # 6. Thin Codex marketplace shape.
+    if [[ "$codex_market_name" == "lean4-skills" ]]; then
+        ok "Codex marketplace name is lean4-skills"
+    else
+        warn "unexpected Codex marketplace name: $codex_market_name"
+    fi
+    if [[ "$codex_market_total" -eq 1 && "$codex_market_plugin_count" -eq 1 && "$codex_contribute_count" -eq 0 ]]; then
+        ok "Codex marketplace contains only the lean4 plugin"
+    else
+        warn "Codex marketplace must contain exactly one lean4 entry and no lean4-contribute entry"
+    fi
+    if [[ "$codex_source_type" == "local" \
+       && "$codex_source_path" == "./plugins/lean4" \
+       && "$codex_source_in_repo" == "yes" ]]; then
+        ok "Codex marketplace source is local ./plugins/lean4"
+    else
+        warn "unexpected or out-of-repository Codex marketplace source: $codex_source_type $codex_source_path"
+    fi
+    if [[ "$codex_installation" == "AVAILABLE" && "$codex_authentication" == "ON_INSTALL" ]]; then
+        ok "Codex marketplace policy metadata is complete"
+    else
+        warn "unexpected Codex marketplace policy: installation=$codex_installation authentication=$codex_authentication"
+    fi
+    if [[ "$codex_category" == "Coding" ]]; then
+        ok "Codex marketplace category is Coding"
+    else
+        warn "unexpected Codex marketplace category: $codex_category"
+    fi
+
+    # 7. CHANGELOG entry.
     if grep -q "## v${plugin_version}" "$changelog"; then
         ok "CHANGELOG v${plugin_version} entry present"
     else


### PR DESCRIPTION
Closes #157.
Supersedes #89.

## Summary

- add an in-place Codex manifest, thin marketplace, and dedicated Codex hook configuration
- make bootstrap, preflight, prompt validation, doctor guidance, and the canonical skill host-aware without mirroring skills or changing Claude hook configuration
- use truthful SessionStart absolute paths instead of persistent Codex environment or PATH claims
- extend release linting and CI coverage, and document the native Tier-3 install
- reconcile onto current `main` (`869f511`, v4.5.9) and release the adapter as **v4.5.10** (maintainer-pushed merge + retarget after PR #165 took v4.5.9; all three manifests synchronized)

## Verification

### Deterministic repository gates (rerun 2026-08-02 at `f885f56`)

- `test_codex_adapter.sh`: 8/8
- Claude/Codex bootstrap and preflight: 17/17 and 19/19
- prompt validation: 35/35; guardrails: 327/327
- wrapper runtime: 30/30; release-notes: 8/8; semantic contracts: 31/31
- release-lint probes: 6/6
- Python unit tests: 43/43
- runtime-portability self-tests: 62/62; axiom-inline: 30/30; unused-declarations: 10/10; Bash 3.2 smoke: 14/14
- pinned Ruff 0.15.13, pinned mypy 1.20.2, pinned actionlint 1.7.12, and the CI-equivalent ShellCheck invocation passed (local ShellCheck 0.11.0; CI pins 0.10.0)
- the full documentation lint now exits cleanly on this branch (the repository-wide warning baseline was resolved upstream); the Codex version-drift and release-note checks pass at v4.5.10

### Disposable real-Codex acceptance (original adapter runtime; unchanged by this upstream-docs merge)

- Codex CLI 0.144.6 installed the adapter from the worktree into a fresh disposable cache; the runtime was observed through Codex Desktop app-server 0.145.0-alpha.30
- before trust, `$lean4` remained discoverable while all three plugin hooks were reported untrusted and skipped
- the exact SessionStart, UserPromptSubmit, and PreToolUse commands were reviewed through the app-server hook listing and their hashes were explicitly trusted only in the disposable config (the app-server equivalent used because this run was mobile, not a claim that the `/hooks` UI was opened)
- SessionStart was observed for startup, a cold resume after app-server restart, a clear-source thread, and the first turn after successful compaction
- every SessionStart context path pointed under the disposable versioned plugin cache, never back to the source worktree, and reported `shell_env_persistent=false`
- the cached absolute preflight and a representative wrapper succeeded with all `LEAN4_*` variables unset and plugin `bin/` absent from PATH
- UserPromptSubmit passed an ordinary `$lean4` prompt, added context for a valid CLI-like invocation, and blocked an invalid invocation
- in a disposable Lean-project directory, PreToolUse allowed a harmless `printf` and blocked `git clean -fd -- <verified-nonexistent-target>` before execution; the target remained absent
- cache parity, no-symlink/no-mirror checks, and manifest selection of `codex-hooks.json` passed; no credentials or normal user cache were copied or logged

The exact disposable cache was not re-created because this reconciliation changes upstream documentation plus release metadata, not the previously accepted adapter runtime. The deterministic adapter and cache-shape contracts were rerun at the current head.

## Current GitHub status

- head `a8095a8` is mergeable against `main` at `869f511` (v4.5.9); the base includes PRs #163 and #165
- the PR is marked ready for review
- both `lint` and `bash3-compat` workflows ran at this head and completed fully green — all checks pass, including release-contract and macOS Bash 3.2

## Out of scope

- no mirrored package tree or generated focused skills
- no `lean4-contribute` packaging
- no `/lean4:*` slash-command parity claim
- PreToolUse remains advisory, project-scoped, and not an enforcement boundary


