### PR TITLE
fix(ci): release.yml invalid workflow file — ${{ }} in a comment broke the v4.5.6 release run; add actionlint gate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -129,6 +129,43 @@ jobs:
             plugins/lean4/tools/*.sh \
             plugins/lean4/bin/lean4-skills-*
 
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Static validation of the workflow files themselves — YAML
+      # shape, Actions expression syntax, action inputs. Added after an
+      # empty dollar-double-brace expression inside a *shell comment*
+      # in release.yml shipped an invalid workflow file to main (the
+      # v4.5.6 release run failed with "An expression was expected"):
+      # GitHub evaluates expressions anywhere in a value, comments
+      # included, plain YAML parsing can't see that class, and an
+      # invalid workflow file only surfaces post-merge as 0-second
+      # phantom run failures that never appear in PR checks. actionlint
+      # catches it pre-merge (its [expression] check flags exactly that
+      # error). Pinned exact like shellcheck below.
+      - name: Install actionlint 1.7.12
+        run: |
+          cd "$RUNNER_TEMP"
+          curl -fsSL \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz \
+            -o actionlint.tar.gz
+          tar -xzf actionlint.tar.gz actionlint
+          ./actionlint --version | head -1 | grep -Fxq '1.7.12'
+
+      # -ignore: actionlint 1.7.12's concurrency schema predates
+      # GitHub's opt-in queueing and misreports `queue: max` as an
+      # unknown key — GitHub itself accepts it (documented feature, and
+      # the live validator parsed past it when release.yml broke for
+      # the unrelated reason above). Drop the -ignore once actionlint
+      # learns the key.
+      - name: actionlint (.github/workflows)
+        run: |
+          "$RUNNER_TEMP/actionlint" \
+            -ignore 'unexpected key "queue" for "concurrency" section' \
+            .github/workflows/*.yml
+
   release-contract:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -160,11 +160,14 @@ jobs:
       # the live validator parsed past it when release.yml broke for
       # the unrelated reason above). Drop the -ignore once actionlint
       # learns the key.
+      # No positional file args: in a git repository actionlint
+      # auto-discovers .github/workflows/*.{yml,yaml}, so a future
+      # .yaml workflow can't silently escape the gate the way a *.yml
+      # glob would allow.
       - name: actionlint (.github/workflows)
         run: |
           "$RUNNER_TEMP/actionlint" \
-            -ignore 'unexpected key "queue" for "concurrency" section' \
-            .github/workflows/*.yml
+            -ignore 'unexpected key "queue" for "concurrency" section'
 
   release-contract:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,12 @@ jobs:
           version=$(python3 -c "import json; print(json.load(open('plugins/lean4/.claude-plugin/plugin.json'))['version'])")
           # Guard against a malformed manifest producing a garbage tag
           # like "v" or "vNone". Anchored X.Y.Z only — also keeps the
-          # value safe to interpolate into later ${{ }} expressions.
+          # value safe to interpolate into later workflow expressions.
+          # (Never write a literal dollar-double-brace in this file,
+          # even in a comment: the Actions expression parser evaluates
+          # it anywhere in a value, and an empty or malformed one makes
+          # the whole workflow file invalid — that exact mistake here
+          # broke the v4.5.6 release run.)
           echo "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' \
             || { echo "plugin.json version '$version' is not X.Y.Z" >&2; exit 1; }
           echo "version=$version" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What broke

The `release` workflow failed on the #158 merge commit with **`Invalid workflow file: (Line: 83, Col: 14): An expression was expected`** — no release was cut. Root cause: a shell comment in the version-guard step contained a literal empty `${{ }}`. GitHub's expression parser evaluates `${{ … }}` anywhere in a `run:` value, comments included, and an empty expression invalidates the entire file.

The file had been invalid since the concurrency-race commit: every branch push was producing 0-second phantom `release.yml` failures, but those never appear in `gh pr checks` (they're not PR check runs), and `yaml.safe_load` can't see expression errors — which is how it survived three review rounds and six green CI runs.

## Changes

- **release.yml** — comment reworded (and now warns against ever writing a literal `${{ }}` in the file).
- **New pinned `actionlint` job in lint.yml** (1.7.12, install pattern mirrors the shellcheck job) — verified against the broken file from main: its `[expression]` check flags exactly this error (line 83: "unexpected end of input while parsing…"). One documented `-ignore`: actionlint 1.7.12's schema predates GitHub's `queue: max` and misreports it as an unknown key — GitHub itself accepts the key (documented feature; its live validator parsed past line 55 to the real error at 83). Drop the ignore when actionlint learns the key.

No version bump: v4.5.6 is unreleased and this must land *before* its release is cut; bumping would orphan 4.5.6.

## Recovery plan for v4.5.6 (after this merges)

The fix's own push won't trigger `release` (plugin.json untouched — by design). To cut v4.5.6 with correct provenance:

1. `git tag v4.5.6 2835dcb && git push origin v4.5.6`  (the #158 squash commit = the version-bump commit)
2. `gh workflow run release` (on main)

The dispatch takes the designed recovery path: tag exists, release doesn't → validates ancestry + manifest version at the tag → publishes the release attached to `2835dcb` with notes extracted from *that* commit's CHANGELOG. Plain dispatch without the tag also works but would tag the fix commit instead of the bump commit.

## Testing

- actionlint 1.7.12 on the broken file (from main): flags line 83 `[expression]` — the exact incident error (plus the known `queue` false positive, covered by the `-ignore`).
- actionlint with the `-ignore` on the fixed tree: all three workflows clean.
- Grep for empty `${{ }}` across workflows: none. Both edited YAMLs parse.