### PR TITLE
ci(release-contract): run the seven test suites no workflow executed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -224,6 +224,32 @@ jobs:
       - name: Self-test — disprove artifact transactions
         run: bash plugins/lean4/tests/test_disprove_artifact_txn.sh
 
+      # The remaining /disprove suites and the cycle tracker were run by no
+      # workflow (audit after #195). They live here rather than in the
+      # python-tests job because the disprove scripts require Python 3.11+
+      # (stdlib tomllib) while python-tests pins the documented 3.10 floor;
+      # this job uses the runner's system python3.
+      - name: Self-test — disprove emit-artifact writer
+        run: bash plugins/lean4/tests/test_disprove_emit_artifact.sh
+
+      - name: Self-test — disprove target profile
+        run: bash plugins/lean4/tests/test_disprove_target_profile.sh
+
+      - name: Self-test — disprove target resolve
+        run: bash plugins/lean4/tests/test_disprove_target_resolve.sh
+
+      - name: Self-test — disprove end-to-end flow
+        run: bash plugins/lean4/tests/test_disprove_flow.sh
+
+      - name: Unit tests — disprove method registry + probe (Python 3.11+)
+        run: |
+          python3 --version
+          python3 plugins/lean4/tests/test_disprove_methods.py
+          python3 plugins/lean4/tests/test_disprove_method_probe.py
+
+      - name: Self-test — cycle tracker
+        run: bash plugins/lean4/tests/test_cycle_tracker.sh
+
       # Also run the lint_docs self-test on Linux so its staleness probes
       # (7–8) exercise the GNU `date -d` branch of Check 20's portable date
       # parser; the macOS bash3-compat job runs the same probes against the

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -204,6 +204,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Pin the interpreter this job's /disprove self-tests run under to the
+      # documented /disprove floor (Python 3.11+, stdlib tomllib) instead of
+      # whatever python3 ubuntu-latest ships — so the suites exercise the
+      # minimum supported version reproducibly rather than a floating newer one.
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
       # Until this job, lint_docs.sh was maintainer-run only: CI ran
       # ruff/mypy/shellcheck plus the bash3 self-tests, and those
       # self-tests deliberately ignore lint_docs' overall exit status
@@ -228,7 +236,7 @@ jobs:
       # workflow (audit after #195). They live here rather than in the
       # python-tests job because the disprove scripts require Python 3.11+
       # (stdlib tomllib) while python-tests pins the documented 3.10 floor;
-      # this job uses the runner's system python3.
+      # this job pins Python 3.11 via setup-python (see the job header).
       - name: Self-test — disprove emit-artifact writer
         run: bash plugins/lean4/tests/test_disprove_emit_artifact.sh
 


### PR DESCRIPTION
CI-only; no runtime or doc change, unversioned (precedent: PR #182).

## What

An audit after #195 (which wired `test_disprove_artifact_txn.sh` into CI) found that **seven test suites were run by no workflow**:

- `tests/test_cycle_tracker.sh` (224 cases)
- `tests/test_disprove_emit_artifact.sh` (28)
- `tests/test_disprove_target_profile.sh` (25)
- `tests/test_disprove_target_resolve.sh` (18)
- `tests/test_disprove_flow.sh` (16)
- `tests/test_disprove_methods.py`, `tests/test_disprove_method_probe.py` (stdlib unittest)

All seven pass locally on the current toolchain. Each now has an explicit step in the `release-contract` job, after the transaction self-test.

## Why release-contract and not python-tests

`python-tests` pins Python **3.10** (the documented compatibility floor). The `/disprove` scripts require **3.11+** (stdlib `tomllib`) and exit 2 on anything older, which is presumably why these suites never landed there. `release-contract` now pins **Python 3.11** via `setup-python` (review suggestion: exercise the documented `/disprove` floor reproducibly rather than whatever `python3` ubuntu-latest ships) and already hosts `test_disprove_artifact_txn.sh`; a `python3 --version` line in the new unit-test step records what ran. A macOS leg is deliberately not added: the code under test is Python plus the cycle-tracker shell script, and `bash3-compat` can pick up `test_cycle_tracker.sh` separately if its Bash 3.2 behaviour is ever in question.

## Verification

- Local: all seven suites green (counts above); workflow YAML parses.
- CI: `actionlint` on the edit; the new steps are visible in this PR's `release-contract` run.
