### PR TITLE
fix(lint): age-based staleness is advisory, not a CI hard-fail

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -215,9 +215,10 @@ jobs:
       - name: test_contracts.sh (wrapper/doc/agent contract suite)
         run: bash plugins/lean4/tools/test_contracts.sh
 
-      # Also run the lint_docs self-test on Linux (GNU date), so its
-      # staleness probes (7–8) actually exercise the age-advisory path —
-      # they SKIP on the macOS bash3-compat runner, which lacks `date -d`.
+      # Also run the lint_docs self-test on Linux so its staleness probes
+      # (7–8) exercise the GNU `date -d` branch of Check 20's portable date
+      # parser; the macOS bash3-compat job runs the same probes against the
+      # BSD `date -j -f` branch.
       - name: Self-test — lint_docs.sh (GNU-date staleness probes)
         run: bash plugins/lean4/tests/test_lint_docs.sh
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -215,6 +215,12 @@ jobs:
       - name: test_contracts.sh (wrapper/doc/agent contract suite)
         run: bash plugins/lean4/tools/test_contracts.sh
 
+      # Also run the lint_docs self-test on Linux (GNU date), so its
+      # staleness probes (7–8) actually exercise the age-advisory path —
+      # they SKIP on the macOS bash3-compat runner, which lacks `date -d`.
+      - name: Self-test — lint_docs.sh (GNU-date staleness probes)
+        run: bash plugins/lean4/tests/test_lint_docs.sh
+
       # Regression suite for the extraction contract itself (prefix
       # collision, duplicate headings, empty section, malformed/missing
       # version) — fixture-based, so it covers the failure cases the

--- a/plugins/lean4/tests/test_lint_docs.sh
+++ b/plugins/lean4/tests/test_lint_docs.sh
@@ -249,74 +249,72 @@ fi
 # the scanned advanced references; we mutate its date and restore from a
 # mktemp backup (never git checkout).
 # ---------------------------------------------------------------------------
-# Check 20's age computation uses GNU `date -d`, which BSD/macOS `date` does
-# not support — there, every date falls through to "Could not parse" and the
-# age-advisory path is never reached. The behavior under test is Linux-only,
-# so SKIP these probes gracefully when `date -d` is unavailable rather than
-# assert something the platform cannot produce.
-if ! date -d '2000-01-01' +%s >/dev/null 2>&1; then
-  echo "  SKIP: Probes 7–8 — GNU 'date -d' unavailable (age check is Linux-only)"
-else
-  SIMP_FILE="$PLUGIN_ROOT/skills/lean4/references/simp-reference.md"
-  SIMP_BACKUP=$(mktemp)
-  cp "$SIMP_FILE" "$SIMP_BACKUP"
-  trap 'cp "$CE_BACKUP" "$CE_FILE"; cp "$CODEX_BACKUP" "$CODEX_MANIFEST"; cp "$SIMP_BACKUP" "$SIMP_FILE"; rm -f "$CE_BACKUP" "$CODEX_BACKUP" "$SIMP_BACKUP" "$SCRATCH"' EXIT
+# Check 20 parses "Last validated" portably (GNU `date -d`, else BSD
+# `date -j -f`), so these probes run on BOTH platforms without a skip:
+# Linux exercises the GNU branch, macOS the BSD branch.
+SIMP_FILE="$PLUGIN_ROOT/skills/lean4/references/simp-reference.md"
+SIMP_BACKUP=$(mktemp)
+cp "$SIMP_FILE" "$SIMP_BACKUP"
+trap 'cp "$CE_BACKUP" "$CE_FILE"; cp "$CODEX_BACKUP" "$CODEX_MANIFEST"; cp "$SIMP_BACKUP" "$SIMP_FILE"; rm -f "$CE_BACKUP" "$CODEX_BACKUP" "$SIMP_BACKUP" "$SCRATCH"' EXIT
 
-  # Baseline exit on the unmutated tree (staleness is advisory, so this is the
-  # reference we compare against — a valid-but-old date must not change it).
-  # Only the exit code matters here, so the output is discarded.
-  if "$BASH_FOR_COMPAT" "$LINT" >/dev/null 2>&1; then base_ec=0; else base_ec=$?; fi
+# Baseline exit on the unmutated tree (staleness is advisory, so this is the
+# reference we compare against — a valid-but-old date must not change it).
+# Only the exit code matters here, so the output is discarded.
+if "$BASH_FOR_COMPAT" "$LINT" >/dev/null 2>&1; then base_ec=0; else base_ec=$?; fi
 
-  # Probe 7 — valid but very old date → advisory (ℹ️), and the exit code is
-  # UNCHANGED from baseline (the old date contributed no fatal issue).
-  sed -i.bak -E 's/^(> - \*\*Last validated:\*\*) [0-9]{4}-[0-9]{2}-[0-9]{2}$/\1 2000-01-01/' "$SIMP_FILE" && rm -f "$SIMP_FILE.bak"
-  if adv_out=$("$BASH_FOR_COMPAT" "$LINT" 2>&1); then adv_ec=0; else adv_ec=$?; fi
+# Probe 7 — valid but very old date → advisory (ℹ️), and the exit code is
+# UNCHANGED from baseline (the old date contributed no fatal issue). This also
+# proves the portable parser accepts a valid date on the BSD branch — the very
+# bug the parser fix addresses.
+sed -i.bak -E 's/^(> - \*\*Last validated:\*\*) [0-9]{4}-[0-9]{2}-[0-9]{2}$/\1 2000-01-01/' "$SIMP_FILE" && rm -f "$SIMP_FILE.bak"
+if adv_out=$("$BASH_FOR_COMPAT" "$LINT" 2>&1); then adv_ec=0; else adv_ec=$?; fi
 
-  probe7_ok=1
-  if ! echo "$adv_out" | grep -qE "ℹ️  simp-reference\.md: Last validated is [0-9]+ days old"; then
-    echo "  FAIL: Probe 7 — old valid date did not produce the advisory (ℹ️) staleness line"
-    probe7_ok=0
-  fi
-  if echo "$adv_out" | grep -qE "⚠️  simp-reference\.md: Last validated is [0-9]+ days old"; then
-    echo "  FAIL: Probe 7 — staleness reported as a fatal warning (⚠️), should be advisory"
-    probe7_ok=0
-  fi
-  if [[ "$adv_ec" -ne "$base_ec" ]]; then
-    echo "  FAIL: Probe 7 — exit code changed ($base_ec → $adv_ec); an old valid date must not add a fatal issue"
-    probe7_ok=0
-  fi
-  if [[ $probe7_ok -eq 1 ]]; then
-    echo "  PASS: Probe 7 — old valid date is advisory (ℹ️) and does not change the exit code"
-    ((PASS++)) || true
-  else
-    ((FAIL++)) || true
-  fi
-
-  cp "$SIMP_BACKUP" "$SIMP_FILE"
-
-  # Probe 8 — malformed date (digit-shaped but unparseable) → fatal (⚠️) and a
-  # nonzero exit, proving structural metadata problems are NOT downgraded.
-  sed -i.bak -E 's/^(> - \*\*Last validated:\*\*) [0-9]{4}-[0-9]{2}-[0-9]{2}$/\1 2026-13-45/' "$SIMP_FILE" && rm -f "$SIMP_FILE.bak"
-  if mal_out=$("$BASH_FOR_COMPAT" "$LINT" 2>&1); then mal_ec=0; else mal_ec=$?; fi
-
-  probe8_ok=1
-  if ! echo "$mal_out" | grep -qF "simp-reference.md: Could not parse Last validated date"; then
-    echo "  FAIL: Probe 8 — malformed date did not produce the fatal parse warning"
-    probe8_ok=0
-  fi
-  if [[ "$mal_ec" -eq 0 ]]; then
-    echo "  FAIL: Probe 8 — malformed metadata did not fail the lint (exit 0)"
-    probe8_ok=0
-  fi
-  if [[ $probe8_ok -eq 1 ]]; then
-    echo "  PASS: Probe 8 — malformed date stays fatal (⚠️, nonzero exit)"
-    ((PASS++)) || true
-  else
-    ((FAIL++)) || true
-  fi
-
-  cp "$SIMP_BACKUP" "$SIMP_FILE"
+probe7_ok=1
+if ! echo "$adv_out" | grep -qE "ℹ️  simp-reference\.md: Last validated is [0-9]+ days old"; then
+  echo "  FAIL: Probe 7 — old valid date did not produce the advisory (ℹ️) staleness line"
+  probe7_ok=0
 fi
+if echo "$adv_out" | grep -qE "⚠️  simp-reference\.md: Last validated is [0-9]+ days old"; then
+  echo "  FAIL: Probe 7 — staleness reported as a fatal warning (⚠️), should be advisory"
+  probe7_ok=0
+fi
+if [[ "$adv_ec" -ne "$base_ec" ]]; then
+  echo "  FAIL: Probe 7 — exit code changed ($base_ec → $adv_ec); an old valid date must not add a fatal issue"
+  probe7_ok=0
+fi
+if [[ $probe7_ok -eq 1 ]]; then
+  echo "  PASS: Probe 7 — old valid date is advisory (ℹ️) and does not change the exit code"
+  ((PASS++)) || true
+else
+  ((FAIL++)) || true
+fi
+
+cp "$SIMP_BACKUP" "$SIMP_FILE"
+
+# Probe 8 — malformed metadata stays FATAL (⚠️, nonzero exit). A non-date
+# value fails Check 20's strict format regex identically on GNU and BSD (no
+# date parsing involved), so this asserts the severity split deterministically
+# on both platforms: valid-but-old is advisory, structurally malformed is not.
+sed -i.bak -E 's/^(> - \*\*Last validated:\*\*) [0-9]{4}-[0-9]{2}-[0-9]{2}$/\1 not-a-date/' "$SIMP_FILE" && rm -f "$SIMP_FILE.bak"
+if mal_out=$("$BASH_FOR_COMPAT" "$LINT" 2>&1); then mal_ec=0; else mal_ec=$?; fi
+
+probe8_ok=1
+if ! echo "$mal_out" | grep -qF "simp-reference.md: Missing or malformed 'Last validated' field"; then
+  echo "  FAIL: Probe 8 — malformed metadata did not produce the fatal warning"
+  probe8_ok=0
+fi
+if [[ "$mal_ec" -eq 0 ]]; then
+  echo "  FAIL: Probe 8 — malformed metadata did not fail the lint (exit 0)"
+  probe8_ok=0
+fi
+if [[ $probe8_ok -eq 1 ]]; then
+  echo "  PASS: Probe 8 — malformed metadata stays fatal (⚠️, nonzero exit)"
+  ((PASS++)) || true
+else
+  ((FAIL++)) || true
+fi
+
+cp "$SIMP_BACKUP" "$SIMP_FILE"
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/plugins/lean4/tests/test_lint_docs.sh
+++ b/plugins/lean4/tests/test_lint_docs.sh
@@ -249,65 +249,74 @@ fi
 # the scanned advanced references; we mutate its date and restore from a
 # mktemp backup (never git checkout).
 # ---------------------------------------------------------------------------
-SIMP_FILE="$PLUGIN_ROOT/skills/lean4/references/simp-reference.md"
-SIMP_BACKUP=$(mktemp)
-cp "$SIMP_FILE" "$SIMP_BACKUP"
-trap 'cp "$CE_BACKUP" "$CE_FILE"; cp "$CODEX_BACKUP" "$CODEX_MANIFEST"; cp "$SIMP_BACKUP" "$SIMP_FILE"; rm -f "$CE_BACKUP" "$CODEX_BACKUP" "$SIMP_BACKUP" "$SCRATCH"' EXIT
-
-# Baseline exit on the unmutated tree (staleness is advisory, so this is the
-# reference we compare against — a valid-but-old date must not change it).
-# Only the exit code matters here, so the output is discarded.
-if "$BASH_FOR_COMPAT" "$LINT" >/dev/null 2>&1; then base_ec=0; else base_ec=$?; fi
-
-# Probe 7 — valid but very old date → advisory (ℹ️), and the exit code is
-# UNCHANGED from baseline (the old date contributed no fatal issue).
-sed -i.bak -E 's/^(> - \*\*Last validated:\*\*) [0-9]{4}-[0-9]{2}-[0-9]{2}$/\1 2000-01-01/' "$SIMP_FILE" && rm -f "$SIMP_FILE.bak"
-if adv_out=$("$BASH_FOR_COMPAT" "$LINT" 2>&1); then adv_ec=0; else adv_ec=$?; fi
-
-probe7_ok=1
-if ! echo "$adv_out" | grep -qE "ℹ️  simp-reference\.md: Last validated is [0-9]+ days old"; then
-  echo "  FAIL: Probe 7 — old valid date did not produce the advisory (ℹ️) staleness line"
-  probe7_ok=0
-fi
-if echo "$adv_out" | grep -qE "⚠️  simp-reference\.md: Last validated is [0-9]+ days old"; then
-  echo "  FAIL: Probe 7 — staleness reported as a fatal warning (⚠️), should be advisory"
-  probe7_ok=0
-fi
-if [[ "$adv_ec" -ne "$base_ec" ]]; then
-  echo "  FAIL: Probe 7 — exit code changed ($base_ec → $adv_ec); an old valid date must not add a fatal issue"
-  probe7_ok=0
-fi
-if [[ $probe7_ok -eq 1 ]]; then
-  echo "  PASS: Probe 7 — old valid date is advisory (ℹ️) and does not change the exit code"
-  ((PASS++)) || true
+# Check 20's age computation uses GNU `date -d`, which BSD/macOS `date` does
+# not support — there, every date falls through to "Could not parse" and the
+# age-advisory path is never reached. The behavior under test is Linux-only,
+# so SKIP these probes gracefully when `date -d` is unavailable rather than
+# assert something the platform cannot produce.
+if ! date -d '2000-01-01' +%s >/dev/null 2>&1; then
+  echo "  SKIP: Probes 7–8 — GNU 'date -d' unavailable (age check is Linux-only)"
 else
-  ((FAIL++)) || true
-fi
+  SIMP_FILE="$PLUGIN_ROOT/skills/lean4/references/simp-reference.md"
+  SIMP_BACKUP=$(mktemp)
+  cp "$SIMP_FILE" "$SIMP_BACKUP"
+  trap 'cp "$CE_BACKUP" "$CE_FILE"; cp "$CODEX_BACKUP" "$CODEX_MANIFEST"; cp "$SIMP_BACKUP" "$SIMP_FILE"; rm -f "$CE_BACKUP" "$CODEX_BACKUP" "$SIMP_BACKUP" "$SCRATCH"' EXIT
 
-cp "$SIMP_BACKUP" "$SIMP_FILE"
+  # Baseline exit on the unmutated tree (staleness is advisory, so this is the
+  # reference we compare against — a valid-but-old date must not change it).
+  # Only the exit code matters here, so the output is discarded.
+  if "$BASH_FOR_COMPAT" "$LINT" >/dev/null 2>&1; then base_ec=0; else base_ec=$?; fi
 
-# Probe 8 — malformed date (digit-shaped but unparseable) → fatal (⚠️) and a
-# nonzero exit, proving structural metadata problems are NOT downgraded.
-sed -i.bak -E 's/^(> - \*\*Last validated:\*\*) [0-9]{4}-[0-9]{2}-[0-9]{2}$/\1 2026-13-45/' "$SIMP_FILE" && rm -f "$SIMP_FILE.bak"
-if mal_out=$("$BASH_FOR_COMPAT" "$LINT" 2>&1); then mal_ec=0; else mal_ec=$?; fi
+  # Probe 7 — valid but very old date → advisory (ℹ️), and the exit code is
+  # UNCHANGED from baseline (the old date contributed no fatal issue).
+  sed -i.bak -E 's/^(> - \*\*Last validated:\*\*) [0-9]{4}-[0-9]{2}-[0-9]{2}$/\1 2000-01-01/' "$SIMP_FILE" && rm -f "$SIMP_FILE.bak"
+  if adv_out=$("$BASH_FOR_COMPAT" "$LINT" 2>&1); then adv_ec=0; else adv_ec=$?; fi
 
-probe8_ok=1
-if ! echo "$mal_out" | grep -qF "simp-reference.md: Could not parse Last validated date"; then
-  echo "  FAIL: Probe 8 — malformed date did not produce the fatal parse warning"
-  probe8_ok=0
-fi
-if [[ "$mal_ec" -eq 0 ]]; then
-  echo "  FAIL: Probe 8 — malformed metadata did not fail the lint (exit 0)"
-  probe8_ok=0
-fi
-if [[ $probe8_ok -eq 1 ]]; then
-  echo "  PASS: Probe 8 — malformed date stays fatal (⚠️, nonzero exit)"
-  ((PASS++)) || true
-else
-  ((FAIL++)) || true
-fi
+  probe7_ok=1
+  if ! echo "$adv_out" | grep -qE "ℹ️  simp-reference\.md: Last validated is [0-9]+ days old"; then
+    echo "  FAIL: Probe 7 — old valid date did not produce the advisory (ℹ️) staleness line"
+    probe7_ok=0
+  fi
+  if echo "$adv_out" | grep -qE "⚠️  simp-reference\.md: Last validated is [0-9]+ days old"; then
+    echo "  FAIL: Probe 7 — staleness reported as a fatal warning (⚠️), should be advisory"
+    probe7_ok=0
+  fi
+  if [[ "$adv_ec" -ne "$base_ec" ]]; then
+    echo "  FAIL: Probe 7 — exit code changed ($base_ec → $adv_ec); an old valid date must not add a fatal issue"
+    probe7_ok=0
+  fi
+  if [[ $probe7_ok -eq 1 ]]; then
+    echo "  PASS: Probe 7 — old valid date is advisory (ℹ️) and does not change the exit code"
+    ((PASS++)) || true
+  else
+    ((FAIL++)) || true
+  fi
 
-cp "$SIMP_BACKUP" "$SIMP_FILE"
+  cp "$SIMP_BACKUP" "$SIMP_FILE"
+
+  # Probe 8 — malformed date (digit-shaped but unparseable) → fatal (⚠️) and a
+  # nonzero exit, proving structural metadata problems are NOT downgraded.
+  sed -i.bak -E 's/^(> - \*\*Last validated:\*\*) [0-9]{4}-[0-9]{2}-[0-9]{2}$/\1 2026-13-45/' "$SIMP_FILE" && rm -f "$SIMP_FILE.bak"
+  if mal_out=$("$BASH_FOR_COMPAT" "$LINT" 2>&1); then mal_ec=0; else mal_ec=$?; fi
+
+  probe8_ok=1
+  if ! echo "$mal_out" | grep -qF "simp-reference.md: Could not parse Last validated date"; then
+    echo "  FAIL: Probe 8 — malformed date did not produce the fatal parse warning"
+    probe8_ok=0
+  fi
+  if [[ "$mal_ec" -eq 0 ]]; then
+    echo "  FAIL: Probe 8 — malformed metadata did not fail the lint (exit 0)"
+    probe8_ok=0
+  fi
+  if [[ $probe8_ok -eq 1 ]]; then
+    echo "  PASS: Probe 8 — malformed date stays fatal (⚠️, nonzero exit)"
+    ((PASS++)) || true
+  else
+    ((FAIL++)) || true
+  fi
+
+  cp "$SIMP_BACKUP" "$SIMP_FILE"
+fi
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/plugins/lean4/tests/test_lint_docs.sh
+++ b/plugins/lean4/tests/test_lint_docs.sh
@@ -291,24 +291,25 @@ fi
 
 cp "$SIMP_BACKUP" "$SIMP_FILE"
 
-# Probe 8 — malformed metadata stays FATAL (⚠️, nonzero exit). A non-date
-# value fails Check 20's strict format regex identically on GNU and BSD (no
-# date parsing involved), so this asserts the severity split deterministically
-# on both platforms: valid-but-old is advisory, structurally malformed is not.
-sed -i.bak -E 's/^(> - \*\*Last validated:\*\*) [0-9]{4}-[0-9]{2}-[0-9]{2}$/\1 not-a-date/' "$SIMP_FILE" && rm -f "$SIMP_FILE.bak"
+# Probe 8 — a format-valid but IMPOSSIBLE date (month 13) is unparseable,
+# stays FATAL (⚠️ "Could not parse"), and exits nonzero. Unlike a non-date
+# value (which fails the format regex before any parser runs), this passes the
+# regex and forces BOTH parsers to reject it, exercising the "both reject →
+# fatal" path on each platform (GNU date -d on Linux, BSD date -j -f on macOS).
+sed -i.bak -E 's/^(> - \*\*Last validated:\*\*) [0-9]{4}-[0-9]{2}-[0-9]{2}$/\1 2026-13-45/' "$SIMP_FILE" && rm -f "$SIMP_FILE.bak"
 if mal_out=$("$BASH_FOR_COMPAT" "$LINT" 2>&1); then mal_ec=0; else mal_ec=$?; fi
 
 probe8_ok=1
-if ! echo "$mal_out" | grep -qF "simp-reference.md: Missing or malformed 'Last validated' field"; then
-  echo "  FAIL: Probe 8 — malformed metadata did not produce the fatal warning"
+if ! echo "$mal_out" | grep -qF "simp-reference.md: Could not parse Last validated date"; then
+  echo "  FAIL: Probe 8 — impossible date did not produce the fatal 'Could not parse' warning"
   probe8_ok=0
 fi
 if [[ "$mal_ec" -eq 0 ]]; then
-  echo "  FAIL: Probe 8 — malformed metadata did not fail the lint (exit 0)"
+  echo "  FAIL: Probe 8 — unparseable metadata did not fail the lint (exit 0)"
   probe8_ok=0
 fi
 if [[ $probe8_ok -eq 1 ]]; then
-  echo "  PASS: Probe 8 — malformed metadata stays fatal (⚠️, nonzero exit)"
+  echo "  PASS: Probe 8 — unparseable date stays fatal (⚠️ 'Could not parse', nonzero exit)"
   ((PASS++)) || true
 else
   ((FAIL++)) || true

--- a/plugins/lean4/tests/test_lint_docs.sh
+++ b/plugins/lean4/tests/test_lint_docs.sh
@@ -242,6 +242,74 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Probes 7–8 — Check 20 staleness severity (lint-infra fix): a valid-but-old
+# "Last validated" date is ADVISORY (ℹ️, non-fatal) so a green commit cannot
+# turn red merely because the wall clock advanced; but MALFORMED metadata
+# stays fatal (⚠️, counts toward the exit code). simp-reference.md is one of
+# the scanned advanced references; we mutate its date and restore from a
+# mktemp backup (never git checkout).
+# ---------------------------------------------------------------------------
+SIMP_FILE="$PLUGIN_ROOT/skills/lean4/references/simp-reference.md"
+SIMP_BACKUP=$(mktemp)
+cp "$SIMP_FILE" "$SIMP_BACKUP"
+trap 'cp "$CE_BACKUP" "$CE_FILE"; cp "$CODEX_BACKUP" "$CODEX_MANIFEST"; cp "$SIMP_BACKUP" "$SIMP_FILE"; rm -f "$CE_BACKUP" "$CODEX_BACKUP" "$SIMP_BACKUP" "$SCRATCH"' EXIT
+
+# Baseline exit on the unmutated tree (staleness is advisory, so this is the
+# reference we compare against — a valid-but-old date must not change it).
+# Only the exit code matters here, so the output is discarded.
+if "$BASH_FOR_COMPAT" "$LINT" >/dev/null 2>&1; then base_ec=0; else base_ec=$?; fi
+
+# Probe 7 — valid but very old date → advisory (ℹ️), and the exit code is
+# UNCHANGED from baseline (the old date contributed no fatal issue).
+sed -i.bak -E 's/^(> - \*\*Last validated:\*\*) [0-9]{4}-[0-9]{2}-[0-9]{2}$/\1 2000-01-01/' "$SIMP_FILE" && rm -f "$SIMP_FILE.bak"
+if adv_out=$("$BASH_FOR_COMPAT" "$LINT" 2>&1); then adv_ec=0; else adv_ec=$?; fi
+
+probe7_ok=1
+if ! echo "$adv_out" | grep -qE "ℹ️  simp-reference\.md: Last validated is [0-9]+ days old"; then
+  echo "  FAIL: Probe 7 — old valid date did not produce the advisory (ℹ️) staleness line"
+  probe7_ok=0
+fi
+if echo "$adv_out" | grep -qE "⚠️  simp-reference\.md: Last validated is [0-9]+ days old"; then
+  echo "  FAIL: Probe 7 — staleness reported as a fatal warning (⚠️), should be advisory"
+  probe7_ok=0
+fi
+if [[ "$adv_ec" -ne "$base_ec" ]]; then
+  echo "  FAIL: Probe 7 — exit code changed ($base_ec → $adv_ec); an old valid date must not add a fatal issue"
+  probe7_ok=0
+fi
+if [[ $probe7_ok -eq 1 ]]; then
+  echo "  PASS: Probe 7 — old valid date is advisory (ℹ️) and does not change the exit code"
+  ((PASS++)) || true
+else
+  ((FAIL++)) || true
+fi
+
+cp "$SIMP_BACKUP" "$SIMP_FILE"
+
+# Probe 8 — malformed date (digit-shaped but unparseable) → fatal (⚠️) and a
+# nonzero exit, proving structural metadata problems are NOT downgraded.
+sed -i.bak -E 's/^(> - \*\*Last validated:\*\*) [0-9]{4}-[0-9]{2}-[0-9]{2}$/\1 2026-13-45/' "$SIMP_FILE" && rm -f "$SIMP_FILE.bak"
+if mal_out=$("$BASH_FOR_COMPAT" "$LINT" 2>&1); then mal_ec=0; else mal_ec=$?; fi
+
+probe8_ok=1
+if ! echo "$mal_out" | grep -qF "simp-reference.md: Could not parse Last validated date"; then
+  echo "  FAIL: Probe 8 — malformed date did not produce the fatal parse warning"
+  probe8_ok=0
+fi
+if [[ "$mal_ec" -eq 0 ]]; then
+  echo "  FAIL: Probe 8 — malformed metadata did not fail the lint (exit 0)"
+  probe8_ok=0
+fi
+if [[ $probe8_ok -eq 1 ]]; then
+  echo "  PASS: Probe 8 — malformed date stays fatal (⚠️, nonzero exit)"
+  ((PASS++)) || true
+else
+  ((FAIL++)) || true
+fi
+
+cp "$SIMP_BACKUP" "$SIMP_FILE"
+
+# ---------------------------------------------------------------------------
 echo ""
 echo "=== test_lint_docs.sh: $PASS passed, $FAIL failed ==="
 [[ "$FAIL" -eq 0 ]]

--- a/plugins/lean4/tests/test_lint_docs.sh
+++ b/plugins/lean4/tests/test_lint_docs.sh
@@ -2,8 +2,10 @@
 set -euo pipefail
 
 # Self-test for lint_docs.sh Check 8c (Python helper interpreter prefix),
-# Check 8e (compilation-errors.md heading uniqueness), and Check 23
-# (Claude/Codex release-metadata consistency).
+# Check 8e (compilation-errors.md heading uniqueness), Check 23
+# (Claude/Codex release-metadata consistency), and Check 20's staleness
+# severity split (a valid-but-old "Last validated" date is advisory, while
+# malformed/unparseable metadata stays fatal).
 # For each check, verify it fires on a planted violation and emits its
 # clean-run OK line once the violation is removed.
 #

--- a/plugins/lean4/tools/lint_docs.sh
+++ b/plugins/lean4/tools/lint_docs.sh
@@ -30,6 +30,15 @@ warn() {
     ((ISSUES++)) || true
 }
 
+# Non-fatal advisory: printed for visibility but does NOT count toward the
+# issue total or the exit code. Reserved for time-based "refresh recommended"
+# notices, which must not turn a valid, unchanged commit red just because the
+# wall clock advanced past a threshold. Structural problems (missing,
+# malformed, or unparseable metadata) stay fatal via warn().
+note() {
+    echo "ℹ️  $1"
+}
+
 ok() {
     echo "✓ $1"
 }
@@ -1319,7 +1328,10 @@ check_advanced_reference_metadata() {
             else
                 _am_age_days=$(( (_am_now_epoch - _am_date_epoch) / 86400 ))
                 if [[ $_am_age_days -gt 180 ]]; then
-                    warn "$_am_base: Last validated is $_am_age_days days old (refresh recommended)"
+                    # Advisory only: a valid-but-old date must not hard-fail CI
+                    # (that would make a green commit turn red purely because
+                    # time passed). Revalidation is tracked out of band.
+                    note "$_am_base: Last validated is $_am_age_days days old (refresh recommended)"
                 fi
             fi
         fi

--- a/plugins/lean4/tools/lint_docs.sh
+++ b/plugins/lean4/tools/lint_docs.sh
@@ -1322,7 +1322,13 @@ check_advanced_reference_metadata() {
 
         _am_date=$(grep -E '^> - \*\*Last validated:\*\* [0-9]{4}-[0-9]{2}-[0-9]{2}$' "$_am_file" 2>/dev/null | head -1 | sed -E 's/^> - \*\*Last validated:\*\* ([0-9-]+)$/\1/' || true)
         if [[ -n "$_am_date" ]]; then
-            _am_date_epoch=$(date -d "$_am_date" +%s 2>/dev/null || true)
+            # Parse portably: GNU `date -d` (Linux) then BSD `date -j -f`
+            # (macOS). Only when BOTH reject the value is it unparseable —
+            # otherwise macOS would treat every valid date as a fatal parse
+            # error. Pin midnight so the day count is deterministic.
+            _am_date_epoch=$(date -d "$_am_date" +%s 2>/dev/null \
+                || date -j -f '%Y-%m-%d %H:%M:%S' "$_am_date 00:00:00" +%s 2>/dev/null \
+                || true)
             if [[ -z "$_am_date_epoch" ]]; then
                 warn "$_am_base: Could not parse Last validated date '$_am_date'"
             else


### PR DESCRIPTION
Unversioned lint-infrastructure fix (no plugin release). Unblocks every PR from today onward.

## Problem

`lint_docs.sh` Check 20 records a `Last validated:` date on the advanced reference files and hard-failed once a date passed 180 days — via `warn()`, which increments the fatal issue count and forces `exit 1`. That makes a **valid, unchanged commit turn green→red purely because the wall clock advanced**. It tripped today (2026-08-17): five untouched references dated `2026-02-17` crossed 181 days, so `release-contract` fails on every branch until addressed.

## Fix

- Add a non-fatal `note()` path (prints `ℹ️`, does **not** count toward the issue total or exit code).
- Use it **only** for a valid-but-old date (the "refresh recommended" notice, which matches its own wording).
- **Missing, malformed, or unparseable** `Last validated` metadata stays **fatal** via `warn()` — structural problems are not downgraded.

## Regression (`test_lint_docs.sh` probes 7–8)

- **Probe 7** — a valid but very old date produces the `ℹ️` advisory line, no `⚠️`, and leaves the exit code **unchanged from baseline** (the old date adds no fatal issue).
- **Probe 8** — a malformed (digit-shaped but unparseable) date still emits the `⚠️` parse warning and exits **nonzero**.

Both mutate `simp-reference.md` and restore from a `mktemp` backup (never `git checkout`), matching the existing probe pattern.

## Follow-up, not done here

The five aged references get **genuine revalidation** in #181 — dates are **not** bulk-bumped (that would falsify the attestation the field records). This PR only corrects the severity.

## Verification

`lint_docs.sh` now exits 0 with the five advisories shown as `ℹ️`; `test_contracts.sh` clean; `test_lint_docs.sh` passes; shellcheck clean; runs under `/bin/bash` 3.2. No version bump, so no release is cut and Check 23 stays consistent.
