### PR TITLE
docs(readme): trim the front door — identity, chooser, workflows, cycle, links

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -552,7 +552,7 @@ search and sub-second feedback. Works with any MCP-capable host. Setup: a few mi
 **One-time setup:** ~5 minutes. Highly recommended.
 
 Per-host MCP configuration (check each host's latest docs for current syntax):
-- **Claude Code** (run from your Lean project root): `claude mcp add --transport stdio --scope user lean-lsp -- uvx lean-lsp-mcp`
+- **Claude Code** (run from your Lean project root): `claude mcp add --transport stdio --scope user lean-lsp -- uvx lean-lsp-mcp`. Project-scoped alternative (shared with collaborators via `.mcp.json`): `claude mcp add --transport stdio --scope project lean-lsp -- uvx lean-lsp-mcp`. User scope is recommended — it has been more reliable for keeping the MCP tools visible inside proof-editing subagents; project-scoped servers may not propagate to plugin subagents in some Claude Code versions.
 - **Codex CLI:** Check [Codex docs](https://developers.openai.com/codex/) for MCP setup
 - **Gemini CLI:** Check [Gemini CLI docs](https://github.com/google-gemini/gemini-cli) for MCP setup
 - **OpenCode:** Check [OpenCode docs](https://opencode.ai/docs/) for MCP setup

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ others all use the same core skill; only the invocation surface differs.
 |---|---|---|---|
 | Claude Code | Native plugin (Tier 3) | Skill + `/lean4:*` commands, hooks, guardrails, subagents, helper runtime | [Claude Code](INSTALLATION.md#claude-code-native-plugin) |
 | Codex | Native plugin (Tier 3) | Skill + trusted hooks + absolute-path helper runtime; no `/lean4:*` parity | [Codex](INSTALLATION.md#openai-codex-cli) |
-| Other Agent Skills hosts (Gemini, Antigravity, Copilot, Cursor, Windsurf, OpenCode, …) | Skill-only quick install | Instructions + references (documented, not CI-verified) | [Host sections](INSTALLATION.md#installation-tiers) |
+| Other Agent Skills hosts (Gemini, Antigravity, Copilot, Cursor, Windsurf, OpenCode, …) | Skill-only quick install | Instructions + references (documented, not CI-verified) | [Installation guide](INSTALLATION.md) |
 | Any host, full runtime | Portable checkout (Tier 2) | Skill + wrappers + helper scripts | [Portable](INSTALLATION.md#portable-checkout--helper-runtime-all-hosts) |
 
-**Claude Code:**
+**Claude Code** (run in chat):
 
-```bash
+```text
 /plugin marketplace add cameronfreer/lean4-skills
 /plugin install lean4
 ```
@@ -58,13 +58,15 @@ CLI-like inputs to the seven parameter-heavy commands are validated by a host-ag
 
 ## The Shared Proof Cycle
 
-The proof engines all run one cycle — **Plan → Work → Checkpoint → Review → Replan → Continue/Stop** — where each sorry gets a mathlib search, tactic attempts, and validation, and being stuck forces a review + replan. Statement and header changes belong to the synthesis workflows (`formalize` / `autoformalize`); `prove` and `autoprove` keep declaration headers immutable. Editing `.lean` files without a command runs one bounded pass — fix the immediate issue, then hand off to the right workflow — with the [Blocked-Goal Triage loop](plugins/lean4/skills/lean4/references/sorry-filling.md#blocked-goal-triage) for a goal that resists it. Details: [cycle-engine.md](plugins/lean4/skills/lean4/references/cycle-engine.md).
+The proving workflows (`prove`, `autoprove`, `formalize`, and `autoformalize`) share one cycle — **Plan → Work → Checkpoint → Review → Replan → Continue/Stop** — where each sorry gets a mathlib search, tactic attempts, and validation, and being stuck forces a review + replan. Statement and header changes belong to the synthesis workflows (`formalize` / `autoformalize`); `prove` and `autoprove` keep declaration headers immutable. Editing `.lean` files without a command runs one bounded pass — fix the immediate issue, then hand off to the right workflow — with the [Blocked-Goal Triage loop](plugins/lean4/skills/lean4/references/sorry-filling.md#blocked-goal-triage) for a goal that resists it. Details: [cycle-engine.md](plugins/lean4/skills/lean4/references/cycle-engine.md).
+
+## Verification
 
 CI gates every PR: full documentation lint, semantic contract suites, hook and wrapper runtime tests on Linux and macOS Bash 3.2, and pinned shellcheck/ruff/mypy/actionlint. Hosts marked "documented" in the Quick Start table follow verified setup patterns but are not CI-tested.
 
 ## Lean LSP MCP (Optional, Recommended)
 
-The skill works standalone, but pairs best with [lean-lsp-mcp](https://github.com/oOo0oOo/lean-lsp-mcp): live goal inspection, mathlib search, and typically much faster feedback than repeated full builds. See [INSTALLATION.md → MCP Server](INSTALLATION.md#lean-lsp-mcp-server-all-hosts) for registration on any host, including the Claude Code scope choice that keeps the tools visible inside proof-editing subagents.
+The skill works standalone, but pairs best with [lean-lsp-mcp](https://github.com/oOo0oOo/lean-lsp-mcp): live goal inspection, mathlib search, and typically much faster feedback than repeated full builds. See [INSTALLATION.md → MCP Server](INSTALLATION.md#lean-lsp-mcp-server-all-hosts) for registration on any host, including the Claude Code scope trade-off for subagent visibility.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,34 @@ prove/review/golf loop, mathlib search, axiom checking, and safety guardrails.
 The workflows are host-agnostic — Claude Code, Codex, Gemini CLI, Cursor, and
 others all use the same core skill; only the invocation surface differs.
 
+## Quick Start
+
+| Host | Recommended installation | What you get | Details |
+|---|---|---|---|
+| Claude Code | Native plugin (Tier 3) | Skill + `/lean4:*` commands, hooks, guardrails, subagents, helper runtime | [Claude Code](INSTALLATION.md#claude-code-native-plugin) |
+| Codex | Native plugin (Tier 3) | Skill + trusted hooks + absolute-path helper runtime; no `/lean4:*` parity | [Codex](INSTALLATION.md#openai-codex-cli) |
+| Other Agent Skills hosts (Gemini, Antigravity, Copilot, Cursor, Windsurf, OpenCode, …) | Skill-only quick install | Instructions + references (documented, not CI-verified) | [Host sections](INSTALLATION.md#installation-tiers) |
+| Any host, full runtime | Portable checkout (Tier 2) | Skill + wrappers + helper scripts | [Portable](INSTALLATION.md#portable-checkout--helper-runtime-all-hosts) |
+
+**Claude Code:**
+
+```bash
+/plugin marketplace add cameronfreer/lean4-skills
+/plugin install lean4
+```
+
+**Codex** (in your shell):
+
+```bash
+codex plugin marketplace add cameronfreer/lean4-skills --ref main
+codex plugin add lean4@lean4-skills
+```
+
+> Host-native skill installers generally provide the instructions and
+> references only. Use the portable runtime when you also need the bundled
+> wrappers and scripts; Claude Code and Codex provide native full-plugin
+> installations.
+
 ## Workflows
 
 | Workflow | Description |
@@ -24,177 +52,33 @@ others all use the same core skill; only the invocation surface differs.
 
 **Claude Code:** invoke as `/lean4:<name>`. **Other hosts:** follow the corresponding workflow in [SKILL.md](plugins/lean4/skills/lean4/SKILL.md).
 
-Typical session: `draft` (or `formalize` / `autoformalize`) → `prove` (or `autoprove`) → `review` → `refactor` → `golf` → `checkpoint` → `git push`. Use `disprove` instead of `prove` when you want to refute a statement rather than prove it.
+Typical session: `draft` (or `formalize` / `autoformalize`) → `prove` (or `autoprove`) → `review` → `refactor` → `golf` → `checkpoint` → `git push`. Use `disprove` instead of `prove` to refute a statement rather than prove it.
 
-CLI-like inputs are validated by a host-agnostic parser
-(`plugins/lean4/lib/command_args/`) for the seven parameter-heavy commands
-(`draft`, `learn`, `formalize`, `autoformalize`, `prove`, `autoprove`,
-`disprove`). The
-Claude Code adapter pre-validates `/lean4:*` prompts via a `UserPromptSubmit`
-hook; other hosts fall back to model-parsed startup. Commands must announce
-resolved inputs, reject invalid startup configs, and treat wall-clock budgets
-as best-effort rather than host-enforced timeouts. See the
-[Command Invocation Contract](plugins/lean4/skills/lean4/references/command-invocation.md).
+CLI-like inputs to the seven parameter-heavy commands are validated by a host-agnostic parser — see the [Command Invocation Contract](plugins/lean4/skills/lean4/references/command-invocation.md).
 
-## How It Works
+## The Shared Proof Cycle
 
-- **`draft`** — Skeleton-only drafting from informal claims. Use when you want Lean declarations without a full prove run.
-- **`formalize`** — Interactive synthesis. Drafts a skeleton, then runs guided prove cycles with user interaction.
-- **`autoformalize`** — Autonomous synthesis. Extracts claims from a source, drafts skeletons, and proves them unattended.
-- **`prove`** — Guided proof engine for existing declarations. Asks preferences at startup, prompts before each commit, pauses between cycles.
-- **`autoprove`** — Autonomous proof engine for existing declarations. Auto-commits, loops until a stop budget fires (max cycles, wall-clock budget, or stuck). The wall-clock budget is checked between cycles; it is not a host timeout.
-- **`disprove`** — Guided counterexample-search engine for existing declarations. Each cycle's Plan phase generates dynamic Step 0 (knowledge search) / Step 1 (method) / Step 2 (config) menus seeded by accumulated evidence. Reports `REFUTED` **only** when Lean typechecks a proof of the negation; otherwise `WITNESS_UNCERTIFIED` (candidate but uncertified) or `INCONCLUSIVE` (no candidate within budgets). Append-only: never rewrites an existing `theorem T : P := by sorry`.
-- The proof engines share one cycle engine: **Plan → Work → Checkpoint → Review → Replan → Continue/Stop**. Each sorry gets a mathlib search, tactic attempts, and validation. `--commit` controls per-fill commit behavior. When stuck, both force a review + replan.
-- `formalize` and `autoformalize` wrap drafting around that same engine. Statement and header changes belong there — `prove` and `autoprove` keep declaration headers immutable.
-- Editing `.lean` files without a command activates the skill for one bounded pass — fix the immediate issue, then suggest the right next command: `draft` / `formalize` for statement work, `prove` / `autoprove` for proof work. If the agent needs short "what should I try next?" triage on a blocked goal, the skill's [Blocked-Goal Triage loop](plugins/lean4/skills/lean4/references/sorry-filling.md#blocked-goal-triage) covers it.
+The proof engines all run one cycle — **Plan → Work → Checkpoint → Review → Replan → Continue/Stop** — where each sorry gets a mathlib search, tactic attempts, and validation, and being stuck forces a review + replan. Statement and header changes belong to the synthesis workflows (`formalize` / `autoformalize`); `prove` and `autoprove` keep declaration headers immutable. Editing `.lean` files without a command runs one bounded pass — fix the immediate issue, then hand off to the right workflow — with the [Blocked-Goal Triage loop](plugins/lean4/skills/lean4/references/sorry-filling.md#blocked-goal-triage) for a goal that resists it. Details: [cycle-engine.md](plugins/lean4/skills/lean4/references/cycle-engine.md).
 
-See [plugin README](plugins/lean4/README.md) for the full command guide.
+CI gates every PR: full documentation lint, semantic contract suites, hook and wrapper runtime tests on Linux and macOS Bash 3.2, and pinned shellcheck/ruff/mypy/actionlint. Hosts marked "documented" in the Quick Start table follow verified setup patterns but are not CI-tested.
 
-## Installation
+## Lean LSP MCP (Optional, Recommended)
 
-### Claude Code (native plugin)
-
-```bash
-/plugin marketplace add cameronfreer/lean4-skills
-/plugin install lean4
-```
-
-Optionally, install the contribution helper to draft bug reports, feature requests, or shareable insights from your editor:
-
-```bash
-/plugin install lean4-contribute
-```
-
-### Codex
-
-Native plugin install (Tier 3) — run in your shell:
-
-```bash
-codex plugin marketplace add cameronfreer/lean4-skills --ref main
-codex plugin add lean4@lean4-skills
-```
-
-Review the installed hook in `/hooks`, then start a new Codex task. Invoke the
-skill with `$lean4`; trusted SessionStart context supplies absolute helper
-paths without modifying your shell profile or PATH. The Bash PreToolUse hook
-is advisory, and Codex does not register the Claude `/lean4:*` commands.
-
-Core-skill-only fallback — run this in Codex chat, not in your shell:
-
-```text
-$skill-installer Install the `lean4` skill from
-https://github.com/cameronfreer/lean4-skills/tree/main/plugins/lean4/skills/lean4
-```
-
-This fallback installs instructions and references without helper scripts or
-hooks. See [INSTALLATION.md → Codex](INSTALLATION.md#openai-codex-cli) for
-trust, verification, update, and portable-checkout details.
-
-### Other Hosts
-
-Every major host now discovers Agent Skills natively. The recommended
-full setup is one checkout + one symlink + one env block
-([details](INSTALLATION.md#portable-checkout--helper-runtime-all-hosts)):
-
-```bash
-git clone https://github.com/cameronfreer/lean4-skills.git "$HOME/.local/share/lean4-skills"
-mkdir -p "$HOME/.agents/skills"
-src="$HOME/.local/share/lean4-skills/plugins/lean4/skills/lean4"
-dest="$HOME/.agents/skills/lean4"
-if [ -e "$dest" ] && [ ! -L "$dest" ]; then   # back up a prior copy — ln can't replace a real directory
-  if mv "$dest" "$dest.bak-$(date +%Y%m%d%H%M%S)-$$"; then
-    ln -sfn "$src" "$dest"
-  else
-    printf 'Could not back up %s; leaving it unchanged.\n' "$dest" >&2
-  fi
-else
-  ln -sfn "$src" "$dest"
-fi
-```
-
-(Antigravity CLI's global skills live outside `~/.agents/skills` — see
-[INSTALLATION.md → Antigravity](INSTALLATION.md#antigravity-cli) for its separate link.)
-
-Skill-only quick installs and host specifics ([what "skill-only" excludes](INSTALLATION.md#installation-tiers)):
-
-- **Gemini CLI** (Enterprise/API-key; consumer access moved to Antigravity, June 2026) — `gemini skills install https://github.com/cameronfreer/lean4-skills.git --path plugins/lean4/skills/lean4 --scope user`. See [INSTALLATION.md → Gemini](INSTALLATION.md#gemini-cli)
-- **Antigravity CLI** — `gh skill install cameronfreer/lean4-skills lean4@main --agent antigravity-cli --scope user` (gh ≥ 2.96.0). See [INSTALLATION.md → Antigravity](INSTALLATION.md#antigravity-cli)
-- **GitHub Copilot** — `gh skill install cameronfreer/lean4-skills lean4@main --agent github-copilot --scope user` (gh ≥ 2.92.0). See [INSTALLATION.md → Copilot](INSTALLATION.md#github-copilot)
-- **Cursor** — native skills (`.agents/skills` / `.cursor/skills`); invoke with `/lean4`. See [INSTALLATION.md → Cursor](INSTALLATION.md#cursor)
-- **Windsurf** — native skills; invoke with `@lean4`. See [INSTALLATION.md → Windsurf](INSTALLATION.md#windsurf)
-- **OpenCode** — native `skill` tool; discovers `.agents/skills`. See [INSTALLATION.md → OpenCode](INSTALLATION.md#opencode)
-- **Other agents** — point agent at SKILL.md + env block. See [INSTALLATION.md → Generic](INSTALLATION.md#any-agent-generic)
-
-## Lean LSP MCP Server (Optional, Highly Recommended)
-
-The skill works standalone, but plays especially well with [lean-lsp-mcp](https://github.com/oOo0oOo/lean-lsp-mcp) — faster mathlib search and **sub-second feedback** instead of 30+ second `lake build` cycles. Works with any MCP-capable host.
-
-**What you get:**
-- `lean_goal` — exact goal state at any line
-- `lean_local_search` / `lean_leanfinder` / `lean_leansearch` / `lean_loogle` — mathlib search
-- `lean_multi_attempt` — test multiple tactics in parallel
-- `lean_hammer_premise` — premise suggestions for simp/aesop/grind
-- `lean_diagnostic_messages` — per-file error/warning check without a full `lake build`
-- …and more (hover info, goal-conditioned search, state inspection, etc.)
-
-**Claude Code** (run from your Lean project root):
-```bash
-# User-scoped — available in all your projects
-claude mcp add --transport stdio --scope user lean-lsp -- uvx lean-lsp-mcp
-
-# Or project-scoped — shared via .mcp.json
-claude mcp add --transport stdio --scope project lean-lsp -- uvx lean-lsp-mcp
-```
-
-> **Tip:** User-scoped (`--scope user`) is recommended — it has been more reliable
-> for keeping MCP tools visible inside proof-editing subagents. Project-scoped
-> servers may not propagate to plugin subagents in some Claude Code versions.
-
-**Other hosts:** See [INSTALLATION.md → MCP Server](INSTALLATION.md#lean-lsp-mcp-server-all-hosts)
-
-## Compatibility
-
-| Host | Status | Workflow |
-|---|---|---|
-| Claude Code | Full native | SKILL.md + scripts + `/lean4:*` commands, hooks, guardrails, subagents |
-| Codex | Native plugin | SKILL.md + absolute-path helper runtime + trusted hooks; no `/lean4:*` command parity |
-| Gemini / Antigravity / OpenCode / Copilot | Documented\* | Native Agent Skills discovery (+ scripts via portable checkout) |
-| Cursor / Windsurf | Documented\* | Native Agent Skills discovery (+ scripts via portable checkout) |
-
-\*Documented setup patterns, not CI-verified.
+The skill works standalone, but pairs best with [lean-lsp-mcp](https://github.com/oOo0oOo/lean-lsp-mcp): live goal inspection, mathlib search, and typically much faster feedback than repeated full builds. See [INSTALLATION.md → MCP Server](INSTALLATION.md#lean-lsp-mcp-server-all-hosts) for registration on any host, including the Claude Code scope choice that keeps the tools visible inside proof-editing subagents.
 
 ## Documentation
 
-- [INSTALLATION.md](INSTALLATION.md) - Setup guide
-
-**lean4 plugin**
-- [SKILL.md](plugins/lean4/skills/lean4/SKILL.md) - Core skill reference
-- [Commands](plugins/lean4/commands/) - Command documentation
-- [References](plugins/lean4/skills/lean4/references/) - cycle engine, mathlib style, proof golfing, tactic patterns, grind, metaprogramming, and more
-
-**lean4-contribute plugin** — opt-in helper for filing issues on this repo from your editor
-- [README](plugins/lean4-contribute/README.md) - Full command guide and privacy details
-- `/lean4-contribute:bug-report` — draft a bug report (plugin bugs, not Lean/mathlib issues)
-- `/lean4-contribute:feature-request` — request a workflow the plugin doesn't support yet
-- `/lean4-contribute:share-insight` — share a reusable pattern or antipattern from your session
-
----
-
-- [CHANGELOG.md](CHANGELOG.md) - Version history
-- Migrating from v3 (Claude Code): see [MIGRATION.md](plugins/lean4/MIGRATION.md)
-
-## Changelog
-
-See [CHANGELOG.md](CHANGELOG.md) for version history.
+- [INSTALLATION.md](INSTALLATION.md) — installation tiers, host sections, MCP setup
+- [SKILL.md](plugins/lean4/skills/lean4/SKILL.md) — core skill reference
+- [Commands](plugins/lean4/commands/) — command documentation
+- [References](plugins/lean4/skills/lean4/references/) — cycle engine, mathlib style, proof golfing, tactic patterns, grind, metaprogramming, and more
+- [lean4-contribute](plugins/lean4-contribute/README.md) — opt-in helper for filing bug reports, feature requests, and insights from your editor
+- [CHANGELOG.md](CHANGELOG.md) — version history
+- [MIGRATION.md](plugins/lean4/MIGRATION.md) — migrating from v3 (Claude Code)
 
 ## Contributing
 
-Issues and PRs welcome at https://github.com/cameronfreer/lean4-skills.
-
-If you have the `lean4-contribute` plugin installed, your coding agent may
-suggest filing bug reports, feature requests, or sharing insights at natural
-stopping points. Drafting starts only after you opt in; submission has its own
-separate confirmation. Each draft is shown in full before anything is sent.
+Issues and PRs welcome at https://github.com/cameronfreer/lean4-skills. With the `lean4-contribute` plugin installed, your agent may suggest filing bug reports, feature requests, or insights at natural stopping points — drafting starts only after you opt in, and every draft is shown in full before anything is sent.
 
 ## License & Citation
 


### PR DESCRIPTION
## Summary

Root-README trim per the portfolio review: **213 → 97 lines**, almost entirely deletion-plus-links — everything removed already had a canonical owner, so this is de-duplication, not migration. PR 1 of 2; the follow-up (plugin README trim + `GUARDRAILS.md` + lint ownership move) carries the version bump.

New shape: **Identity → Quick Start → Workflows → The Shared Proof Cycle → Verification → Lean LSP MCP → Documentation → Contributing → License & Citation.**

## Dispositions

| Was | Now |
|---|---|
| Per-host install commands + version floors (Gemini/Antigravity/Copilot/Cursor/Windsurf/OpenCode) | 4-row chooser (drift-prone specifics stay in INSTALLATION.md); Claude + Codex native commands kept as two code blocks |
| Portable symlink script | Deleted — verbatim duplicate of INSTALLATION.md's canonical block |
| "How It Works" per-engine bullets | 5-line Shared Proof Cycle (header-immutability split, stuck rule, bounded no-command pass + Blocked-Goal Triage link) → details in cycle-engine.md / plugin README |
| Parser/startup-contract paragraph | One sentence + command-invocation.md link |
| MCP tool inventory + registration commands | Two sentences with a qualified speed claim; the **project-scoped variant + subagent-visibility tip** (the only root-exclusive MCP content) moved into INSTALLATION.md's MCP section rather than deleted |
| Compatibility table | Absorbed as the chooser's "What you get" column + one CI sentence (no test counts) |
| Two changelog pointers, lean4-contribute command list | One Documentation list, one CHANGELOG link, one-line lean4-contribute pointer |
| Tier distinction | Kept as one durable warning blockquote (skill-only ≠ full runtime — the #154 truthfulness point) |
| BibTeX block | **Retained by maintainer decision** (citation visibility), alongside the CITATION.cff link |

## Testing

- `lint_docs.sh` all checks pass; `test_contracts.sh` 32/32 (Check 30 clean on the new text); snippet smoke clean — all with `LEAN4_PLUGIN_ROOT` cleared.
- Anchor sweep: the only repo-wide `README.md#` reference targets the lean4-contribute plugin README (untouched); all five INSTALLATION.md anchors used by the chooser verified against existing usage or GitHub's anchor rules.
- No version bump and no CHANGELOG entry by design — release lands with PR 2.
