### PR TITLE
docs: mathlib review taxonomy — second Track 2 item (v4.6.8; closes #114, closes #60)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Lean 4 theorem proving with guided + autonomous proving, LSP-first workflows, guardrails, and contribution helpers",
-    "version": "4.6.7"
+    "version": "4.6.8"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v4.6.8 (August 2026)
+
+Mathlib review taxonomy — second Track 2 item (Refs #151; closes #114, closes #60). A reference file, not a runtime behavior change; it names the vocabulary that the schema (#115) and the broadened `/lean4:review` (#110) will build on.
+
+### Added
+
+- **`references/mathlib-review-taxonomy.md`** — what mathlib reviewers actually ask for, in nine buckets (surface style; **naming & namespace**, promoted to its own bucket; documentation; file placement / import hygiene; API / generalization; attributes / `simp`; instances; generated-file / module-system chores; metadata / process), each with what-reviewers-mean / cheap / annoying fixes and a recent-PR example. Cross-links existing references (`mathlib-style.md`, `simp-reference.md`, `instance-pollution.md`) rather than duplicating; bucket 8 links the **shipped** tooling by durable path — the canonical header template (`mathlib-style.md § 1`), the checkpoint `mk_all` gate (`checkpoint.md`), and module-system troubleshooting (`compilation-errors.md` §16–§19 via `/lean4:diagnose`).
+- **Vacuous-API rule (closes #60)** in bucket 5 — flags a *public declaration presenting as substantive API but whose conclusion collapses to `True` or is otherwise vacuous*, scoped **semantically** (not any `True`/`trivial` use, and not `sorry`-scaffolding); delete-or-replace is a *proposed* remedy surfaced as an **advisory** finding, never an automatic edit. Settled mapping `category: api` / `rule_id: vacuous-api` / `severity: advisory`; other buckets carry *illustrative* candidate mappings only — #115 owns the final enums, nothing here freezes the schema.
+- Navigational pointers from `SKILL.md`, `commands/review.md`, and `mathlib-guide.md`. The `review.md` pointer states explicitly that this is background material and **does not** change `/lean4:review`'s behavior — deciding when the buckets become emitted findings is #110's job. Contract test Check 35 pins the structure, the vacuous-api rule, the durable links (never `/lean4:doctor`), the schema-deferral, and the three pointers.
+
 ## v4.6.7 (August 2026)
 
 Workflow-scoped docstring policy — the first Track 2 (mathlib-aware review) item (Refs #151; closes #54, closes #116). Replaces the single blanket "docstrings are off-limits" rule with three mode-scoped rules, and folds in the specific development-history anti-patterns #54 catalogued.

--- a/plugins/lean4/.claude-plugin/plugin.json
+++ b/plugins/lean4/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lean4",
-  "version": "4.6.7",
+  "version": "4.6.8",
   "description": "Unified Lean 4 plugin (draft, formalize, autoformalize, prove, autoprove, disprove, checkpoint, review, refactor, golf, learn, diagnose) — LSP-first, scripts fallback",
   "author": {"name": "Cameron Freer", "email": "cameronfreer@gmail.com"}
 }

--- a/plugins/lean4/.codex-plugin/plugin.json
+++ b/plugins/lean4/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lean4",
-  "version": "4.6.7",
+  "version": "4.6.8",
   "description": "Unified Lean 4 plugin (draft, formalize, autoformalize, prove, autoprove, disprove, checkpoint, review, refactor, golf, learn, diagnose) — LSP-first, scripts fallback",
   "author": {
     "name": "Cameron Freer",

--- a/plugins/lean4/commands/review.md
+++ b/plugins/lean4/commands/review.md
@@ -328,4 +328,5 @@ See [Codex SDK Cookbook](https://cookbook.openai.com/examples/codex/build_code_r
 - `/lean4:disprove` - Guided counterexample search with certified refutation
 - `/lean4:golf` - Apply golfing optimizations
 - [mathlib-style.md](../skills/lean4/references/mathlib-style.md)
+- [mathlib-review-taxonomy.md](../skills/lean4/references/mathlib-review-taxonomy.md) — reference for what mathlib reviewers ask for. This is background material only: it does **not** change `/lean4:review`'s current behavior; deciding when these buckets become emitted findings is Issue #110.
 - [Examples](../skills/lean4/references/command-examples.md#review)

--- a/plugins/lean4/skills/lean4/SKILL.md
+++ b/plugins/lean4/skills/lean4/SKILL.md
@@ -407,6 +407,8 @@ lean4-skills-sorry-analyzer . --report-only
 
 **Search:** [mathlib-guide](references/mathlib-guide.md) (read when searching for existing lemmas), [lean-phrasebook](references/lean-phrasebook.md) (math→Lean translations)
 
+**Review:** [mathlib-review-taxonomy](references/mathlib-review-taxonomy.md) (what mathlib reviewers ask for — the nine review buckets)
+
 **Errors:** [compilation-errors](references/compilation-errors.md) (read first for any build error), [instance-pollution](references/instance-pollution.md) (typeclass conflicts — grep `## Sub-` for patterns), [compiler-guided-repair](references/compiler-guided-repair.md) (escalation-only repair — not first-pass)
 
 **Tactics:** [tactics-reference](references/tactics-reference.md) (tactic lookup — grep `^### TacticName`), [grind-tactic](references/grind-tactic.md) (SMT-style automation — when simp can't close), [simp-reference](references/simp-reference.md) (mechanism choice, simp normal forms, `@[simp]` hygiene, simproc authoring), [tactic-patterns](references/tactic-patterns.md), [calc-patterns](references/calc-patterns.md)

--- a/plugins/lean4/skills/lean4/references/mathlib-guide.md
+++ b/plugins/lean4/skills/lean4/references/mathlib-guide.md
@@ -2,6 +2,8 @@
 
 This reference provides comprehensive guidance for finding, importing, and using mathlib lemmas effectively.
 
+> For what mathlib *reviewers* ask for (style, docs, placement, API, `simp`, instances, generated-file chores), see the companion [mathlib-review-taxonomy.md](mathlib-review-taxonomy.md).
+
 ## Philosophy: Search Before Prove
 
 **DON'T:** Spend hours proving something mathlib already has

--- a/plugins/lean4/skills/lean4/references/mathlib-review-taxonomy.md
+++ b/plugins/lean4/skills/lean4/references/mathlib-review-taxonomy.md
@@ -12,10 +12,15 @@ results, weakest assumptions, `@[simp]` choices, instance design, and
 generated-file chores. The buckets below name that vocabulary and cross-link
 the existing references instead of duplicating them.
 
-**On the category / rule_id / severity tags below:** these are
-*illustrative candidate mappings*, not a schema. They keep this taxonomy
-aligned with the eventual machine-readable review output. Only
-`api` / `vacuous-api` / `advisory` (bucket 5) is settled.
+**On the category / rule_id / severity tags below:** conceptual review
+buckets and machine-readable categories are **not one-to-one** — one bucket
+may map to several schema categories. The tags are
+*illustrative candidate mappings*, not a schema; they track the provisional
+enum in Issue #115
+(`style`, `naming`, `docstring`, `module-doc`, `file-placement`,
+`import-hygiene`, `api`, `generalization`, `attribute`, `simp`, `instance`,
+`module-system`, `metadata`). Only the vacuous-API rule's full triple is
+settled — `category: api`, `rule_id: vacuous-api`, `severity: advisory`.
 Issue #115 owns the final enums and severity semantics; nothing here freezes
 the review schema.
 
@@ -50,20 +55,27 @@ governed by the workflow-scoped policy (Rule A/B/C) in
 [SKILL.md](../SKILL.md); review flags and proposes wording but never mutates
 (Rule B). What counts as development-history language lives in
 [mathlib-style.md § Avoid Development History References](mathlib-style.md#avoid-development-history-references).
-*Candidate:* `category: docs`.
+*Candidate:* `category: docstring` / `module-doc`.
 
 ## 4. File placement / import hygiene
 
-**Reviewers mean:** does the declaration live in the lowest sensible module?
-Are the imports heavier than needed? **Cheap:** drop an unused import.
-**Annoying:** move a declaration to a new file and fix downstream imports.
-**Example:** [mathlib4#33420](https://github.com/leanprover-community/mathlib4/pull/33420) (`Change mathlib imports from OrderType`), [mathlib4#35906](https://github.com/leanprover-community/mathlib4/pull/35906)
-(`rename the file name`). *Candidate:* `category: placement`.
+**Reviewers mean:** does an **equivalent or more-general result already
+exist** (search first — see [mathlib-guide.md](mathlib-guide.md))? If not,
+does the declaration live in the lowest sensible module, with the lightest
+reasonable imports? **Cheap:** drop an unused import. **Annoying:** move a
+declaration to a new file and fix downstream imports.
+**Example:** [mathlib4#33420](https://github.com/leanprover-community/mathlib4/pull/33420) (`Change mathlib imports from OrderType`; review also found declarations/instances that already existed), [mathlib4#35906](https://github.com/leanprover-community/mathlib4/pull/35906)
+(rename the file to match the moved declaration, e.g. `SimpleGraph/Walk/Chord.lean`).
+*Candidate:* `category: file-placement` / `import-hygiene`.
 
 ## 5. API / generalization
 
 **Reviewers mean:** the weakest reasonable hypotheses; `structure` vs a
-conjunction; natural generalizations the current form blocks.
+conjunction; natural generalizations the current form blocks; and whether a
+declaration is substantive at all. **Cheap:** remove an obviously unnecessary
+hypothesis, or delete an isolated vacuous placeholder. **Annoying:** generalize
+or redesign public API and migrate callers, or replace a depended-on
+placeholder with a substantive result.
 
 **Vacuous-API rule (absorbs Issue #60).** Flag a **public declaration that
 presents as substantive API but whose conclusion collapses to `True` or is
@@ -73,8 +85,8 @@ credibility. Scope it **semantically, not lexically**: this is *not* "any use
 of `True`/`trivial`" (many legitimate statements use them), and it explicitly
 does **not** cover `sorry`-scaffolding — the `sorry` linter already flags that.
 The **proposed** remedy is delete-or-replace (track the planned result in a
-blueprint or comment); it is surfaced as an **advisory** finding —
-never an automatic edit.
+blueprint or comment). Its settled review semantics are **advisory**: when
+emitted (by Issue #110), it is a suggestion, never an automatic edit.
 
 ```lean
 -- ❌ Vacuous: renders as a real theorem in doc-gen4, proves nothing.
@@ -83,16 +95,20 @@ theorem homDensity_concentration (W : Graphon α μ) (ε : ℝ) (hε : ε > 0) :
     ∃ N : ℕ, ∀ n ≥ N, True := ⟨1, fun _ _ => trivial⟩
 ```
 
-*Mapping (settled):* `category: api`, `rule_id: vacuous-api`, `severity: advisory`.
-**Example:** [mathlib4#35906](https://github.com/leanprover-community/mathlib4/pull/35906) (`IsChordless` as `def` vs `structure`).
+*Mapping (settled):* `category: api`, `rule_id: vacuous-api`, `severity: advisory`
+(the broader bucket also maps to `generalization`).
+**Example:** [mathlib4#35906](https://github.com/leanprover-community/mathlib4/pull/35906) — the review separated chordlessness from cyclehood, generalized it beyond closed walks, and weighed a bundled vs unbundled representation (`def` vs `structure`), landing `Walk.IsChordless` in `SimpleGraph/Walk/Chord.lean`.
 
 ## 6. Attributes / `simp`
 
-**Reviewers mean:** is `@[simp]` justified (confluent, terminating, good LHS)?
-Is `@[ext]` needed? Should this be `@[reducible]`? **Cheap:** drop an
-unjustified `@[simp]`. **Annoying:** re-derive a simp normal form. **Example:**
+**Reviewers mean:** is `@[simp]` globally canonical — an LHS already in simp
+normal form (it does not rewrite under the intended set *excluding the
+candidate lemma itself*), an RHS that reaches or approaches the chosen normal
+form, and no applicable cycle or conflicting rewrite? Is `@[ext]` needed?
+Should this be `@[reducible]`? **Cheap:** drop an unjustified `@[simp]`.
+**Annoying:** re-derive a simp normal form. **Example:**
 [mathlib4#33420](https://github.com/leanprover-community/mathlib4/pull/33420) (`Remove simp tag`, `Adding simp tag`). See
-[simp-reference.md](simp-reference.md). *Candidate:* `category: attribute`.
+[simp-reference.md](simp-reference.md). *Candidate:* `category: attribute` / `simp`.
 
 ## 7. Instances
 
@@ -114,14 +130,18 @@ the checkpoint gate in
 and error triage in
 [compilation-errors.md §16–§19](compilation-errors.md#16-cannot-import-non-module-from-module)
 (reachable via [`/lean4:diagnose`](../../../commands/diagnose.md)).
-*Candidate:* `category: integration`.
+*Candidate:* `category: module-system`.
 
 ## 9. Metadata / process
 
-**Reviewers mean:** PR title shape, description, labels, move/deletion
-metadata. **Out of runtime scope today** — `/lean4:review` has no GitHub PR
-context — but named so the vocabulary is complete for future GitHub-aware
-work. *Candidate:* `category: process`.
+**Reviewers mean:** PR title shape, description, labels, dependency
+declaration, and move/deletion metadata. **Out of runtime scope today** —
+`/lean4:review` has no GitHub PR context — but named so the vocabulary is
+complete for future GitHub-aware work. **Cheap:** repair the PR title,
+description, labels, dependency declaration, or omitted move/deletion
+metadata. **Annoying:** reconstruct move/deletion provenance after a large
+refactor. **Example:** [mathlib4#33420](https://github.com/leanprover-community/mathlib4/pull/33420)'s dependency checkbox and standard `Moves:` / `Deletions:` metadata contract.
+*Candidate:* `category: metadata`.
 
 ## See Also
 

--- a/plugins/lean4/skills/lean4/references/mathlib-review-taxonomy.md
+++ b/plugins/lean4/skills/lean4/references/mathlib-review-taxonomy.md
@@ -20,13 +20,13 @@ Issue #115 owns the final enums and severity semantics; nothing here freezes
 the review schema.
 
 Each bucket lists what reviewers usually mean, cheap fixes, annoying fixes,
-and one example from a recent mathlib PR (#33420, #33443, #35906).
+and one example from a recent mathlib PR ([mathlib4#33420](https://github.com/leanprover-community/mathlib4/pull/33420), [mathlib4#33443](https://github.com/leanprover-community/mathlib4/pull/33443), [mathlib4#35906](https://github.com/leanprover-community/mathlib4/pull/35906)).
 
 ## 1. Surface style
 
 **Reviewers mean:** line width, whitespace, tactic choices, `↦` vs `=>`.
 **Cheap:** reflow to 100 chars, fix spacing. **Annoying:** large tactic-block
-rewrites. **Example:** PR #33443 (100-char fixes). See
+rewrites. **Example:** [mathlib4#33443](https://github.com/leanprover-community/mathlib4/pull/33443) (100-char fixes). See
 [mathlib-style.md](mathlib-style.md). *Candidate:* `category: style`.
 
 ## 2. Naming & namespace
@@ -35,7 +35,7 @@ rewrites. **Example:** PR #33443 (100-char fixes). See
 types, `lowerCamelCase` for functions; dot-notation friendliness; the right
 namespace and depth so callers write `X.foo`, not `Foo.X.baz`. **Cheap:**
 rename a private lemma. **Annoying:** re-namespacing a public declaration that
-callers already use. **Example:** PR #35906 (naming discussion). See
+callers already use. **Example:** [mathlib4#35906](https://github.com/leanprover-community/mathlib4/pull/35906) (naming discussion). See
 [mathlib-style.md § 3 Naming Conventions](mathlib-style.md#3-naming-conventions).
 *Candidate:* `category: naming`.
 
@@ -45,7 +45,7 @@ callers already use. **Example:** PR #35906 (naming discussion). See
 proof sketch for genuinely intricate arguments, cross-references, no
 development-history language. **Cheap:** add a missing one-line docstring.
 **Annoying:** write a real module docstring for a large file. **Example:**
-PR #33420 (`Add doc-string and some more typos`). Docstring *editing* is
+[mathlib4#33420](https://github.com/leanprover-community/mathlib4/pull/33420) (`Add doc-string and some more typos`). Docstring *editing* is
 governed by the workflow-scoped policy (Rule A/B/C) in
 [SKILL.md](../SKILL.md); review flags and proposes wording but never mutates
 (Rule B). What counts as development-history language lives in
@@ -57,7 +57,7 @@ governed by the workflow-scoped policy (Rule A/B/C) in
 **Reviewers mean:** does the declaration live in the lowest sensible module?
 Are the imports heavier than needed? **Cheap:** drop an unused import.
 **Annoying:** move a declaration to a new file and fix downstream imports.
-**Example:** PR #33420 (`Change mathlib imports from OrderType`), PR #35906
+**Example:** [mathlib4#33420](https://github.com/leanprover-community/mathlib4/pull/33420) (`Change mathlib imports from OrderType`), [mathlib4#35906](https://github.com/leanprover-community/mathlib4/pull/35906)
 (`rename the file name`). *Candidate:* `category: placement`.
 
 ## 5. API / generalization
@@ -84,21 +84,21 @@ theorem homDensity_concentration (W : Graphon α μ) (ε : ℝ) (hε : ε > 0) :
 ```
 
 *Mapping (settled):* `category: api`, `rule_id: vacuous-api`, `severity: advisory`.
-**Example:** PR #35906 (`IsChordless` as `def` vs `structure`).
+**Example:** [mathlib4#35906](https://github.com/leanprover-community/mathlib4/pull/35906) (`IsChordless` as `def` vs `structure`).
 
 ## 6. Attributes / `simp`
 
 **Reviewers mean:** is `@[simp]` justified (confluent, terminating, good LHS)?
 Is `@[ext]` needed? Should this be `@[reducible]`? **Cheap:** drop an
 unjustified `@[simp]`. **Annoying:** re-derive a simp normal form. **Example:**
-PR #33420 (`Remove simp tag`, `Adding simp tag`). See
+[mathlib4#33420](https://github.com/leanprover-community/mathlib4/pull/33420) (`Remove simp tag`, `Adding simp tag`). See
 [simp-reference.md](simp-reference.md). *Candidate:* `category: attribute`.
 
 ## 7. Instances
 
 **Reviewers mean:** diamonds, instance loops, unification hazards, `Prop` vs
 `Type` instances. **Cheap:** add a missing `instance` docstring. **Annoying:**
-restructure a diamond. **Example:** PR #33420 (`Add docs to instance`). See
+restructure a diamond. **Example:** [mathlib4#33420](https://github.com/leanprover-community/mathlib4/pull/33420) (`Add docs to instance`). See
 [instance-pollution.md](instance-pollution.md). *Candidate:* `category: instance`.
 
 ## 8. Generated-file / module-system chores
@@ -106,7 +106,7 @@ restructure a diamond. **Example:** PR #33420 (`Add docs to instance`). See
 **Reviewers mean:** stale `Mathlib.lean` after add/rename/delete, a missing
 `module` header, wrong `public import` vs `import`. **Cheap:** run
 `lake exe mk_all`. **Annoying:** convert a file to the module system.
-**Example:** PR #33420 (`Run mk_all`, `Fix module error`, `Fix Mathlib.lean`).
+**Example:** [mathlib4#33420](https://github.com/leanprover-community/mathlib4/pull/33420) (`Run mk_all`, `Fix module error`, `Fix Mathlib.lean`).
 Shipped tooling covers this end to end: the canonical header in
 [mathlib-style.md § 1](mathlib-style.md#1-file-header-copyright-module-imports-critical),
 the checkpoint gate in

--- a/plugins/lean4/skills/lean4/references/mathlib-review-taxonomy.md
+++ b/plugins/lean4/skills/lean4/references/mathlib-review-taxonomy.md
@@ -15,11 +15,13 @@ the existing references instead of duplicating them.
 **On the category / rule_id / severity tags below:** conceptual review
 buckets and machine-readable categories are **not one-to-one** — one bucket
 may map to several schema categories. The tags are
-*illustrative candidate mappings*, not a schema; they track the provisional
-enum in Issue #115
+*illustrative candidate mappings*, not a schema; they are the taxonomy-facing
+subset of the enum in Issue #115
 (`style`, `naming`, `docstring`, `module-doc`, `file-placement`,
 `import-hygiene`, `api`, `generalization`, `attribute`, `simp`, `instance`,
-`module-system`, `metadata`). Only the vacuous-API rule's full triple is
+`module-system`, `metadata`) — which also retains proof-hygiene and
+compatibility values (`sorry`, `axiom`, `structure`, `golf`, `import`) that no
+bucket here maps to. Only the vacuous-API rule's full triple is
 settled — `category: api`, `rule_id: vacuous-api`, `severity: advisory`.
 Issue #115 owns the final enums and severity semantics; nothing here freezes
 the review schema.

--- a/plugins/lean4/skills/lean4/references/mathlib-review-taxonomy.md
+++ b/plugins/lean4/skills/lean4/references/mathlib-review-taxonomy.md
@@ -1,0 +1,132 @@
+# Mathlib Review Taxonomy
+
+What mathlib reviewers actually ask for, organized into buckets. This is a
+**reference**, not review behavior: it does not decide *when* `/lean4:review`
+emits a finding — that is [`/lean4:review`](../../../commands/review.md)'s job
+(Issue #110). Consult it any time; commands that want to use it selectively
+gate their own consumption.
+
+Modern mathlib review is more than surface style — a large fraction is
+**library-integration work**: file placement, import hygiene, duplicate
+results, weakest assumptions, `@[simp]` choices, instance design, and
+generated-file chores. The buckets below name that vocabulary and cross-link
+the existing references instead of duplicating them.
+
+**On the category / rule_id / severity tags below:** these are
+*illustrative candidate mappings*, not a schema. They keep this taxonomy
+aligned with the eventual machine-readable review output. Only
+`api` / `vacuous-api` / `advisory` (bucket 5) is settled.
+Issue #115 owns the final enums and severity semantics; nothing here freezes
+the review schema.
+
+Each bucket lists what reviewers usually mean, cheap fixes, annoying fixes,
+and one example from a recent mathlib PR (#33420, #33443, #35906).
+
+## 1. Surface style
+
+**Reviewers mean:** line width, whitespace, tactic choices, `↦` vs `=>`.
+**Cheap:** reflow to 100 chars, fix spacing. **Annoying:** large tactic-block
+rewrites. **Example:** PR #33443 (100-char fixes). See
+[mathlib-style.md](mathlib-style.md). *Candidate:* `category: style`.
+
+## 2. Naming & namespace
+
+**Reviewers mean:** `snake_case` for lemmas/theorems, `UpperCamelCase` for
+types, `lowerCamelCase` for functions; dot-notation friendliness; the right
+namespace and depth so callers write `X.foo`, not `Foo.X.baz`. **Cheap:**
+rename a private lemma. **Annoying:** re-namespacing a public declaration that
+callers already use. **Example:** PR #35906 (naming discussion). See
+[mathlib-style.md § 3 Naming Conventions](mathlib-style.md#3-naming-conventions).
+*Candidate:* `category: naming`.
+
+## 3. Documentation
+
+**Reviewers mean:** module and declaration docstrings on public API, a short
+proof sketch for genuinely intricate arguments, cross-references, no
+development-history language. **Cheap:** add a missing one-line docstring.
+**Annoying:** write a real module docstring for a large file. **Example:**
+PR #33420 (`Add doc-string and some more typos`). Docstring *editing* is
+governed by the workflow-scoped policy (Rule A/B/C) in
+[SKILL.md](../SKILL.md); review flags and proposes wording but never mutates
+(Rule B). What counts as development-history language lives in
+[mathlib-style.md § Avoid Development History References](mathlib-style.md#avoid-development-history-references).
+*Candidate:* `category: docs`.
+
+## 4. File placement / import hygiene
+
+**Reviewers mean:** does the declaration live in the lowest sensible module?
+Are the imports heavier than needed? **Cheap:** drop an unused import.
+**Annoying:** move a declaration to a new file and fix downstream imports.
+**Example:** PR #33420 (`Change mathlib imports from OrderType`), PR #35906
+(`rename the file name`). *Candidate:* `category: placement`.
+
+## 5. API / generalization
+
+**Reviewers mean:** the weakest reasonable hypotheses; `structure` vs a
+conjunction; natural generalizations the current form blocks.
+
+**Vacuous-API rule (absorbs Issue #60).** Flag a **public declaration that
+presents as substantive API but whose conclusion collapses to `True` or is
+otherwise vacuous** — e.g. `theorem foo ... : ∃ N, ∀ n ≥ N, True`. doc-gen4
+renders it identically to a real result, so it silently erodes the API's
+credibility. Scope it **semantically, not lexically**: this is *not* "any use
+of `True`/`trivial`" (many legitimate statements use them), and it explicitly
+does **not** cover `sorry`-scaffolding — the `sorry` linter already flags that.
+The **proposed** remedy is delete-or-replace (track the planned result in a
+blueprint or comment); it is surfaced as an **advisory** finding —
+never an automatic edit.
+
+```lean
+-- ❌ Vacuous: renders as a real theorem in doc-gen4, proves nothing.
+/-- Concentration of homomorphism density in sampled graphs. -/
+theorem homDensity_concentration (W : Graphon α μ) (ε : ℝ) (hε : ε > 0) :
+    ∃ N : ℕ, ∀ n ≥ N, True := ⟨1, fun _ _ => trivial⟩
+```
+
+*Mapping (settled):* `category: api`, `rule_id: vacuous-api`, `severity: advisory`.
+**Example:** PR #35906 (`IsChordless` as `def` vs `structure`).
+
+## 6. Attributes / `simp`
+
+**Reviewers mean:** is `@[simp]` justified (confluent, terminating, good LHS)?
+Is `@[ext]` needed? Should this be `@[reducible]`? **Cheap:** drop an
+unjustified `@[simp]`. **Annoying:** re-derive a simp normal form. **Example:**
+PR #33420 (`Remove simp tag`, `Adding simp tag`). See
+[simp-reference.md](simp-reference.md). *Candidate:* `category: attribute`.
+
+## 7. Instances
+
+**Reviewers mean:** diamonds, instance loops, unification hazards, `Prop` vs
+`Type` instances. **Cheap:** add a missing `instance` docstring. **Annoying:**
+restructure a diamond. **Example:** PR #33420 (`Add docs to instance`). See
+[instance-pollution.md](instance-pollution.md). *Candidate:* `category: instance`.
+
+## 8. Generated-file / module-system chores
+
+**Reviewers mean:** stale `Mathlib.lean` after add/rename/delete, a missing
+`module` header, wrong `public import` vs `import`. **Cheap:** run
+`lake exe mk_all`. **Annoying:** convert a file to the module system.
+**Example:** PR #33420 (`Run mk_all`, `Fix module error`, `Fix Mathlib.lean`).
+Shipped tooling covers this end to end: the canonical header in
+[mathlib-style.md § 1](mathlib-style.md#1-file-header-copyright-module-imports-critical),
+the checkpoint gate in
+[checkpoint.md § Generated Root Files gate](../../../commands/checkpoint.md#generated-root-files-gate),
+and error triage in
+[compilation-errors.md §16–§19](compilation-errors.md#16-cannot-import-non-module-from-module)
+(reachable via [`/lean4:diagnose`](../../../commands/diagnose.md)).
+*Candidate:* `category: integration`.
+
+## 9. Metadata / process
+
+**Reviewers mean:** PR title shape, description, labels, move/deletion
+metadata. **Out of runtime scope today** — `/lean4:review` has no GitHub PR
+context — but named so the vocabulary is complete for future GitHub-aware
+work. *Candidate:* `category: process`.
+
+## See Also
+
+- [mathlib-guide.md](mathlib-guide.md) — search-before-prove workflow (the
+  companion to this review guide)
+- [mathlib-style.md](mathlib-style.md) — formatting, naming, headers
+- [`/lean4:review`](../../../commands/review.md) — the review command that
+  will consume these buckets (Issue #110)

--- a/plugins/lean4/tools/test_contracts.sh
+++ b/plugins/lean4/tools/test_contracts.sh
@@ -1169,6 +1169,81 @@ if [[ "$check34_ok" -eq 1 ]]; then
     ok "Check 34: workflow-scoped docstring policy pinned (matrix, per-command boundaries, #54 content, no blanket rule)"
 fi
 
+# ---------------------------------------------------------------------------
+# Check 35: mathlib review taxonomy (#114 + #60). A reference file, not
+# runtime behavior; pin the nine-bucket structure, naming/namespace as its
+# own bucket, #60's semantically-scoped vacuous-api rule (the settled
+# category/rule_id/severity), bucket 8's durable shipped-reference links (not
+# closed issue numbers, and /lean4:diagnose never /lean4:doctor), the
+# schema-not-frozen note, and the three navigational pointers.
+# ---------------------------------------------------------------------------
+check35_ok=1
+_c35_tax="$PLUGIN_ROOT/skills/lean4/references/mathlib-review-taxonomy.md"
+if [[ ! -f "$_c35_tax" ]]; then
+    fail "Check 35: mathlib-review-taxonomy.md is missing"
+    check35_ok=0
+else
+    # Nine buckets (## 1. … ## 9.)
+    _c35_buckets=$(grep -cE '^## [1-9]\. ' "$_c35_tax")
+    if [[ "$_c35_buckets" -ne 9 ]]; then
+        fail "Check 35: expected 9 review buckets, found $_c35_buckets"
+        check35_ok=0
+    fi
+    # Naming & namespace is its own bucket, not folded into surface style.
+    if ! grep -qE '^## 2\. Naming & namespace' "$_c35_tax"; then
+        fail "Check 35: 'Naming & namespace' is not its own bucket"
+        check35_ok=0
+    fi
+    # #60 vacuous-api: settled triple + semantic (not lexical) scope + advisory
+    _c35_b5=$(extract_section "$_c35_tax" "## 5. API / generalization")
+    if ! echo "$_c35_b5" | grep -Fq 'vacuous-api' \
+        || ! echo "$_c35_b5" | grep -Fq 'category: api' \
+        || ! echo "$_c35_b5" | grep -Fq 'severity: advisory' \
+        || ! echo "$_c35_b5" | grep -Fq 'semantically, not lexically' \
+        || ! echo "$_c35_b5" | grep -Fq 'does **not** cover `sorry`-scaffolding' \
+        || ! echo "$_c35_b5" | grep -Fq 'never an automatic edit'; then
+        fail "Check 35: bucket 5 missing the semantically-scoped vacuous-api rule / settled mapping / advisory framing"
+        check35_ok=0
+    fi
+    # Bucket 8: durable shipped-reference links + /lean4:diagnose, never doctor.
+    _c35_b8=$(extract_section "$_c35_tax" "## 8. Generated-file / module-system chores")
+    if ! echo "$_c35_b8" | grep -Fq 'mathlib-style.md#1-file-header' \
+        || ! echo "$_c35_b8" | grep -Fq 'checkpoint.md#generated-root-files-gate' \
+        || ! echo "$_c35_b8" | grep -Fq 'compilation-errors.md#16' \
+        || ! echo "$_c35_b8" | grep -Fq '/lean4:diagnose'; then
+        fail "Check 35: bucket 8 missing a durable shipped-reference link or the /lean4:diagnose pointer"
+        check35_ok=0
+    fi
+    if grep -Fq 'lean4:doctor' "$_c35_tax"; then
+        fail "Check 35: taxonomy references the retired /lean4:doctor"
+        check35_ok=0
+    fi
+    # Schema not frozen — #115 owns the enums; other tags are illustrative.
+    if ! grep -Fq 'illustrative candidate mappings' "$_c35_tax" \
+        || ! grep -Fq 'Issue #115 owns the final enums' "$_c35_tax"; then
+        fail "Check 35: taxonomy does not mark non-settled category tags as illustrative / defer enums to #115"
+        check35_ok=0
+    fi
+fi
+# Three navigational pointers; review.md's must disclaim activation.
+if ! grep -Fq 'mathlib-review-taxonomy' "$PLUGIN_ROOT/skills/lean4/SKILL.md"; then
+    fail "Check 35: SKILL.md missing the taxonomy pointer"
+    check35_ok=0
+fi
+if ! grep -Fq 'mathlib-review-taxonomy' "$PLUGIN_ROOT/skills/lean4/references/mathlib-guide.md"; then
+    fail "Check 35: mathlib-guide.md missing the taxonomy pointer"
+    check35_ok=0
+fi
+_c35_rev_seealso=$(extract_section "$PLUGIN_ROOT/commands/review.md" "## See Also")
+if ! echo "$_c35_rev_seealso" | grep -Fq 'mathlib-review-taxonomy' \
+    || ! echo "$_c35_rev_seealso" | grep -Fq 'does **not** change'; then
+    fail "Check 35: review.md See Also missing the taxonomy pointer or its 'does not change behavior' disclaimer"
+    check35_ok=0
+fi
+if [[ "$check35_ok" -eq 1 ]]; then
+    ok "Check 35: mathlib review taxonomy pinned (nine buckets, naming bucket, vacuous-api #60, durable links, schema-deferred, pointers)"
+fi
+
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [[ "$FAIL" -eq 0 ]]

--- a/plugins/lean4/tools/test_contracts.sh
+++ b/plugins/lean4/tools/test_contracts.sh
@@ -1194,6 +1194,45 @@ else
         fail "Check 35: 'Naming & namespace' is not its own bucket"
         check35_ok=0
     fi
+    # Every bucket must actually carry the promised four-field shape. Extract
+    # each '## N.' section by number and require all four markers — the intro,
+    # issue, and changelog all promise this shape, so a missing field is a
+    # broken structural promise, not cosmetics.
+    for _c35_n in 1 2 3 4 5 6 7 8 9; do
+        _c35_sec=$(awk -v n="^## ${_c35_n}\\\\. " '
+            $0 ~ n {f=1; print; next}
+            f && /^## [0-9]+\. / {exit}
+            f {print}
+        ' "$_c35_tax")
+        for _c35_field in '**Reviewers mean:**' '**Cheap:**' '**Annoying:**' '**Example:**'; do
+            if ! echo "$_c35_sec" | grep -Fq "$_c35_field"; then
+                fail "Check 35: bucket $_c35_n missing '$_c35_field'"
+                check35_ok=0
+            fi
+        done
+    done
+    # Load-bearing companion links live in their buckets, not only See Also.
+    _c35_b4=$(extract_section "$_c35_tax" "## 4. File placement / import hygiene")
+    _c35_b6=$(extract_section "$_c35_tax" "## 6. Attributes / \`simp\`")
+    _c35_b7=$(extract_section "$_c35_tax" "## 7. Instances")
+    if ! echo "$_c35_b4" | grep -Fq 'mathlib-guide.md'; then
+        fail "Check 35: bucket 4 does not link mathlib-guide.md (the duplicate-result / search axis)"
+        check35_ok=0
+    fi
+    if ! echo "$_c35_b6" | grep -Fq 'simp-reference.md'; then
+        fail "Check 35: bucket 6 does not link simp-reference.md"
+        check35_ok=0
+    fi
+    if ! echo "$_c35_b7" | grep -Fq 'instance-pollution.md'; then
+        fail "Check 35: bucket 7 does not link instance-pollution.md"
+        check35_ok=0
+    fi
+    # Bucket 4 carries the duplicate-existing-result axis (#110 Library
+    # Integration), not just file placement.
+    if ! echo "$_c35_b4" | grep -Fq 'already'; then
+        fail "Check 35: bucket 4 missing the 'does an equivalent/more-general result already exist' axis"
+        check35_ok=0
+    fi
     # #60 vacuous-api: settled triple + semantic (not lexical) scope + advisory
     _c35_b5=$(extract_section "$_c35_tax" "## 5. API / generalization")
     if ! echo "$_c35_b5" | grep -Fq 'vacuous-api' \


### PR DESCRIPTION
Closes #114, closes #60. Refs #151 (Track 2). The taxonomy foundation that #115 (schema) and #110 (broaden `/lean4:review`) build on. A reference file — no runtime behavior change.

## What

**New `references/mathlib-review-taxonomy.md`** — what mathlib reviewers actually ask for, in **nine buckets** (each with what-reviewers-mean / cheap fixes / annoying fixes / one recent-PR example):
1. Surface style · 2. **Naming & namespace** (promoted to its own bucket, per review) · 3. Documentation · 4. File placement / import hygiene · 5. API / generalization · 6. Attributes / `simp` · 7. Instances · 8. Generated-file / module-system chores · 9. Metadata / process.

Cross-links existing references rather than duplicating. Bucket 8 links the **shipped** module-system tooling by durable path — the canonical header template (`mathlib-style.md § 1`), the checkpoint `mk_all` gate (`checkpoint.md`), and module-system troubleshooting (`compilation-errors.md` §16–§19) via `/lean4:diagnose` — not closed issue numbers or `/lean4:doctor`.

**Vacuous-API rule (closes #60)** in bucket 5, with the three refinements from review:
- **Scoped semantically, not lexically** — flags a *public declaration presenting as substantive API but whose conclusion collapses to `True`/vacuous*; explicitly not any `True`/`trivial` use, and not `sorry`-scaffolding (the sorry linter already covers that).
- **Delete-or-replace is a proposed remedy**, surfaced as an **advisory** finding, never an automatic edit.
- **Only `api` / `vacuous-api` / `advisory` is the settled mapping** (the roadmap decided it); every other bucket's category tag is an *illustrative* candidate mapping. #115 owns the final enums and severity semantics — nothing here freezes the schema.

**Navigational pointers** from `SKILL.md`, `review.md`, and `mathlib-guide.md`. The `review.md` pointer states explicitly that this is background material and **does not** change `/lean4:review`'s behavior — deciding when the buckets become emitted findings is #110's job.

**Check 35** pins the nine-bucket structure, the naming bucket, the semantically-scoped vacuous-api rule and its settled mapping, bucket 8's durable links (and the absence of `/lean4:doctor`), the schema-deferral to #115, and the three pointers with review.md's disclaimer.

## Issue hygiene

#114's body was refreshed before implementation (nine-bucket scope, #60 ownership, `/diagnose`, durable shipped-reference links) so `Closes #114, Closes #60` is independently auditable. #60 is an insight/documentation issue satisfied by documenting the advisory rule; the runtime decision of *when* `/lean4:review` emits it stays with #110.

## Amendments (review round 2)

- **Category alignment with #115** — the per-bucket `category` tags now track #115's provisional enum (`docstring`/`module-doc`, `file-placement`/`import-hygiene`, `generalization`, `attribute`/`simp`, `module-system`, `metadata`), with an explicit statement that conceptual buckets and machine categories are **not one-to-one**. Only `api`/`vacuous-api`/`advisory` stays settled. #115's body records the full mapping; #114's cross-link note fixes `simp-reference.md` (5)→(6) and states buckets may split.
- **Duplicate-existing-result axis restored** in bucket 4 (matching #110's Library Integration Review), with an in-bucket `mathlib-guide.md` link.
- **Per-bucket shape made true** — every bucket now carries Reviewers-mean / Cheap / Annoying / Example (bucket 5 gained Cheap+Annoying; bucket 9 gained all three). Check 35 now loops all nine buckets requiring the four fields and pins the in-bucket companion links (4→mathlib-guide, 6→simp-reference, 7→instance-pollution); negative-probed by deleting bucket 9's Example.
- **Simp criterion corrected** — bucket 6 replaces "confluent, terminating, good LHS" with the accurate local test (LHS already in simp normal form *excluding the candidate lemma*, RHS reaches normal form, no cycle), matching `simp-reference.md`.
- **Cleanups** — concrete bucket-4/5 examples from mathlib4#35906; the vacuous-API rule now reads "when emitted (by #110), it is a suggestion" to avoid present-tense conflict with the no-behavior-change scope.
- **Issue hygiene** — #110's stale "Future issue: mathlib-review-taxonomy.md" replaced with the delivered #114/#180 reference; #115 updated to "nine buckets" with the recorded mapping.

## Verification

Local gates green: `lint_docs.sh` (`bash -e`, reference links validated), `test_contracts.sh` incl. Check 35, shellcheck, the doc-lint suite. Check 35 negative-probed — reintroducing `/lean4:doctor` and demoting the naming bucket each fail. No stray fixtures.
